### PR TITLE
Vertical (mobile) pane layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "tape tests/*.js"
   },
   "dependencies": {
+    "animated-scrollto": "^1.1.0",
     "array.prototype.find": "^1.0.0",
     "bugsnag": "^1.6.4",
     "classnames": "^2.1.3",

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -27,6 +27,8 @@ export default class PaneBase extends FluxComponent {
         return (
             <div className={ classNames.join(' ') }>
                 <header>
+                    <a className="section-pane-closelink"
+                        onClick={ this.onCloseClick.bind(this) }/>
                     <h2>{ this.getPaneTitle(data) }</h2>
                     <small>{ this.getPaneSubTitle(data) }</small>
                 </header>
@@ -80,6 +82,10 @@ export default class PaneBase extends FluxComponent {
         var parentPath = parentPathElements.join('/');
 
         this.context.router.navigate(parentPath);
+    }
+
+    onCloseClick(ev) {
+        this.closePane();
     }
 }
 

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -76,7 +76,7 @@ export default class PaneBase extends FluxComponent {
 
     closePane() {
         var pathElements = this.props.panePath.split('/');
-        var parentPathElements = pathElements.slice(0, pathElements.length-1);
+        var parentPathElements = pathElements.slice(0, pathElements.length);
         var parentPath = parentPathElements.join('/');
 
         this.context.router.navigate(parentPath);

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -93,8 +93,19 @@ function resetHorizontalLayout() {
     }
 
     if (_panes.length > 1) {
-        var lastPane = _panes[_panes.length-1];
-        lastPane.setX(_stackWidth - lastPane.getWidth());
+        var topPane = _panes[_panes.length-1];
+
+        // Position top pane so that it's shown in it's entirety
+        topPane.setX(_stackWidth - topPane.getWidth());
+
+        // Distribute the remaining space to the left of the top pane
+        // across all of the underlying panes (except the base pane).
+        var perPane = topPane.getX() / (len - 1)
+        i = len - 1;
+        while (i-->1) {
+            pane = _panes[i];
+            pane.setX(i * perPane);
+        }
     }
 
     // Start updating

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -20,20 +20,26 @@ function run(paneElements, container) {
     }
 
     _layout = (window.innerWidth > 720)? HORIZONTAL : VERTICAL;
+    _stackWidth = container.offsetWidth;
 
     window.addEventListener('resize', function(ev) {
+        var prevLayout = _layout;
+
         _layout = (window.innerWidth > 720)? HORIZONTAL : VERTICAL;
+        _stackWidth = container.offsetWidth;
 
-        if (_layout == VERTICAL) {
-            resetVerticalLayout();
-        }
-        else {
-            _stackWidth = container.offsetWidth;
-            resetHorizontalLayout();
+        if (_layout != prevLayout) {
+            // Layout changed! Reset and start new layout
+            if (_layout == VERTICAL) {
+                resetVerticalLayout();
+            }
+            else {
+                resetHorizontalLayout();
 
-            if (!_running) {
-                _running = true;
-                updateStack();
+                if (!_running) {
+                    _running = true;
+                    updateStack();
+                }
             }
         }
     });
@@ -44,10 +50,6 @@ function run(paneElements, container) {
     else {
         _stackWidth = container.offsetWidth;
         resetHorizontalLayout();
-
-        // Start updating
-        _running = true;
-        updateStack();
     }
 }
 
@@ -71,6 +73,8 @@ function resetVerticalLayout() {
         pane.resetTransform();
         pane.setY(40 * i);
     }
+
+    _running = false;
 }
 
 function resetHorizontalLayout() {
@@ -86,10 +90,21 @@ function resetHorizontalLayout() {
         var lastPane = _panes[_panes.length-1];
         lastPane.setX(_stackWidth - lastPane.getWidth());
     }
+
+    // Start updating
+    _running = true;
+    updateStack();
 }
 
 function updateStack() {
     var i, len, shade, maxRight;
+
+    if (!_running) {
+        // The loop has been requested to stop. Bail
+        // before doing anything and before requesting
+        // a new animation frame.
+        return;
+    }
 
     len = _panes.length;
     for (i=0; i<len; i++) {
@@ -126,9 +141,7 @@ function updateStack() {
         maxRight = sectionX;
     }
 
-    if (_running) {
-        requestAnimationFrame(updateStack);
-    }
+    requestAnimationFrame(updateStack);
 }
 
 

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -35,11 +35,6 @@ function run(paneElements, container) {
             }
             else {
                 resetHorizontalLayout();
-
-                if (!_running) {
-                    _running = true;
-                    updateStack();
-                }
             }
         }
     });
@@ -92,8 +87,10 @@ function resetHorizontalLayout() {
     }
 
     // Start updating
-    _running = true;
-    updateStack();
+    if (!_running) {
+        _running = true;
+        updateStack();
+    }
 }
 
 function updateStack() {

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -69,6 +69,17 @@ function resetVerticalLayout() {
         pane.setY(40 * i);
     }
 
+    if (len > 2) {
+        var animatedScrollTo = require('animated-scrollto');
+
+        // Scroll down to show the topmost pane as well as the
+        // header of the one underneith (vertically above) that.
+        var scrollTop = (len - 2) * 40;
+        setTimeout(function() {
+            animatedScrollTo(document.body, scrollTop, 400);
+        }, 70);
+    }
+
     _running = false;
 }
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -1,7 +1,4 @@
 html {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
     box-sizing: border-box;
 }
 
@@ -10,29 +7,23 @@ html {
 }
 
 body {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    margin: 0;
     background-color: #ddd;
     font-size: 62.5%;
 
     font-family: Arial, sans-serif;
 }
 
+#main {
+    position: absolute;
+    top: 4.8em;
+    right: 0;
+    left: 0;
+}
+
 a {
     color: inherit;
     text-decoration: none;
-}
-
-#main {
-    position: fixed;
-    overflow: hidden;
-    top: 4.8em;
-    left: 0;
-    right: 0;
-    bottom: 0;
 }
 
 .shortcutref {

--- a/src/scss/_medium.scss
+++ b/src/scss/_medium.scss
@@ -1,0 +1,20 @@
+html {
+    overflow: hidden;
+}
+
+body {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+#main {
+    position: fixed;
+    overflow: hidden;
+    top: 4.8em;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}

--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -3,6 +3,7 @@
     top: 0;
     left: 0;
     right: 0;
+    height: 4.8em;
     z-index: 1000;
     padding: 0.8em;
     background-color: $c-brand-main;

--- a/src/scss/section/_base.scss
+++ b/src/scss/section/_base.scss
@@ -2,3 +2,30 @@
     background-color: black;
     width: 100%;
 }
+
+.section-pane {
+    left: 0;
+    right: 0;
+    padding: 0 1em 1em;
+    background-color: white;
+    position: absolute;
+
+    .section-pane-content {
+        display: none;
+    }
+
+    &::before {
+        content: "";
+        display: block;
+        position: absolute;
+        top: -40px;
+        left: 0;
+        width: 100%;
+        height: 40px;
+        background: linear-gradient(180deg, rgba(0,0,0,0.1), rgba(0,0,0,0.1) 80%, rgba(0,0,0,0.2));
+    }
+
+    &:last-child .section-pane-content {
+        display: block;
+    }
+}

--- a/src/scss/section/_base.scss
+++ b/src/scss/section/_base.scss
@@ -14,6 +14,24 @@
         display: none;
     }
 
+    &:first-child {
+        .section-pane-closelink {
+            display: none;
+        }
+    }
+
+    // Completely transparent link placed just over the pane (where the header
+    // of the underlying pane shows). The user will be tapping the underlying
+    // header, but actually hitting this to close the overlying pane.
+    .section-pane-closelink {
+        background: transparent;
+        position: absolute;
+        top: -40px;
+        left: 0;
+        right: 0;
+        height: 40px;
+    }
+
     &::before {
         content: "";
         display: block;

--- a/src/scss/section/_base.scss
+++ b/src/scss/section/_base.scss
@@ -1,3 +1,4 @@
 .section-nav {
     background-color: black;
+    width: 100%;
 }

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -80,6 +80,7 @@
         position: absolute;
         top: 0;
         bottom: 0;
+        right: auto;
         display: block;
         background-color: white;
 
@@ -99,7 +100,7 @@
         }
 
         .section-pane-content {
-            margin: 20px;
+            display: block;
         }
 
         .section-pane-shader {

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -74,6 +74,10 @@
         // Base pane, always full-width and not interactive
         left: 0;
         right: 0;
+
+        .section-pane-closelink {
+            display: none;
+        }
     }
 
     .section-pane {
@@ -97,6 +101,15 @@
 
         header {
             margin: 100px 20px 0;
+        }
+
+        .section-pane-closelink {
+            top: 1em;
+            left: 1em;
+            right: auto;
+            background-color: red;
+            width: 1em;
+            height: 1em;
         }
 
         .section-pane-content {


### PR DESCRIPTION
On devices with narrow screens the horizontal pane layout does not work. This PR creates a layout for narrow screens, where panes are stacked vertically and can no longer be dragged around. Scrolling in this layout is not managed, but instead relies on browser scrolling which is both easier to implement and will likely work better on devices with narrow screens (which tend to be slower).

![image](https://cloud.githubusercontent.com/assets/550212/8963737/ecf95ea4-3621-11e5-875b-c906ea0b210e.png)

The screenshot shows a (contrived) situation where six panes have been stacked on top of eachother in this new vertical layout. It will be possible to jump back in the stack by tapping the name of an underlying pane.