### PR TITLE
Avoid npm (re-)install

### DIFF
--- a/env/app/run.sh
+++ b/env/app/run.sh
@@ -3,6 +3,9 @@
 cd /var/app
 
 exec 2>&1
-echo "npm install"
-npm install
+if [ ! -d node_modules ]
+then
+    echo "npm install"
+    npm install
+fi
 exec node dist/organize.zetk.in/server/main.js


### PR DESCRIPTION
A developer who already has all dependencies locally shouldn't have to install
them inside the container too.