### PR TITLE
Better preloading

### DIFF
--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -28,8 +28,16 @@ function waitForActions(execActions) {
     }
 }
 
+router.get([/people$/, /people\/list$/], waitForActions(req => [
+    req.flux.getActions('person').retrievePeople()
+]));
+
 router.get(/person:(\d+)$/, waitForActions(req => [
     req.flux.getActions('person').retrievePerson(req.params[0])
+]));
+
+router.get([/maps$/, /maps\/locations$/], waitForActions(req => [
+    req.flux.getActions('location').retrieveLocations()
 ]));
 
 router.get(/location:(\d+)$/, waitForActions(req => [

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -20,43 +20,32 @@ router.all(/.*/, function(req, res, next) {
         });
 });
 
-router.get(/person:(\d+)$/, function(req, res, next) {
+function waitForActions(execActions) {
+    return function(req, res, next) {
+        var promises = execActions(req);
+
+        Promise.all(promises).then(() => next());
+    }
+}
+
+router.get(/person:(\d+)$/, waitForActions(req => [
     req.flux.getActions('person').retrievePerson(req.params[0])
-        .then(function() {
-            next();
-        })
-        .catch(function(err) {
-            // TODO: What could this be? Handle!
-            next();
-        });
-});
+]));
 
-router.get(/location:(\d+)$/, function(req, res, next) {
+router.get(/location:(\d+)$/, waitForActions(req => [
     req.flux.getActions('location').retrieveLocation(req.params[0])
-        .then(function() {
-            next();
-        });
-});
+]));
 
-router.get(/campaigns$/, function(req, res, next) {
+router.get(/campaigns$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaigns()
-        .then(function() {
-            next();
-        });
-});
+]));
 
-router.get(/campaign:(\d+)$/, function(req, res, next) {
+router.get(/campaign:(\d+)$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaign(req.params[0])
-        .then(function() {
-            next();
-        });
-});
+]));
 
-router.get(/campaign\/actions$/, function(req, res, next) {
+router.get(/campaign\/actions$/, waitForActions(req => [
     req.flux.getActions('action').retrieveAllActions()
-        .then(function() {
-            next();
-        });
-});
+]));
 
 export default router;


### PR DESCRIPTION
There was a lot of boilerplate involved in preloading data for every route, even though they essentially all did the exact same thing; execute one or several actions and invoke next() when it finished. The new waitForActions() function does this and makes the code much shorter. 

This PR also adds previously missing preloaders for people and locations.