### PR TITLE
Campaign locations

### DIFF
--- a/src/js/components/misc/actionlocations/ActionLocationItem.jsx
+++ b/src/js/components/misc/actionlocations/ActionLocationItem.jsx
@@ -1,0 +1,41 @@
+import React from 'react/addons';
+
+export default class ActionLocationItem extends React.Component {
+    render() {
+        const loc = this.props.location;
+        const counts = [
+            this.props.numMorningActions,
+            this.props.numNoonActions,
+            this.props.numAfternoonActions,
+            this.props.numEveningActions,
+            this.props.numNightActions
+        ];
+
+        const totalCount = counts.reduce((x, y) => x + y, 0);
+        const average = this.props.numActionsAverage;
+        const ballSize = Math.max(24, Math.min(50, 37 * totalCount/average));
+        const countStyle = {
+            width: ballSize,
+            height: ballSize
+        };
+
+        return (
+            <li>
+                <span className="title">{ loc.title }</span>
+                <span style={ countStyle } className="actioncount">
+                    <span>{ totalCount }</span></span>
+            </li>
+        );
+    }
+}
+
+ActionLocationItem.propTypes = {
+    numMorningActions: React.PropTypes.number.isRequired,
+    numNoonActions: React.PropTypes.number.isRequired,
+    numAfternoonActions: React.PropTypes.number.isRequired,
+    numEveningActions: React.PropTypes.number.isRequired,
+    numNightActions: React.PropTypes.number.isRequired,
+    location: React.PropTypes.shape({
+        title: React.PropTypes.string.isRequired
+    }).isRequired
+};

--- a/src/js/components/misc/actionlocations/ActionLocationItem.jsx
+++ b/src/js/components/misc/actionlocations/ActionLocationItem.jsx
@@ -1,5 +1,8 @@
 import React from 'react/addons';
 
+import DayCycleGraph from './DayCycleGraph';
+
+
 export default class ActionLocationItem extends React.Component {
     render() {
         const loc = this.props.location;
@@ -20,10 +23,11 @@ export default class ActionLocationItem extends React.Component {
         };
 
         return (
-            <li>
+            <li className="actionlocationitem">
                 <span className="title">{ loc.title }</span>
                 <span style={ countStyle } className="actioncount">
                     <span>{ totalCount }</span></span>
+                <DayCycleGraph phases={ counts }/>
             </li>
         );
     }

--- a/src/js/components/misc/actionlocations/ActionLocations.jsx
+++ b/src/js/components/misc/actionlocations/ActionLocations.jsx
@@ -1,0 +1,72 @@
+import React from 'react/addons';
+
+import ActionLocationItem from './ActionLocationItem';
+
+
+export default class ActionLocations extends React.Component {
+    render() {
+        const actions = this.props.actions;
+        const locations = {};
+
+        var i;
+
+        for (i = 0; i < actions.length; i++) {
+            var action = actions[i];
+            var loc = action.location;
+
+            if (!locations.hasOwnProperty(loc.id)) {
+                locations[loc.id] = {
+                    loc: loc,
+                    numMorningActions: 0,
+                    numNoonActions: 0,
+                    numAfternoonActions: 0,
+                    numEveningActions: 0,
+                    numNightActions: 0
+                };
+            }
+
+            var startTime = new Date(action.start_time);
+            var hour = startTime.getHours();
+
+            if (hour <= 4 || hour > 22) {
+                locations[loc.id].numNightActions++;
+            }
+            else if (hour <= 9) {
+                locations[loc.id].numMorningActions++;
+            }
+            else if (hour <= 13) {
+                locations[loc.id].numNoonActions++;
+            }
+            else if (hour <= 17) {
+                locations[loc.id].numAfternoonActions++;
+            }
+            else if (hour <= 22) {
+                locations[loc.id].numEveningActions++;
+            }
+        }
+
+        const numLocations = Object.keys(locations).length;
+        const average = actions.length / numLocations;
+
+        return (
+            <ul className="actionlocations">
+                {Object.keys(locations).map(function(id) {
+                    const loc = locations[id].loc;
+                    const counts = locations[id]
+
+                    return <ActionLocationItem key={ id } location={ loc }
+                            numActionsAverage={ average }
+                            numMorningActions={ counts.numMorningActions }
+                            numNoonActions={ counts.numNoonActions }
+                            numAfternoonActions={ counts.numAfternoonActions }
+                            numEveningActions={ counts.numEveningActions }
+                            numNightActions={ counts.numNightActions }/>
+                })}
+            </ul>
+        );
+    }
+}
+
+ActionLocations.propTypes = {
+    actions: React.PropTypes.array.isRequired
+};

--- a/src/js/components/misc/actionlocations/ActionLocations.jsx
+++ b/src/js/components/misc/actionlocations/ActionLocations.jsx
@@ -26,7 +26,7 @@ export default class ActionLocations extends React.Component {
             }
 
             var startTime = new Date(action.start_time);
-            var hour = startTime.getHours();
+            var hour = startTime.getUTCHours();
 
             if (hour <= 4 || hour > 22) {
                 locations[loc.id].numNightActions++;

--- a/src/js/components/misc/actionlocations/DayCycleGraph.jsx
+++ b/src/js/components/misc/actionlocations/DayCycleGraph.jsx
@@ -9,7 +9,7 @@ export default class DayCycleGraph extends React.Component {
         var content = null;
 
         if (sum > 0) {
-            const minWidth = 0.05;
+            const minWidth = 0.03;
             const minCount = minWidth * sum;
             const staticCounts = phases.filter(x => x <= minCount);
             const dynWidth = 1.0 - (staticCounts.length * minWidth);

--- a/src/js/components/misc/actionlocations/DayCycleGraph.jsx
+++ b/src/js/components/misc/actionlocations/DayCycleGraph.jsx
@@ -1,0 +1,44 @@
+import React from 'react/addons';
+
+
+export default class DayCycleGraph extends React.Component {
+    render() {
+        const phases = this.props.phases;
+        const sum = phases.reduce((x, y) => x + y, 0);
+
+        var content = null;
+
+        if (sum > 0) {
+            const minWidth = 0.05;
+            const minCount = minWidth * sum;
+            const staticCounts = phases.filter(x => x <= minCount);
+            const dynWidth = 1.0 - (staticCounts.length * minWidth);
+            const dynSum = sum - staticCounts.reduce((x, y) => x + y, 0);
+
+            const widths = phases.map(count => (count < minCount)?
+                minWidth : dynWidth * count/dynSum);
+
+            content = phases.map(function(count, idx) {
+                const className = 'phase' + idx;
+                const style = {
+                    width: (widths[idx] * 100) + '%'
+                };
+
+                return (
+                    <li className={ className } style={ style }>
+                        { count }</li>
+                );
+            });
+        }
+
+        return (
+            <ul className="daycyclegraph">
+                { content }
+            </ul>
+        );
+    }
+}
+
+DayCycleGraph.propTypes = {
+    phases: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
+};

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -2,6 +2,7 @@ import React from 'react/addons';
 
 import PaneBase from '../../panes/PaneBase';
 import CampaignSelect from '../../misc/CampaignSelect';
+import ActionLocations from '../../misc/actionlocations/ActionLocations';
 
 
 export default class AllActionsPane extends PaneBase {
@@ -16,8 +17,12 @@ export default class AllActionsPane extends PaneBase {
     }
 
     renderPaneContent() {
+        const actionStore = this.getStore('action');
+        const actions = actionStore.getActions();
+
         return [
-            <CampaignSelect/>
+            <CampaignSelect/>,
+            <ActionLocations actions={ actions }/>
         ];
     }
 }

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -1,0 +1,23 @@
+import React from 'react/addons';
+
+import PaneBase from '../../panes/PaneBase';
+import CampaignSelect from '../../misc/CampaignSelect';
+
+
+export default class AllActionsPane extends PaneBase {
+    getPaneTitle() {
+        return 'Campaign locations';
+    }
+
+    componentDidMount() {
+        this.listenTo('action', this.forceUpdate);
+        this.listenTo('campaign', this.forceUpdate);
+        this.getActions('action').retrieveAllActions();
+    }
+
+    renderPaneContent() {
+        return [
+            <CampaignSelect/>
+        ];
+    }
+}

--- a/src/js/components/sections/campaign/CampaignSection.jsx
+++ b/src/js/components/sections/campaign/CampaignSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react/addons';
 
 import SectionBase from '../SectionBase';
+import CampaignLocationsPane from './CampaignLocationsPane';
 import CampaignOverviewPane from './CampaignOverviewPane';
 import CampaignPlannerPane from './CampaignPlannerPane';
 import AllActivitiesPane from './AllActivitiesPane';
@@ -14,6 +15,8 @@ export default class CampaignSection extends SectionBase {
                 startPane: CampaignOverviewPane },
             { path: 'actions', title: 'All actions',
                 startPane: AllActionsPane },
+            { path: 'locations', title: 'Campaign locations',
+                startPane: CampaignLocationsPane },
             { path: 'activities', title: 'Activities',
                 startPane: AllActivitiesPane },
             { path: 'planner', title: 'Planner',

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -64,6 +64,11 @@ router.get(/campaigns$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaigns()
 ]));
 
+router.get(/campaign\/locations$/, waitForActions(req => [
+    req.flux.getActions('campaign').retrieveCampaigns(),
+    req.flux.getActions('action').retrieveAllActions()
+]));
+
 router.get(/campaign:(\d+)$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaign(req.params[0])
 ]));

--- a/src/scss/actionlocations/_base.scss
+++ b/src/scss/actionlocations/_base.scss
@@ -1,14 +1,13 @@
-.actionlocations {
-    li {
-        position: relative;
-        display: block;
-        float: left;
-        margin: 1em;
-        padding: 1em;
+.actionlocationitem {
+    position: relative;
+    display: block;
+    float: left;
+    margin: 1em;
+    padding: 1em;
+    min-height: 5em;
 
-        background-color: white;
-        box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
-    }
+    background-color: white;
+    box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
 
     .title {
         &::before {
@@ -33,6 +32,7 @@
         z-index: 2;
 
         transform: translate(50%, 0);
+        pointer-events: none;
 
         transition: width 0.3s, height 0.3s;
 
@@ -60,6 +60,65 @@
 
             font-weight: bold;
             text-align: center;
+        }
+    }
+}
+
+.daycyclegraph {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 0.6em;
+    background-color: #888;
+
+    &:hover {
+        // Show above ball when hovering
+        z-index: 3;
+    }
+
+    li {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        float: left;
+        box-sizing: border-box;
+        border-left: 0.2em solid #cde;
+        overflow: hidden;
+        text-indent: 1000px;
+        cursor: pointer;
+
+        transition: width 0.2s;
+
+        &:hover {
+            &::before {
+                content: "";
+                display: block;
+                width: 100%;
+                height: 100%;
+                background-color: rgba(240,250,255,0.2);
+            }
+        }
+
+        &.phase0 {
+            border-left: none;
+            background-color: #6df;
+        }
+
+        &.phase1 {
+            background-color: #4ad;
+        }
+
+        &.phase2 {
+            background-color: #26a;
+        }
+
+        &.phase3 {
+            background-color: #026;
+        }
+
+        &.phase4 {
+            background-color: #002;
         }
     }
 }

--- a/src/scss/actionlocations/_base.scss
+++ b/src/scss/actionlocations/_base.scss
@@ -1,0 +1,65 @@
+.actionlocations {
+    li {
+        position: relative;
+        display: block;
+        float: left;
+        margin: 1em;
+        padding: 1em;
+
+        background-color: white;
+        box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+    }
+
+    .title {
+        &::before {
+            // TODO: Location icon
+            content: "";
+            display: block;
+            width: 1em;
+            height: 1em;
+            background-color: #ccc;
+            float: left;
+            margin-right: 0.2em;
+        }
+
+        font-size: 1.2em;
+        font-weight: bold;
+    }
+
+    .actioncount {
+        position: absolute;
+        top: 50%;
+        right: 1em;
+        z-index: 2;
+
+        transform: translate(50%, 0);
+
+        transition: width 0.3s, height 0.3s;
+
+        &::before {
+            z-index: 0;
+            position: absolute;
+            top: -50%;
+            left: -50%;
+            content: "";
+            display: block;
+            width: 100%;
+            height: 100%;
+            border-radius: 50%;
+            background-color: red;
+        }
+
+        span {
+            z-index: 1;
+            position: absolute;
+            color: white;
+            width: 2em;
+            height: 1em;
+            left: -1em;
+            top: -0.5em;
+
+            font-weight: bold;
+            text-align: center;
+        }
+    }
+}

--- a/src/scss/actionlocations/_medium.scss
+++ b/src/scss/actionlocations/_medium.scss
@@ -1,0 +1,5 @@
+.actionlocations {
+    li {
+        width: 25%;
+    }
+}

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -1,3 +1,7 @@
+.section-pane {
+    background-color: #f8f8f8;
+}
+
 .section-pane-person {
     min-width: 400px;
 }

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -82,7 +82,6 @@
         bottom: 0;
         right: auto;
         display: block;
-        background-color: white;
 
         &::before {
             content: "";

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -7,6 +7,7 @@
 @import "actionlist/_base";
 @import "forms/_base";
 @import "locations/_base";
+@import "actionlocations/_base";
 
 @media screen and (min-width: 720px) {
     @import "_medium";
@@ -16,4 +17,5 @@
     @import "panes/_medium";
     @import "actionlist/_medium";
     @import "forms/_medium";
+    @import "actionlocations/_medium";
 }


### PR DESCRIPTION
Adds a sub-section under Campaigns which displays information about the distribution of actions across locations. Each location is a card with the name and total number of actions displayed, as well as a breakdown of the ratio between different times of day (morning, noon, afternoon, evening, night).

![image](https://cloud.githubusercontent.com/assets/550212/9529375/31ca3e88-4cfa-11e5-897d-fdd46f8a8876.png)

