### PR TITLE
Campaign calendar view

### DIFF
--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -52,6 +52,7 @@ export default class ActionCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
+                    onAddAction={ this.onAddAction.bind(this, new Date(d)) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
             );
 
@@ -78,6 +79,12 @@ export default class ActionCalendar extends React.Component {
     onSelectAction(action) {
         if (this.props.onSelectAction) {
             this.props.onSelectAction(action);
+        }
+    }
+
+    onAddAction(date) {
+        if (this.props.onAddAction) {
+            this.props.onAddAction(date);
         }
     }
 }

--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -55,8 +55,6 @@ export default class ActionCalendar extends React.Component {
                     onSelectAction={ this.onSelectAction.bind(this) }/>
             );
 
-            console.log(d);
-
             if (d.getDay() == 0) {
                 weeks.push(
                     <ActionWeek firstDate={ new Date(d) }>

--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -53,6 +53,7 @@ export default class ActionCalendar extends React.Component {
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
                     onAddAction={ this.onAddAction.bind(this, new Date(d)) }
+                    onMoveAction={ this.onMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
             );
 
@@ -87,8 +88,16 @@ export default class ActionCalendar extends React.Component {
             this.props.onAddAction(date);
         }
     }
+
+    onMoveAction(action, date) {
+        if (this.props.onMoveAction) {
+            this.props.onMoveAction(action, date);
+        }
+    }
 }
 
 ActionCalendar.propTypes = {
-    onSelectAction: React.PropTypes.func
+    onAddAction: React.PropTypes.func,
+    onSelectAction: React.PropTypes.func,
+    onMoveAction: React.PropTypes.func
 };

--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -1,0 +1,78 @@
+import React from 'react/addons';
+
+import ActionWeek from './ActionWeek';
+import ActionDay from './ActionDay';
+
+
+export default class ActionCalendar extends React.Component {
+    render() {
+        const actions = this.props.actions;
+
+        var startDate = this.props.startDate;
+        var endDate = this.props.endDate;
+
+        if (!startDate && actions.length > 0) {
+            startDate = new Date(actions[0].start_time);
+        }
+
+        if (!endDate && actions.length > 0) {
+            endDate = new Date(actions[actions.length-1].end_time);
+        }
+
+        // Always start on previous Monday
+        startDate.setDate(startDate.getDate() - startDate.getDay() + 1);
+
+        // Always end on next Sunday
+        endDate.setDate(endDate.getDate() + (7 - endDate.getDay()));
+
+        var d = new Date(startDate.toDateString());
+        var weeks = [];
+        var days = [];
+        var idx = 0;
+
+        while (d <= endDate) {
+            var dayActions = [];
+
+            while (idx < actions.length) {
+                const action = actions[idx];
+                const ad = new Date(action.start_time);
+
+                if (d.getYear() == ad.getYear()
+                    && d.getMonth() == ad.getMonth()
+                    && d.getDate() == ad.getDate()) {
+
+                    dayActions.push(action);
+
+                    idx++;
+                }
+                else {
+                    break;
+                }
+            }
+
+            days.push(
+                <ActionDay date={ new Date(d) } actions={ dayActions }/>
+            );
+
+            console.log(d);
+
+            if (d.getDay() == 0) {
+                weeks.push(
+                    <ActionWeek firstDate={ new Date(d) }>
+                        { days }
+                    </ActionWeek>
+                );
+
+                days = [];
+            }
+
+            d.setDate(d.getDate() + 1);
+        }
+
+        return (
+            <div className="actioncalendar">
+                { weeks }
+            </div>
+        );
+    }
+}

--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -51,7 +51,8 @@ export default class ActionCalendar extends React.Component {
             }
 
             days.push(
-                <ActionDay date={ new Date(d) } actions={ dayActions }/>
+                <ActionDay date={ new Date(d) } actions={ dayActions }
+                    onSelectAction={ this.onSelectAction.bind(this) }/>
             );
 
             console.log(d);
@@ -75,4 +76,14 @@ export default class ActionCalendar extends React.Component {
             </div>
         );
     }
+
+    onSelectAction(action) {
+        if (this.props.onSelectAction) {
+            this.props.onSelectAction(action);
+        }
+    }
 }
+
+ActionCalendar.propTypes = {
+    onSelectAction: React.PropTypes.func
+};

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -18,28 +18,39 @@ export default class ActionDay extends React.Component {
                 <ul>
                 { this.props.actions.map(function(action) {
                     return (
-                        <div key={ action.id }
+                        <li key={ action.id }
                             className="actionday-actionitem"
-                            onClick={ this.onClick.bind(this, action) }>
+                            onClick={ this.onActionClick.bind(this, action) }>
                             <span className="activity">
                                 { action.activity.title }</span>
                             <span className="location">
                                 { action.location.title }</span>
-                        </div>
+                        </li>
                     );
                 }, this) }
+                    <li className="actionday-pseudoitem">
+                        <button className="actionday-addbutton"
+                            onClick={ this.onAddClick.bind(this) }/>
+                    </li>
                 </ul>
             </div>
         );
     }
 
-    onClick(action) {
+    onActionClick(action) {
         if (this.props.onSelectAction) {
             this.props.onSelectAction(action);
+        }
+    }
+
+    onAddClick() {
+        if (this.props.onAddAction) {
+            this.props.onAddAction();
         }
     }
 }
 
 ActionDay.propTypes = {
-    onSelectAction: React.PropTypes.func
+    onSelectAction: React.PropTypes.func,
+    onAddAction: React.PropTypes.func
 };

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -1,0 +1,33 @@
+import React from 'react/addons';
+
+
+export default class ActionDay extends React.Component {
+    render() {
+        const DAY_LABELS = [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ];
+
+        const date = this.props.date;
+        const dateLabel = date.getDate() + '/' + date.getMonth();
+        const dayLabel = DAY_LABELS[date.getDay()];
+
+        return (
+            <div className="actionday">
+                <h3>
+                    <span className="date">{ dateLabel }</span>
+                    <span className="weekday">{ dayLabel }</span>
+                </h3>
+                <ul>
+                { this.props.actions.map(function(action) {
+                    return (
+                        <div className="actionday-actionitem">
+                            <span className="activity">
+                                { action.activity.title }</span>
+                            <span className="location">
+                                { action.location.title }</span>
+                        </div>
+                    );
+                }) }
+                </ul>
+            </div>
+        );
+    }
+}

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -1,8 +1,31 @@
 import React from 'react/addons';
+import { DropTarget } from 'react-dnd';
 
 import ActionItem from './ActionItem';
 
 
+const dayTarget = {
+    canDrop(props, monitor) {
+        return true;
+    },
+
+    drop(props) {
+        return {
+            onMoveAction: props.onMoveAction,
+            newDate: props.date
+        };
+    }
+};
+
+function collect(connect, monitor) {
+    return {
+        connectDropTarget: connect.dropTarget(),
+        isOver: monitor.isOver(),
+        canDrop: monitor.canDrop()
+    };
+}
+
+@DropTarget('action', dayTarget, collect)
 export default class ActionDay extends React.Component {
     render() {
         const DAY_LABELS = [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ];
@@ -11,7 +34,7 @@ export default class ActionDay extends React.Component {
         const dateLabel = date.getDate() + '/' + date.getMonth();
         const dayLabel = DAY_LABELS[date.getDay()];
 
-        return (
+        return this.props.connectDropTarget(
             <div className="actionday">
                 <h3>
                     <span className="date">{ dateLabel }</span>

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -18,16 +18,28 @@ export default class ActionDay extends React.Component {
                 <ul>
                 { this.props.actions.map(function(action) {
                     return (
-                        <div className="actionday-actionitem">
+                        <div key={ action.id }
+                            className="actionday-actionitem"
+                            onClick={ this.onClick.bind(this, action) }>
                             <span className="activity">
                                 { action.activity.title }</span>
                             <span className="location">
                                 { action.location.title }</span>
                         </div>
                     );
-                }) }
+                }, this) }
                 </ul>
             </div>
         );
     }
+
+    onClick(action) {
+        if (this.props.onSelectAction) {
+            this.props.onSelectAction(action);
+        }
+    }
 }
+
+ActionDay.propTypes = {
+    onSelectAction: React.PropTypes.func
+};

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -1,5 +1,7 @@
 import React from 'react/addons';
 
+import ActionItem from './ActionItem';
+
 
 export default class ActionDay extends React.Component {
     render() {
@@ -17,16 +19,8 @@ export default class ActionDay extends React.Component {
                 </h3>
                 <ul>
                 { this.props.actions.map(function(action) {
-                    return (
-                        <li key={ action.id }
-                            className="actionday-actionitem"
-                            onClick={ this.onActionClick.bind(this, action) }>
-                            <span className="activity">
-                                { action.activity.title }</span>
-                            <span className="location">
-                                { action.location.title }</span>
-                        </li>
-                    );
+                    return <ActionItem key={ action.id } action={ action }
+                            onClick={ this.onActionClick.bind(this, action) }/>
                 }, this) }
                     <li className="actionday-pseudoitem">
                         <button className="actionday-addbutton"

--- a/src/js/components/misc/actioncal/ActionItem.jsx
+++ b/src/js/components/misc/actioncal/ActionItem.jsx
@@ -1,11 +1,40 @@
 import React from 'react/addons';
+import { DragSource } from 'react-dnd';
 
 
+const actionSource = {
+    beginDrag(props) {
+        return props.action;
+    },
+
+    endDrag(props, monitor, component) {
+        const dropResult = monitor.getDropResult();
+        if (!dropResult) {
+            return;
+        }
+
+        const action = monitor.getItem();
+        const newDate = dropResult.newDate;
+
+        if (dropResult.onMoveAction) {
+            dropResult.onMoveAction(action, newDate);
+        }
+    }
+};
+
+function collect(connect, monitor) {
+    return {
+        connectDragSource: connect.dragSource(),
+        isDragging: monitor.isDragging()
+    }
+}
+
+@DragSource('action', actionSource, collect)
 export default class ActionItem extends React.Component {
     render() {
         const action = this.props.action;
 
-        return (
+        return this.props.connectDragSource(
             <li className="actionday-actionitem"
                 onClick={ this.onClick.bind(this) }>
                 <span className="activity">

--- a/src/js/components/misc/actioncal/ActionItem.jsx
+++ b/src/js/components/misc/actioncal/ActionItem.jsx
@@ -1,0 +1,33 @@
+import React from 'react/addons';
+
+
+export default class ActionItem extends React.Component {
+    render() {
+        const action = this.props.action;
+
+        return (
+            <li className="actionday-actionitem"
+                onClick={ this.onClick.bind(this) }>
+                <span className="activity">
+                    { action.activity.title }</span>
+                <span className="location">
+                    { action.location.title }</span>
+            </li>
+        );
+    }
+
+    onClick(ev) {
+        if (this.props.onClick) {
+            this.props.onClick(this.props.action);
+        }
+    }
+}
+
+ActionItem.propTypes = {
+    onClick: React.PropTypes.func,
+    action: React.PropTypes.shape({
+        id: React.PropTypes.string,
+        location: React.PropTypes.object,
+        activity: React.PropTypes.object
+    }).isRequired
+};

--- a/src/js/components/misc/actioncal/ActionWeek.jsx
+++ b/src/js/components/misc/actioncal/ActionWeek.jsx
@@ -1,0 +1,15 @@
+import React from 'react/addons';
+
+
+export default class ActionWeek extends React.Component {
+    render() {
+        const week = this.props.firstDate.getWeekNumber();
+
+        return (
+            <div className="actionweek">
+                <h2>v. { week }</h2>
+                { this.props.children }
+            </div>
+        );
+    }
+}

--- a/src/js/components/panes/AddActionPane.jsx
+++ b/src/js/components/panes/AddActionPane.jsx
@@ -1,0 +1,16 @@
+import React from 'react/addons';
+
+import PaneBase from './PaneBase';
+import PersonForm from '../forms/PersonForm';
+
+
+export default class AddActionPane extends PaneBase {
+    getPaneTitle(data) {
+        return "Add action";
+    }
+
+    renderPaneContent(data) {
+        // TODO: Implement pane content
+        return null;
+    }
+}

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -3,9 +3,19 @@ import React from 'react/addons';
 import PaneBase from '../../panes/PaneBase';
 import ActionList from '../../misc/actionlist/ActionList';
 import CampaignSelect from '../../misc/CampaignSelect';
+import ActionCalendar from '../../misc/actioncal/ActionCalendar';
+import ViewSwitch from '../../misc/ViewSwitch';
 
 
 export default class AllActionsPane extends PaneBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            viewMode: 'cal'
+        };
+    }
+
     getPaneTitle() {
         return 'All actions';
     }
@@ -22,12 +32,35 @@ export default class AllActionsPane extends PaneBase {
     renderPaneContent() {
         var actionStore = this.getStore('action');
         var actions = actionStore.getActions();
+        var viewComponent;
+
+        if (this.state.viewMode == 'cal') {
+            viewComponent = <ActionCalendar actions={ actions } />;
+        }
+        else {
+            viewComponent = <ActionList actions={ actions }
+                    onActionOperation={ this.onActionOperation.bind(this) }/>;
+        }
+
+        const viewStates = {
+            'cal': 'Calendar',
+            'list': 'List'
+        };
 
         return [
+            <ViewSwitch states={ viewStates }
+                selected={ this.state.viewMode }
+                onSwitch={ this.onViewSwitch.bind(this) }/>,
+
             <CampaignSelect/>,
-            <ActionList actions={ actions }
-                onActionOperation={ this.onActionOperation.bind(this) }/>
+            viewComponent
         ];
+    }
+
+    onViewSwitch(state) {
+        this.setState({
+            viewMode: state
+        });
     }
 
     onActionOperation(action, operation) {

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -35,7 +35,8 @@ export default class AllActionsPane extends PaneBase {
         var viewComponent;
 
         if (this.state.viewMode == 'cal') {
-            viewComponent = <ActionCalendar actions={ actions } />;
+            viewComponent = <ActionCalendar actions={ actions }
+                    onSelectAction={ this.onSelectAction.bind(this) }/>
         }
         else {
             viewComponent = <ActionList actions={ actions }
@@ -61,6 +62,10 @@ export default class AllActionsPane extends PaneBase {
         this.setState({
             viewMode: state
         });
+    }
+
+    onSelectAction(action) {
+        this.gotoSubPane('editaction', action.id);
     }
 
     onActionOperation(action, operation) {

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -37,6 +37,7 @@ export default class AllActionsPane extends PaneBase {
         if (this.state.viewMode == 'cal') {
             viewComponent = <ActionCalendar actions={ actions }
                     onAddAction={ this.onCalendarAddAction.bind(this) }
+                    onMoveAction={ this.onCalendarMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
         }
         else {
@@ -68,6 +69,28 @@ export default class AllActionsPane extends PaneBase {
     onCalendarAddAction(date) {
         // TODO: Pass date to new action somehow
         this.gotoSubPane('addaction');
+    }
+
+    onCalendarMoveAction(action, date) {
+        const oldStartTime = new Date(action.start_time);
+        const oldEndTime = new Date(action.end_time);
+
+        const startTime = new Date(date);
+        startTime.setHours(oldStartTime.getHours());
+        startTime.setMinutes(oldStartTime.getMinutes());
+        startTime.setSeconds(oldStartTime.getSeconds());
+
+        const endTime = new Date(date);
+        endTime.setHours(oldEndTime.getHours());
+        endTime.setMinutes(oldEndTime.getMinutes());
+        endTime.setSeconds(oldEndTime.getSeconds());
+
+        const values = {
+            start_time: startTime.toISOString(),
+            end_time: endTime.toISOString()
+        };
+
+        this.getActions('action').updateAction(action.id, values);
     }
 
     onSelectAction(action) {

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -36,6 +36,7 @@ export default class AllActionsPane extends PaneBase {
 
         if (this.state.viewMode == 'cal') {
             viewComponent = <ActionCalendar actions={ actions }
+                    onAddAction={ this.onCalendarAddAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
         }
         else {
@@ -62,6 +63,11 @@ export default class AllActionsPane extends PaneBase {
         this.setState({
             viewMode: state
         });
+    }
+
+    onCalendarAddAction(date) {
+        // TODO: Pass date to new action somehow
+        this.gotoSubPane('addaction');
     }
 
     onSelectAction(action) {

--- a/src/js/stores/action.js
+++ b/src/js/stores/action.js
@@ -41,7 +41,9 @@ export default class ActionStore extends Store {
 
     onRetrieveAllActionsComplete(res) {
         this.setState({
-            actions: res.data.data
+            actions: res.data.data.sort((a0, a1) =>
+                (new Date(a0.start_time)).getTime() -
+                (new Date(a1.start_time)).getTime())
         });
     }
 

--- a/src/js/utils/PaneUtils.js
+++ b/src/js/utils/PaneUtils.js
@@ -1,3 +1,4 @@
+import AddActionPane from '../components/panes/AddActionPane';
 import AddActivityPane from '../components/panes/AddActivityPane';
 import AddCampaignPane from '../components/panes/AddCampaignPane';
 import AddPersonPane from '../components/panes/AddPersonPane';
@@ -12,6 +13,7 @@ import MoveParticipantsPane from '../components/panes/MoveParticipantsPane';
 import PersonPane from '../components/panes/PersonPane';
 
 var _panes = {
+    'addaction': AddActionPane,
     'addactivity': AddActivityPane,
     'addperson': AddPersonPane,
     'addcampaign': AddCampaignPane,

--- a/src/js/utils/polyfills.js
+++ b/src/js/utils/polyfills.js
@@ -1,1 +1,8 @@
 require('array.prototype.find');
+
+Date.prototype.getWeekNumber = function(){
+    var d = new Date(+this);
+    d.setHours(0,0,0);
+    d.setDate(d.getDate()+4-(d.getDay()||7));
+    return Math.ceil((((d-new Date(d.getFullYear(),0,1))/8.64e7)+1)/7);
+};

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -62,3 +62,29 @@
         }
     }
 }
+
+.actionday-addbutton {
+    visibility: hidden;
+    display: block;
+    width: 100%;
+    background-color: #eee;
+    border-width: 0;
+    cursor: pointer;
+    opacity: 0;
+
+    text-align: center;
+
+    transition: opacity 0.3s 0.1s;
+
+    &::before {
+        content: "+";
+        color: #aaa;
+        font-size: 1.5em;
+        font-weight: bold;
+    }
+}
+
+.actionday:hover .actionday-addbutton {
+    visibility: visible;
+    opacity: 1;
+}

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -1,0 +1,64 @@
+.actionweek {
+    margin: 1em 0;
+
+    h2 {
+        float: left;
+        font-size: 1em;
+        font-weight: normal;
+        width: 5%;
+    }
+    
+    &::after {
+        content: "";
+        display: block;
+        clear: both;
+    }
+}
+
+.actionday {
+    width: 13%;
+    margin-left: 0.5%;
+    float: left;
+
+    h3 {
+        margin: 0 0 0.1em;
+        padding: 0.5em 1em;
+        background-color: white;
+        box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+
+        .date {
+            font-size: 1.3em;
+            font-weight: bold;
+            padding-right: 0.5em;
+        }
+    }
+}
+
+.actionday-actionitem {
+    padding: 0.5em 1em;
+    margin: 0 0 0.1em;
+    background-color: white;
+    box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+
+    .activity {
+        display: block;
+        font-size: 1.2em;
+        font-weight: bold;
+        margin: 0 0 0.2em;
+    }
+
+    .location {
+        display: block;
+        font-size: 1.1em;
+
+        &::before {
+            content: "";
+            display: block;
+            float: left;
+            background-color: #888;
+            width: 0.5em;
+            height: 0.5em;
+            margin: 0.1em;
+        }
+    }
+}

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -1,3 +1,11 @@
+.section-pane {
+    background-color: white;
+}
+
+.section-pane-actions {
+    background-color: #fafafa;
+}
+
 .section-pane-person {
     min-width: 400px;
 }

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -1,5 +1,6 @@
 .section-pane {
     background-color: white;
+    min-width: 400px;
 }
 
 .section-pane-actions {

--- a/src/scss/section/_base.scss
+++ b/src/scss/section/_base.scss
@@ -7,7 +7,6 @@
     left: 0;
     right: 0;
     padding: 0 2em 2em;
-    background-color: white;
     position: absolute;
 
     .section-pane-content {

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -82,7 +82,6 @@
         bottom: 0;
         right: auto;
         display: block;
-        background-color: white;
 
         &::before {
             content: "";

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -15,5 +15,6 @@
     @import "dashboard/_medium";
     @import "panes/_medium";
     @import "actionlist/_medium";
+    @import "actioncal/_medium";
     @import "forms/_medium";
 }


### PR DESCRIPTION
Creates a component to display actions in a calendar and adds it as a second view mode to the "All actions" sub-section.

The `ActionCalendar` component is completely "dumb", displays all actions that are given to it (assuming that they are ordered correctly), allows clicking on an action to "open" (or whatever the parent component dictates) and supports drag and drop between days.

![image](https://cloud.githubusercontent.com/assets/550212/9524638/342216a2-4ce0-11e5-8cd0-5e619d1679ee.png)
