### PR TITLE
Campaign playback

### DIFF
--- a/src/js/components/App.jsx
+++ b/src/js/components/App.jsx
@@ -28,7 +28,7 @@ export default class App extends FluxComponent {
                     <link rel="stylesheet" type="text/css"
                         href="/static/css/style.css"/>
                     <script type="text/javascript"
-                          src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCih1zeZELzFJxP2SFkNJVDLs2ZCT_y3gY"/>
+                          src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCih1zeZELzFJxP2SFkNJVDLs2ZCT_y3gY&libraries=visualization"/>
                 </head>
                 <body>
                     <div id="app">

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -1,5 +1,7 @@
 import React from 'react/addons';
 
+import Scrubber from './Scrubber';
+
 
 export default class CampaignPlayer extends React.Component {
     constructor(props) {
@@ -56,6 +58,12 @@ export default class CampaignPlayer extends React.Component {
     render() {
         var d = new Date(this.state.time);
 
+        const actions = this.props.actions;
+        const startTime = actions.length?
+            new Date(actions[0].start_time).getTime() : 0;
+        const endTime = actions.length?
+            new Date(actions[actions.length-1].end_time).getTime() : 0;
+
         return (
             <div className="campaignplayer">
                 <input type="button" value="play"
@@ -63,8 +71,32 @@ export default class CampaignPlayer extends React.Component {
                 <input type="button" value="stop"
                     onClick={ this.onStop.bind(this) }/>
                 <h1>{ d.toUTCString() }</h1>
+                <Scrubber time={ this.state.time }
+                    startTime={ startTime } endTime={ endTime }
+                    onScrubBegin={ this.onScrubBegin.bind(this) }
+                    onScrubEnd={ this.onScrubEnd.bind(this) }
+                    onScrub={ this.onScrub.bind(this) }/>
             </div>
         );
+    }
+
+    onScrubBegin() {
+        this.wasPlaying = this.state.playing;
+        this.stop();
+    }
+
+    onScrubEnd() {
+        if (this.wasPlaying) {
+            this.wasPlaying = undefined;
+
+            this.play();
+        }
+    }
+
+    onScrub(time) {
+        this.setState({
+            time: time
+        });
     }
 
     onPlay(ev) {
@@ -83,11 +115,7 @@ export default class CampaignPlayer extends React.Component {
     }
 
     onStop(ev) {
-        cancelAnimationFrame(this.rafId);
-
-        this.setState({
-            playing: false
-        });
+        this.stop();
     }
 
     play(startTime) {
@@ -122,6 +150,14 @@ export default class CampaignPlayer extends React.Component {
         }).bind(this);
 
         updateTime();
+    }
+
+    stop() {
+        cancelAnimationFrame(this.rafId);
+
+        this.setState({
+            playing: false
+        });
     }
 }
 

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -84,7 +84,7 @@ export default class CampaignPlayer extends React.Component {
             <div className="campaignplayer">
                 <h1>{ d.toUTCString() }</h1>
                 <div className="heatmap" ref="mapContainer"/>
-                <Transport time={ this.state.time }
+                <Transport time={ this.state.time } playing={ this.state.playing }
                     startTime={ startTime } endTime={ endTime }
                     onPlay={ this.onPlay.bind(this) }
                     onStop={ this.onStop.bind(this) }

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -1,6 +1,6 @@
 import React from 'react/addons';
 
-import Scrubber from './Scrubber';
+import Transport from './Transport';
 
 
 export default class CampaignPlayer extends React.Component {
@@ -82,14 +82,12 @@ export default class CampaignPlayer extends React.Component {
 
         return (
             <div className="campaignplayer">
-                <input type="button" value="play"
-                    onClick={ this.onPlay.bind(this) }/>
-                <input type="button" value="stop"
-                    onClick={ this.onStop.bind(this) }/>
                 <h1>{ d.toUTCString() }</h1>
                 <div className="heatmap" ref="mapContainer"/>
-                <Scrubber time={ this.state.time }
+                <Transport time={ this.state.time }
                     startTime={ startTime } endTime={ endTime }
+                    onPlay={ this.onPlay.bind(this) }
+                    onStop={ this.onStop.bind(this) }
                     onScrubBegin={ this.onScrubBegin.bind(this) }
                     onScrubEnd={ this.onScrubEnd.bind(this) }
                     onScrub={ this.onScrub.bind(this) }/>

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -11,7 +11,7 @@ export default class CampaignPlayer extends React.Component {
             new Date(props.actions[0].start_time) : null;
 
         this.state = {
-            playing: true,
+            playing: false,
             time: startDate? startDate.getTime() : 0
         };
     }
@@ -61,10 +61,6 @@ export default class CampaignPlayer extends React.Component {
             maxIntensity: 1.5,
             radius: 50
         });
-
-        if (this.props.actions.length) {
-            this.play();
-        }
     }
 
     componentWillUnmount() {

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -1,0 +1,130 @@
+import React from 'react/addons';
+
+
+export default class CampaignPlayer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        const startDate = props.actions.length?
+            new Date(props.actions[0].start_time) : null;
+
+        this.state = {
+            playing: true,
+            time: startDate? startDate.getTime() : 0
+        };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const actions = nextProps.actions;
+
+        if (actions.length) {
+            const startDate = new Date(actions[0].start_time);
+            const endDate = new Date(actions[actions.length-1].end_time);
+
+            if (this.state.time < startDate.getTime()) {
+                this.setState({
+                    playing: false,
+                    time: startDate.getTime()
+                });
+
+                cancelAnimationFrame(this.rafId);
+            }
+            else if (this.state.time > endDate.getTime()) {
+                this.setState({
+                    playing: false,
+                    time: endDate.getTime()
+                });
+
+                cancelAnimationFrame(this.rafId);
+            }
+        }
+        else {
+            cancelAnimationFrame(this.rafId);
+        }
+    }
+
+    componentDidMount() {
+        if (this.props.actions.length) {
+            this.play();
+        }
+    }
+
+    componentWillUnmount() {
+        cancelAnimationFrame(this.rafId);
+    }
+
+    render() {
+        var d = new Date(this.state.time);
+
+        return (
+            <div className="campaignplayer">
+                <input type="button" value="play"
+                    onClick={ this.onPlay.bind(this) }/>
+                <input type="button" value="stop"
+                    onClick={ this.onStop.bind(this) }/>
+                <h1>{ d.toUTCString() }</h1>
+            </div>
+        );
+    }
+
+    onPlay(ev) {
+        if (!this.state.playing) {
+            const actions = this.props.actions;
+            const endDate = new Date(actions[actions.length-1].end_time);
+
+            if (this.state.time >= endDate.getTime()) {
+                const startDate = new Date(actions[0].start_time);
+                this.play(startDate.getTime());
+            }
+            else {
+                this.play();
+            }
+        }
+    }
+
+    onStop(ev) {
+        cancelAnimationFrame(this.rafId);
+
+        this.setState({
+            playing: false
+        });
+    }
+
+    play(startTime) {
+        const updateTime = (function() {
+            const actions = this.props.actions;
+            const endDate = new Date(actions[actions.length-1].end_time);
+            const newTime = this.state.time + 1000000;
+
+            if (startTime !== undefined) {
+                this.setState({
+                    playing: true,
+                    time: startTime
+                });
+
+                startTime = undefined;
+                this.rafId = requestAnimationFrame(updateTime.bind(this));
+            }
+            else if (newTime < endDate.getTime()) {
+                this.setState({
+                    playing: true,
+                    time: newTime
+                });
+
+                this.rafId = requestAnimationFrame(updateTime.bind(this));
+            }
+            else {
+                this.setState({
+                    playing: false,
+                    time: endDate.getTime()
+                });
+            }
+        }).bind(this);
+
+        updateTime();
+    }
+}
+
+CampaignPlayer.propTypes = {
+    actions: React.PropTypes.array
+};

--- a/src/js/components/misc/campaignplayer/Scrubber.jsx
+++ b/src/js/components/misc/campaignplayer/Scrubber.jsx
@@ -1,0 +1,89 @@
+import React from 'react/addons';
+
+
+export default class Scrubber extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            scrubbing: false,
+            scrubPos: 0
+        };
+    }
+
+    render() {
+        const startTime = this.props.startTime;
+        const endTime = this.props.endTime;
+        const time = this.props.time;
+
+        const thumbPos = this.state.scrubbing?
+            this.state.scrubPos : (time - startTime) / (endTime - startTime);
+
+        const thumbStyle = {
+            left: (thumbPos * 100) + '%'
+        }
+
+        return (
+            <div className="scrubber" ref="scrubber">
+                <button className="thumb" style={ thumbStyle }
+                    onMouseDown={ this.onThumbDown.bind(this) }/>
+            </div>
+        );
+    }
+
+    onThumbDown(ev) {
+        const scrubber = React.findDOMNode(this.refs.scrubber);
+        const startTime = this.props.startTime;
+        const endTime = this.props.endTime;
+        const time = this.props.time;
+        const component = this;
+
+        this.setState({
+            scrubbing: true,
+            scrubPos: (time - startTime) / (endTime - startTime)
+        });
+
+        if (this.props.onScrubBegin) {
+            this.props.onScrubBegin();
+        }
+
+        function onMouseMove(ev) {
+            const bounds = scrubber.getBoundingClientRect();
+            const x = ev.clientX - bounds.left;
+            const f = (x / scrubber.offsetWidth);
+
+            component.setState({
+                scrubPos: f
+            });
+
+            if (component.props.onScrub) {
+                component.props.onScrub(startTime + (f * (endTime - startTime)));
+            }
+        }
+
+        function onMouseUp(ev) {
+            scrubber.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+
+            component.setState({
+                scrubbing: false
+            });
+
+            if (component.props.onScrubEnd) {
+                component.props.onScrubEnd();
+            }
+        }
+
+        scrubber.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+    }
+}
+
+Scrubber.propTypes = {
+    startTime: React.PropTypes.number.isRequired,
+    endTime: React.PropTypes.number.isRequired,
+    time: React.PropTypes.number.isRequired,
+    onScrubBegin: React.PropTypes.func,
+    onScrubEnd: React.PropTypes.func,
+    onScrub: React.PropTypes.func
+};

--- a/src/js/components/misc/campaignplayer/Transport.jsx
+++ b/src/js/components/misc/campaignplayer/Transport.jsx
@@ -1,0 +1,33 @@
+import React from 'react/addons';
+
+import Scrubber from './Scrubber';
+
+
+export default class Transport extends React.Component {
+    render() {
+        return (
+            <div className="transport">
+                <input type="button" value="play"
+                    onClick={ this.props.onPlay }/>
+                <input type="button" value="stop"
+                    onClick={ this.props.onStop }/>
+                <Scrubber time={ this.props.time }
+                    startTime={ this.props.startTime } endTime={ this.props.endTime }
+                    onScrubBegin={ this.props.onScrubBegin }
+                    onScrubEnd={ this.props.onScrubEnd }
+                    onScrub={ this.props.onScrub }/>
+            </div>
+        );
+    }
+}
+
+Transport.propTypes = {
+    time: React.PropTypes.number.isRequired,
+    startTime: React.PropTypes.number.isRequired,
+    endTime: React.PropTypes.number.isRequired,
+    onPlay: React.PropTypes.func,
+    onStop: React.PropTypes.func,
+    onScrubBegin: React.PropTypes.func,
+    onScrubEnd: React.PropTypes.func,
+    onScrub: React.PropTypes.func
+};

--- a/src/js/components/misc/campaignplayer/Transport.jsx
+++ b/src/js/components/misc/campaignplayer/Transport.jsx
@@ -1,16 +1,21 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 import Scrubber from './Scrubber';
 
 
 export default class Transport extends React.Component {
     render() {
+        const btnClass = cx({
+            'btn': true,
+            'play-btn': !this.props.playing,
+            'stop-btn': this.props.playing
+        });
+
         return (
             <div className="transport">
-                <input type="button" value="play"
-                    onClick={ this.props.onPlay }/>
-                <input type="button" value="stop"
-                    onClick={ this.props.onStop }/>
+                <button className={ btnClass }
+                    onClick={ this.onPlayStopClick.bind(this) }/>
                 <Scrubber time={ this.props.time }
                     startTime={ this.props.startTime } endTime={ this.props.endTime }
                     onScrubBegin={ this.props.onScrubBegin }
@@ -19,12 +24,24 @@ export default class Transport extends React.Component {
             </div>
         );
     }
+
+    onPlayStopClick(ev) {
+        const playing = this.props.playing;
+
+        if (playing && this.props.onStop) {
+            this.props.onStop();
+        }
+        else if (!playing && this.props.onPlay) {
+            this.props.onPlay();
+        }
+    }
 }
 
 Transport.propTypes = {
     time: React.PropTypes.number.isRequired,
     startTime: React.PropTypes.number.isRequired,
     endTime: React.PropTypes.number.isRequired,
+    playing: React.PropTypes.bool,
     onPlay: React.PropTypes.func,
     onStop: React.PropTypes.func,
     onScrubBegin: React.PropTypes.func,

--- a/src/js/components/panes/AddLocationPane.jsx
+++ b/src/js/components/panes/AddLocationPane.jsx
@@ -14,7 +14,7 @@ export default class AddLocationPane extends PaneBase {
         // sloppy
         if (locationStore.getPendingLocation() === false) {
             this.getActions('location')
-                .setPendingLocation(locationStore.getAverageCenterOfLoctions());
+                .setPendingLocation(locationStore.getAverageCenterOfLocations());
         }
     }
 

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -1,0 +1,28 @@
+import React from 'react/addons';
+
+import PaneBase from '../../panes/PaneBase';
+import CampaignSelect from '../../misc/CampaignSelect';
+import CampaignPlayer from '../../misc/campaignplayer/CampaignPlayer';
+
+
+export default class CampaignPlaybackPane extends PaneBase {
+    getPaneTitle() {
+        return 'Campaign playback';
+    }
+
+    componentDidMount() {
+        this.listenTo('action', this.forceUpdate);
+        this.listenTo('campaign', this.forceUpdate);
+        this.getActions('action').retrieveAllActions();
+    }
+
+    renderPaneContent() {
+        const actionStore = this.getStore('action');
+        const actions = actionStore.getActions();
+
+        return [
+            <CampaignSelect/>,
+            <CampaignPlayer actions={ actions }/>
+        ];
+    }
+}

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -13,16 +13,24 @@ export default class CampaignPlaybackPane extends PaneBase {
     componentDidMount() {
         this.listenTo('action', this.forceUpdate);
         this.listenTo('campaign', this.forceUpdate);
+        this.listenTo('location', this.forceUpdate);
         this.getActions('action').retrieveAllActions();
+        this.getActions('location').retrieveLocations();
     }
 
     renderPaneContent() {
         const actionStore = this.getStore('action');
+        const locationStore = this.getStore('location');
         const actions = actionStore.getActions();
+        const locations = locationStore.getLocations();
+
+        const center = locationStore.getAverageCenterOfLocations();
 
         return [
-            <CampaignSelect/>,
-            <CampaignPlayer actions={ actions }/>
+            <CampaignSelect key="select"/>,
+            <CampaignPlayer key="player"
+                actions={ actions } locations={ locations }
+                centerLat={ center.lat } centerLng={ center.lng }/>
         ];
     }
 }

--- a/src/js/components/sections/campaign/CampaignSection.jsx
+++ b/src/js/components/sections/campaign/CampaignSection.jsx
@@ -3,6 +3,7 @@ import React from 'react/addons';
 import SectionBase from '../SectionBase';
 import CampaignOverviewPane from './CampaignOverviewPane';
 import CampaignPlannerPane from './CampaignPlannerPane';
+import CampaignPlaybackPane from './CampaignPlaybackPane';
 import AllActivitiesPane from './AllActivitiesPane';
 import AllActionsPane from './AllActionsPane';
 
@@ -14,6 +15,8 @@ export default class CampaignSection extends SectionBase {
                 startPane: CampaignOverviewPane },
             { path: 'actions', title: 'All actions',
                 startPane: AllActionsPane },
+            { path: 'playback', title: 'Playback',
+                startPane: CampaignPlaybackPane },
             { path: 'activities', title: 'Activities',
                 startPane: AllActivitiesPane },
             { path: 'planner', title: 'Planner',

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -72,6 +72,11 @@ router.get(/campaign\/dashboard$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaigns()
 ]));
 
+router.get(/campaign\/playback$/, waitForActions(req => [
+    req.flux.getActions('campaign').retrieveCampaigns(),
+    req.flux.getActions('action').retrieveAllActions()
+]));
+
 router.get(/campaign\/actions$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaigns(),
     req.flux.getActions('action').retrieveAllActions()

--- a/src/js/server/datarouter.js
+++ b/src/js/server/datarouter.js
@@ -74,7 +74,8 @@ router.get(/campaign\/dashboard$/, waitForActions(req => [
 
 router.get(/campaign\/playback$/, waitForActions(req => [
     req.flux.getActions('campaign').retrieveCampaigns(),
-    req.flux.getActions('action').retrieveAllActions()
+    req.flux.getActions('action').retrieveAllActions(),
+    req.flux.getActions('location').retrieveLocations()
 ]));
 
 router.get(/campaign\/actions$/, waitForActions(req => [

--- a/src/js/stores/location.js
+++ b/src/js/stores/location.js
@@ -38,15 +38,23 @@ export default class LocationStore extends Store {
     }
 
     getAverageCenterOfLocations() {
-        var sumOfLat = 0;
-        var sumOfLng = 0;
-        this.state.locations.forEach(function(location) {
-            sumOfLng += location.lng;
-            sumOfLat += location.lat;
-        });
-        return {
-            lat :  sumOfLat/this.state.locations.length,
-            lng :  sumOfLng/this.state.locations.length
+        if (this.state.locations.length) {
+            var sumOfLat = 0;
+            var sumOfLng = 0;
+            this.state.locations.forEach(function(location) {
+                sumOfLng += location.lng;
+                sumOfLat += location.lat;
+            });
+            return {
+                lat :  sumOfLat/this.state.locations.length,
+                lng :  sumOfLng/this.state.locations.length
+            }
+        }
+        else {
+            return {
+                lat: 0,
+                lng: 0
+            }
         }
     }
 

--- a/src/js/stores/location.js
+++ b/src/js/stores/location.js
@@ -37,7 +37,7 @@ export default class LocationStore extends Store {
         return this.state.locations.find(p => p.id == id);
     }
 
-    getAverageCenterOfLoctions() {
+    getAverageCenterOfLocations() {
         var sumOfLat = 0;
         var sumOfLng = 0;
         this.state.locations.forEach(function(location) {

--- a/src/scss/campaignplayer/_base.scss
+++ b/src/scss/campaignplayer/_base.scss
@@ -5,20 +5,49 @@
         min-height: 400px;
     }
 
-    .scrubber {
-        background-color: white;
+    .transport {
         position: relative;
+        background-color: white;
         width: 100%;
         height: 4em;
-        padding: 1em;
+        margin: 1.5em 0;
 
         box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
 
+        .btn {
+            width: 5em;
+            height: 5em;
+            margin: -0.5em 0 0 1em;
+            border-radius: 50%;
+            border: none;
+            cursor: pointer;
+
+            transition: background-color 0.2s;
+
+            &:focus {
+                outline: 0;
+            }
+
+            &.play-btn {
+                background-color: black;
+            }
+
+            &.stop-btn {
+                background-color: red;
+            }
+        }
+    }
+
+    .scrubber {
+        position: absolute;
+        top: 1.25em;
+        left: 8em;
+        right: 1em;
+
         &::before {
             position: absolute;
-            top: 1.75em;
-            left: 1em;
-            right: 1em;
+            top: 0.5em;
+            width: 100%;
             content: "";
             display: block;
             background-color: #eee;

--- a/src/scss/campaignplayer/_base.scss
+++ b/src/scss/campaignplayer/_base.scss
@@ -1,0 +1,26 @@
+.campaignplayer {
+    .scrubber {
+        background-color: white;
+        position: relative;
+        width: 100%;
+        height: 4em;
+        padding: 1em;
+
+        box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+
+        &::before {
+            position: absolute;
+            top: 1.75em;
+            left: 1em;
+            right: 1em;
+            content: "";
+            display: block;
+            background-color: #eee;
+            height: 0.5em;
+        }
+
+        .thumb {
+            position: absolute;
+        }
+    }
+}

--- a/src/scss/campaignplayer/_base.scss
+++ b/src/scss/campaignplayer/_base.scss
@@ -1,4 +1,10 @@
 .campaignplayer {
+    .heatmap {
+        width: 100%;
+        height: 70%;
+        min-height: 400px;
+    }
+
     .scrubber {
         background-color: white;
         position: relative;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -7,6 +7,7 @@
 @import "actionlist/_base";
 @import "forms/_base";
 @import "locations/_base";
+@import "campaignplayer/_base";
 
 @media screen and (min-width: 720px) {
     @import "_medium";


### PR DESCRIPTION
This PR creates a CampaignPlayer component and a sub-section in the Campaign section to host it.

The CampaignPlayer takes a list of actions and play them back as a heatmap over time. The player can be started and stopped, and the playback can be scrubbed back and forth using a slider.

![image](https://cloud.githubusercontent.com/assets/550212/9545234/bc98f4b8-4d87-11e5-8acc-c270f534678c.png)
