### PR TITLE
Handle non-officials

### DIFF
--- a/src/js/components/fullpages/ActivistPage.jsx
+++ b/src/js/components/fullpages/ActivistPage.jsx
@@ -1,0 +1,26 @@
+import React from 'react/addons';
+
+import FluxComponent from '../FluxComponent';
+
+
+export default class ActivistPage extends FluxComponent {
+    render() {
+        return (
+            <html>
+                <head>
+                    <title>Restricted area</title>
+                </head>
+                <body>
+                    <h1>Hi there, activist!</h1>
+                    <p>
+                        To make use of the Zetkin Organizer you have to be an
+                        organizer or admin in at least one organization.
+                    </p>
+                    <p>
+                        <a href="/logout">Sign out and log in as organizer</a>
+                    </p>
+                </body>
+            </html>
+        );
+    }
+}

--- a/src/js/server/app.js
+++ b/src/js/server/app.js
@@ -64,7 +64,14 @@ function renderReactPage(Component, req, res) {
 }
 
 app.get('/activist', function(req, res, next) {
-    renderReactPage(ActivistPage, req, res);
+    if (req.flux.getStore('user').isOfficial()) {
+        // Officials should not be able to see the message to non-officials,
+        // which would be very confusing.
+        res.redirect(303, '/');
+    }
+    else {
+        renderReactPage(ActivistPage, req, res);
+    }
 });
 
 app.use(function(req, res, next) {

--- a/src/js/server/app.js
+++ b/src/js/server/app.js
@@ -12,6 +12,7 @@ import authRouter from './authrouter';
 import apiProxy from './apiproxy';
 import search from './search';
 import App from '../components/App';
+import ActivistPage from '../components/fullpages/ActivistPage';
 
 
 var app = express();
@@ -27,11 +28,6 @@ app.use('/static/', express.static(
     path.join(__dirname, '../../static'),
     { fallthrough: false }));
 
-app.use(dataRouter);
-
-expressWs(app);
-app.ws('/search', search);
-
 app.get('/logout', function(req, res, next) {
     Z.resource('/session').del()
         .then(function(result) {
@@ -43,10 +39,32 @@ app.get('/logout', function(req, res, next) {
         });
 });
 
-app.get('/officialsonly', function(req, res, next) {
-    // TODO: Implement error screen (static?)
-    res.type('text/plain');
-    res.send('You are not an official');
+app.use(dataRouter);
+
+expressWs(app);
+app.ws('/search', search);
+
+function renderReactPage(Component, req, res) {
+    try {
+        var PageFactory = React.createFactory(Component);
+        var props = {
+            path: req.path
+        };
+
+        var html = React.renderToString(
+            React.createElement(FluxComponent, { flux: req.flux },
+                PageFactory(props)));
+
+        res.send(html);
+    }
+    catch (err) {
+        res.send('ERROR!')
+        throw err; // TODO: Better error handling
+    }
+}
+
+app.get('/activist', function(req, res, next) {
+    renderReactPage(ActivistPage, req, res);
 });
 
 app.use(function(req, res, next) {
@@ -58,23 +76,7 @@ app.use(function(req, res, next) {
         return next();
     }
 
-    try {
-        var AppFactory = React.createFactory(App);
-        var props = {
-            base: 'http://' + req.headers.host,
-            path: req.path
-        };
-
-        var html = React.renderToString(
-            React.createElement(FluxComponent, { flux: req.flux },
-                AppFactory(props)));
-
-        res.send(html);
-    }
-    catch (err) {
-        res.send('ERROR!')
-        throw err; // TODO: Better error handling
-    }
+    renderReactPage(App, req, res);
 });
 
 module.exports = app;

--- a/src/js/server/app.js
+++ b/src/js/server/app.js
@@ -43,6 +43,12 @@ app.get('/logout', function(req, res, next) {
         });
 });
 
+app.get('/officialsonly', function(req, res, next) {
+    // TODO: Implement error screen (static?)
+    res.type('text/plain');
+    res.send('You are not an official');
+});
+
 app.use(function(req, res, next) {
     if (req.url == '/search') {
         // Don't render any output for search. Because of how

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -14,10 +14,10 @@ router.all(/.*/, function(req, res, next) {
         .then(function(result) {
             var memberships = req.flux.getStore('user').getMemberships();
 
-            if (memberships.length == 0 && req.url != '/officialsonly') {
+            if (memberships.length == 0 && req.url != '/activist') {
                 // This user does not have any official roles. Redirect to
                 // page which explains why they can't use organizer app.
-                res.redirect(303, '/officialsonly');
+                res.redirect(303, '/activist');
             }
             else {
                 next();

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -12,9 +12,9 @@ router.all(/.*/, function(req, res, next) {
     req.flux.getActions('user').getUserInfo()
         .then(req.flux.getActions('user').getUserMemberships)
         .then(function(result) {
-            var memberships = req.flux.getStore('user').getMemberships();
+            var userStore = req.flux.getStore('user');
 
-            if (memberships.length == 0 && req.url != '/activist') {
+            if (userStore.isOfficial() == 0 && req.url != '/activist') {
                 // This user does not have any official roles. Redirect to
                 // page which explains why they can't use organizer app.
                 res.redirect(303, '/activist');

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -12,7 +12,16 @@ router.all(/.*/, function(req, res, next) {
     req.flux.getActions('user').getUserInfo()
         .then(req.flux.getActions('user').getUserMemberships)
         .then(function(result) {
-            next();
+            var memberships = req.flux.getStore('user').getMemberships();
+
+            if (memberships.length == 0 && req.url != '/officialsonly') {
+                // This user does not have any official roles. Redirect to
+                // page which explains why they can't use organizer app.
+                res.redirect(303, '/officialsonly');
+            }
+            else {
+                next();
+            }
         })
         .catch(function(err) {
             // TODO: What could this be? Handle!

--- a/src/js/stores/user.js
+++ b/src/js/stores/user.js
@@ -27,6 +27,10 @@ export default class UserStore extends Store {
         return this.state.memberships;
     }
 
+    isOfficial() {
+        return (this.state.memberships.length > 0);
+    }
+
     getActiveMembership() {
         return this.state.activeMembership;
     }


### PR DESCRIPTION
Users that do not have an official role in any organization should should not be able to access the organizer interface. This PR addss a check in the data router and redirects any such user to a special information page at /activist.

A nice design and copy still needs to be created for the /activist page.