### PR TITLE
Refactor to avoid reduntant API hits

### DIFF
--- a/src/js/server/app.js
+++ b/src/js/server/app.js
@@ -17,8 +17,15 @@ var app = express();
 app.use('/api', apiProxy);
 app.use(cookieParser());
 app.use(authRouter);
+
+app.use('/favicon.ico', (req, res) =>
+    res.status(404).type('txt').send('Not found'));
+
+app.use('/static/', express.static(
+    path.join(__dirname, '../../static'),
+    { fallthrough: false }));
+
 app.use(dataRouter);
-app.use('/static/', express.static(path.join(__dirname, '../../static')));
 
 app.get('/logout', function(req, res, next) {
     Z.resource('/session').del()


### PR DESCRIPTION
The data router should be hit last, to avoid hitting the API when retrieving
static files, favicon.ico, the API (feedback) and things like that.