### PR TITLE
Scoped search

### DIFF
--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -10,6 +10,10 @@ export default class SearchActions extends Actions {
         return scope;
     }
 
+    changeScope(scope) {
+        return scope;
+    }
+
     endSearch() {
         return true;
     }

--- a/src/js/components/KeyboardShortcuts.jsx
+++ b/src/js/components/KeyboardShortcuts.jsx
@@ -116,10 +116,21 @@ export default class KeyboardShortcuts extends FluxComponent {
                 ev.preventDefault();
 
                 switch (ev.keyCode) {
-                    case 47: // '/'
-                        // TODO: Focus search field
+                    case 47:    // '/'
                         this.closeReference();
                         this.getActions('search').beginSearch(null);
+                        break;
+                    case 99:    // 'c' == campaign
+                        this.closeReference();
+                        this.getActions('search').beginSearch('campaign');
+                        break;
+                    case 109:   // 'm' == maps
+                        this.closeReference();
+                        this.getActions('search').beginSearch('maps');
+                        break;
+                    case 112:   // 'p' == people
+                        this.closeReference();
+                        this.getActions('search').beginSearch('people');
                         break;
                 }
 

--- a/src/js/components/KeyboardShortcuts.jsx
+++ b/src/js/components/KeyboardShortcuts.jsx
@@ -46,6 +46,9 @@ export default class KeyboardShortcuts extends FluxComponent {
                     <h2>Search</h2>
                     <ul>
                         <li><code>{ '//' }</code> Activate search field</li>
+                        <li><code>{ '/p' }</code> Activate search, limiting results to people</li>
+                        <li><code>{ '/c' }</code> Activate search, limiting results to campaign</li>
+                        <li><code>{ '/m' }</code> Activate search, limiting results to maps</li>
                     </ul>
 
                     <h2>Misc</h2>

--- a/src/js/components/header/search/ScopeSelect.jsx
+++ b/src/js/components/header/search/ScopeSelect.jsx
@@ -1,0 +1,66 @@
+import React from 'react/addons';
+import cx from 'classnames';
+
+
+const SCOPES = [ 'all', 'people', 'campaign', 'maps' ];
+
+export default class ScopeSelect extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            open: false
+        };
+    }
+
+    render() {
+        var selectedScope = this.props.value || 'all';
+        var selectedClassNames = cx(
+            'search-form-scopeselect-value',
+            'search-form-scopeselect-' + selectedScope
+        );
+
+        var listClassNames = cx({
+            'search-form-scopeselect': true,
+            'open': this.state.open
+        });
+
+        return (
+            <ul className={ listClassNames }
+                onClick={ this.onListClick.bind(this) }>
+
+                <li key={ selectedScope } className={ selectedClassNames }/>
+
+                {SCOPES.map(function(scope) {
+                    var classNames = cx(
+                        'search-form-scopeselect-item',
+                        'search-form-scopeselect-' + scope
+                    );
+
+                    return (
+                        <li key={ scope } className={ classNames }
+                            onClick={ this.onScopeClick.bind(this, scope) }>
+                            { scope }</li>
+                    );
+                }, this)}
+            </ul>
+        );
+    }
+
+    onListClick() {
+        this.setState({
+            open: !this.state.open
+        });
+    }
+
+    onScopeClick(scope) {
+        if (this.props.onSelect) {
+            this.props.onSelect(scope);
+        }
+    }
+}
+
+ScopeSelect.propTypes = {
+    value: React.PropTypes.string,
+    onSelect: React.PropTypes.func
+};

--- a/src/js/components/header/search/Search.jsx
+++ b/src/js/components/header/search/Search.jsx
@@ -1,6 +1,7 @@
 import React from 'react/addons';
 
 import FluxComponent from '../../FluxComponent';
+import ScopeSelect from './ScopeSelect';
 import CampaignMatch from './CampaignMatch';
 import LocationMatch from './LocationMatch';
 import PersonMatch from './PersonMatch';
@@ -24,6 +25,7 @@ export default class Search extends FluxComponent {
     render() {
         var searchStore = this.getStore('search');
         var results = searchStore.getResults();
+        var scope = searchStore.getScope();
         var resultList;
         var classes = ['search-form'];
 
@@ -58,6 +60,9 @@ export default class Search extends FluxComponent {
 
         return (
             <form className={ classes.join(' ') }>
+                <ScopeSelect value={ scope }
+                    onSelect={ this.onScopeSelect.bind(this) }/>
+
                 <input type="search" ref="searchField"
                     placeholder="Start typing to search"
                     value={ searchStore.getQuery() }
@@ -68,6 +73,10 @@ export default class Search extends FluxComponent {
                 { resultList }
             </form>
         );
+    }
+
+    onScopeSelect(scope) {
+        this.getActions('search').changeScope(scope);
     }
 
     onKeyDown(ev) {
@@ -85,7 +94,7 @@ export default class Search extends FluxComponent {
     onFocus(ev) {
         var searchStore = this.getStore('search');
         if (!searchStore.isSearchActive()) {
-            this.getActions('search').beginSearch(null);
+            this.getActions('search').beginSearch();
         }
     }
 

--- a/src/js/server/search.js
+++ b/src/js/server/search.js
@@ -24,11 +24,22 @@ function search(ws, req) {
             queue.abort();
         }
 
-        queue = new SearchQueue(msg.org, msg.query, writeFunc, [
-            searchCampaigns,
-            searchLocations,
-            searchPeople
-        ]);
+        var searchFuncs = [];
+
+        if (!msg.scope || msg.scope == 'people') {
+            searchFuncs.push(searchPeople);
+        }
+
+        if (!msg.scope || msg.scope == 'maps') {
+            searchFuncs.push(searchLocations);
+        }
+
+        if (!msg.scope || msg.scope == 'campaign') {
+            searchFuncs.push(searchCampaigns);
+        }
+
+        queue = new SearchQueue(msg.org, msg.query, writeFunc, searchFuncs);
+        queue.run();
     });
 }
 
@@ -52,7 +63,9 @@ function SearchQueue(orgId, query, writeMatch, searchFuncs) {
         }
     };
 
-    _proceed();
+    this.run = function() {
+        _proceed();
+    }
 
     this.abort = function() {
         _idx = searchFuncs.length;

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -55,9 +55,13 @@ export default class SearchStore extends Store {
     }
 
     onChangeScope(scope) {
-        this.setState({
-            scope: scope
-        });
+        if (scope != this.state.scope) {
+            this.setState({
+                scope: scope
+            });
+
+            this.execSearch(this.state.query, scope, []);
+        }
     }
 
     onEndSearch() {
@@ -76,6 +80,10 @@ export default class SearchStore extends Store {
     }
 
     onSearch(query) {
+        this.execSearch(query, this.state.scope, this.state.results);
+    }
+
+    execSearch(query, scope, initialResults) {
         var orgId = this.flux.getStore('org').getActiveId();
 
         this.setState({
@@ -92,14 +100,14 @@ export default class SearchStore extends Store {
         else {
             // Remove results that no longer match
             this.setState({
-                results: this.state.results
+                results: initialResults
                     .filter(r => searchMatches(query, r.data))
             });
 
             var sendQuery = function(query) {
                 this.ws.send(JSON.stringify({
                     'cmd': 'search',
-                    'scope': this.state.scope,
+                    'scope': scope,
                     'org': orgId,
                     'query': query
                 }));

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -88,6 +88,7 @@ export default class SearchStore extends Store {
             var sendQuery = function(query) {
                 this.ws.send(JSON.stringify({
                     'cmd': 'search',
+                    'scope': this.state.scope,
                     'org': orgId,
                     'query': query
                 }));

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -21,6 +21,7 @@ export default class SearchStore extends Store {
         var searchActions = flux.getActions('search');
         this.register(searchActions.search, this.onSearch);
         this.register(searchActions.beginSearch, this.onBeginSearch);
+        this.register(searchActions.changeScope, this.onChangeScope);
         this.register(searchActions.endSearch, this.onEndSearch);
         this.register(searchActions.clearSearch, this.onClearSearch);
     }
@@ -42,9 +43,19 @@ export default class SearchStore extends Store {
     }
 
     onBeginSearch(scope) {
+        // Don't override scope if undefined
+        if (scope === undefined)
+            scope = this.state.scope;
+
         // TODO: Open WS already at this point?
         this.setState({
             isActive: true,
+            scope: scope
+        });
+    }
+
+    onChangeScope(scope) {
+        this.setState({
             scope: scope
         });
     }

--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -65,11 +65,95 @@
             position: relative;
             z-index: 3000;
             display: block;
-            height: 32px;
-            padding: 4px;
+            height: 2em;
+            padding: 0.4em 0.4em 0.4em 2.5em;
             border-width: 0;
-            width: 100%;
             font-size: 1.5em;
+            width: 100%;
+
+            &:focus {
+                text-align: left;
+            }
+        }
+
+        .search-form-scopeselect {
+            margin: 0;
+            padding: 0;
+            position: absolute;
+            top: 0.5em;
+            left: 0.5em;
+            z-index: 4000;
+
+            li {
+                padding: 0;
+                list-style-type: none;
+            }
+
+            .search-form-scopeselect-value {
+                width: 3em;
+                height: 2em;
+                background-color: #ddd;
+                margin-bottom: 0.5em;
+
+                // Value icon
+                &::before {
+                    content: "";
+                    display: block;
+                    margin: 0.1em;
+                    width: 1.6em;
+                    height: 1.6em;
+                }
+            }
+
+            .search-form-scopeselect-item {
+                position: relative;
+                background-color: white;
+                display: none;
+                font-size: 1.2em;
+                padding: 0.3em 0.3em 0.3em 3em;
+
+                // Item icon
+                &::before {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    content: "";
+                    display: block;
+                    margin: 0.1em;
+                    width: 1.6em;
+                    height: 1.6em;
+                }
+            }
+
+            .search-form-scopeselect-all {
+                &::before {
+                    background-color: black;
+                }
+            }
+
+            .search-form-scopeselect-people {
+                &::before {
+                    background-color: red;
+                }
+            }
+
+            .search-form-scopeselect-campaign {
+                &::before {
+                    background-color: blue;
+                }
+            }
+
+            .search-form-scopeselect-maps {
+                &::before {
+                    background-color: green;
+                }
+            }
+
+            &.open {
+                .search-form-scopeselect-item {
+                    display: block;
+                }
+            }
         }
 
         .search-form-results {


### PR DESCRIPTION
This implements scoped search, i.e. searching for only a single category of content, e.g. maps content, people or campaign content. It adds a widget to the search form for changing the scope and keyboard shortcuts for focusing the search field with a predefined scope.