### PR TITLE
Campaign mini-calendar

### DIFF
--- a/src/js/actions/action.js
+++ b/src/js/actions/action.js
@@ -23,4 +23,19 @@ export default class ActionActions extends Actions {
         var orgId = this.flux.getStore('org').getActiveId();
         return Z.resource('orgs', orgId, 'actions', id).patch(data);
     }
+
+    clearActionHighlights() {
+        return true;
+    }
+
+    highlightActionPhase(locId, phase) {
+        return {
+            locId,
+            phase
+        };
+    }
+
+    highlightActionLocation(locId) {
+        return locId;
+    }
 }

--- a/src/js/actions/action.js
+++ b/src/js/actions/action.js
@@ -38,4 +38,8 @@ export default class ActionActions extends Actions {
     highlightActionLocation(locId) {
         return locId;
     }
+
+    highlightActions(actionIds) {
+        return actionIds;
+    }
 }

--- a/src/js/actions/participant.js
+++ b/src/js/actions/participant.js
@@ -30,7 +30,7 @@ export default class ParticipantActions extends Actions {
         var apiCalls = [];
 
         // TODO: Make some server-side batch executer for this?
-        for (i in moves) {
+        for (i = 0; i < moves.length; i++) {
             var move = moves[i];
             apiCalls.push(Z.resource('orgs', orgId, 'actions',
                 move.from, 'participants', move.person).del());

--- a/src/js/components/dashboard/Dashboard.jsx
+++ b/src/js/components/dashboard/Dashboard.jsx
@@ -16,7 +16,7 @@ export default class Dashboard extends FluxComponent {
         var favoriteElements = [];
         var shortcutElements = [];
 
-        for (i in shortcuts) {
+        for (i = 0; i < shortcuts.length; i++) {
             var shortcut = shortcuts[i];
 
             if (i < 4) {
@@ -31,7 +31,7 @@ export default class Dashboard extends FluxComponent {
             }
         }
 
-        for (i in widgets) {
+        for (i = 0; i < widgets.length; i++) {
             var WidgetClass = null;
             var widgetData = widgets[i];
 

--- a/src/js/components/misc/LocationMap.jsx
+++ b/src/js/components/misc/LocationMap.jsx
@@ -67,7 +67,7 @@ export default class LocationMap extends React.Component {
             pendingId = this.props.pendingLocation.id;
         }
 
-        for (i in locations) {
+        for (i = 0; i < locations.length; i++) {
             if (pendingId !== locations[i].id) {
                 this.createMarker(locations[i], false, bounds);
             }
@@ -88,7 +88,7 @@ export default class LocationMap extends React.Component {
         var i;
         var bounds = new google.maps.LatLngBounds();
         // create Bounds and  loop through locations and 
-        for (i in locations) {
+        for (i = 0; i < locations.length; i++) {
             var latLng = new google.maps.LatLng(locations[i].lat, locations[i].lng);
             bounds.extend(latLng);
         }

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -31,7 +31,7 @@ export default class ActionDay extends React.Component {
         const DAY_LABELS = [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ];
 
         const date = this.props.date;
-        const dateLabel = date.getDate() + '/' + date.getMonth();
+        const dateLabel = date.getDate() + '/' + (date.getMonth() + 1);
         const dayLabel = DAY_LABELS[date.getDay()];
 
         return this.props.connectDropTarget(

--- a/src/js/components/misc/actioncal/ActionItem.jsx
+++ b/src/js/components/misc/actioncal/ActionItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react/addons';
 import { DragSource } from 'react-dnd';
+import cx from 'classnames';
 
 
 const actionSource = {
@@ -33,9 +34,14 @@ function collect(connect, monitor) {
 export default class ActionItem extends React.Component {
     render() {
         const action = this.props.action;
+        const className = cx({
+            'actionday-actionitem': true,
+            'highlight': action.highlight
+        });
+
 
         return this.props.connectDragSource(
-            <li className="actionday-actionitem"
+            <li className={ className }
                 onClick={ this.onClick.bind(this) }>
                 <span className="activity">
                     { action.activity.title }</span>

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -7,15 +7,15 @@ export default class ActionMiniCalendar extends React.Component {
     render() {
         const actions = this.props.actions;
 
-        var startDate = this.props.startDate;
-        var endDate = this.props.endDate;
+        var startDate, endDate;
 
-        if (!startDate && actions.length > 0) {
+        if (actions.length) {
             startDate = new Date(actions[0].start_time);
-        }
-
-        if (!endDate && actions.length > 0) {
             endDate = new Date(actions[actions.length-1].end_time);
+        }
+        else {
+            startDate = new Date();
+            endDate = new Date();
         }
 
         var d = new Date(startDate.toDateString());
@@ -58,3 +58,7 @@ export default class ActionMiniCalendar extends React.Component {
         );
     }
 }
+
+ActionMiniCalendar.propTypes = {
+    actions: React.PropTypes.array.isRequired
+};

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -44,8 +44,8 @@ export default class ActionMiniCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
-                    onMoveAction={ this.onMoveAction.bind(this) }
-                    onSelectAction={ this.onSelectAction.bind(this) }/>
+                    onMoveAction={ this.props.onMoveAction }
+                    onSelectAction={ this.props.onSelectAction }/>
             );
 
             d.setDate(d.getDate() + 1);
@@ -56,11 +56,5 @@ export default class ActionMiniCalendar extends React.Component {
                 { days }
             </div>
         );
-    }
-
-    onMoveAction(action, date) {
-    }
-
-    onSelectAction(action) {
     }
 }

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -1,0 +1,66 @@
+import React from 'react/addons';
+
+import ActionDay from './ActionDay';
+
+
+export default class ActionMiniCalendar extends React.Component {
+    render() {
+        const actions = this.props.actions;
+
+        var startDate = this.props.startDate;
+        var endDate = this.props.endDate;
+
+        if (!startDate && actions.length > 0) {
+            startDate = new Date(actions[0].start_time);
+        }
+
+        if (!endDate && actions.length > 0) {
+            endDate = new Date(actions[actions.length-1].end_time);
+        }
+
+        var d = new Date(startDate.toDateString());
+        var days = [];
+        var idx = 0;
+
+        while (d <= endDate) {
+            var dayActions = [];
+
+            while (idx < actions.length) {
+                const action = actions[idx];
+                const ad = new Date(action.start_time);
+
+                if (d.getYear() == ad.getYear()
+                    && d.getMonth() == ad.getMonth()
+                    && d.getDate() == ad.getDate()) {
+
+                    dayActions.push(action);
+
+                    idx++;
+                }
+                else {
+                    break;
+                }
+            }
+
+            days.push(
+                <ActionDay date={ new Date(d) } actions={ dayActions }
+                    onMoveAction={ this.onMoveAction.bind(this) }
+                    onSelectAction={ this.onSelectAction.bind(this) }/>
+            );
+
+            d.setDate(d.getDate() + 1);
+        }
+
+        return (
+            <div className="actionminicalendar">
+                { days }
+            </div>
+        );
+    }
+
+    onMoveAction(action, date) {
+    }
+
+    onSelectAction(action) {
+    }
+}

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -44,6 +44,7 @@ export default class ActionMiniCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
+                    onAddAction={ this.props.onAddAction }
                     onMoveAction={ this.props.onMoveAction }
                     onSelectAction={ this.props.onSelectAction }/>
             );

--- a/src/js/components/misc/actionlocations/ActionLocationItem.jsx
+++ b/src/js/components/misc/actionlocations/ActionLocationItem.jsx
@@ -23,13 +23,36 @@ export default class ActionLocationItem extends React.Component {
         };
 
         return (
-            <li className="actionlocationitem">
+            <li className="actionlocationitem"
+                onMouseOver={ this.onMouseOver.bind(this) }
+                onMouseOut={ this.props.onMouseOut }>
                 <span className="title">{ loc.title }</span>
                 <span style={ countStyle } className="actioncount">
-                    <span>{ totalCount }</span></span>
-                <DayCycleGraph phases={ counts }/>
+                    <span>{ totalCount }</span>
+                </span>
+                <DayCycleGraph phases={ counts }
+                    onMouseOver={ this.onDayCycleMouseOver.bind(this) }
+                    onMouseOut={ this.onDayCycleMouseOut.bind(this) }/>
             </li>
         );
+    }
+
+    onMouseOver(ev) {
+        if (this.props.onMouseOver) {
+            this.props.onMouseOver(this.props.location);
+        }
+    }
+
+    onDayCycleMouseOver(phase) {
+        if (this.props.onMouseOverPhase) {
+            this.props.onMouseOverPhase(this.props.location, phase);
+        }
+    }
+
+    onDayCycleMouseOut() {
+        if (this.props.onMouseOut) {
+            this.props.onMouseOut();
+        }
     }
 }
 
@@ -41,5 +64,8 @@ ActionLocationItem.propTypes = {
     numNightActions: React.PropTypes.number.isRequired,
     location: React.PropTypes.shape({
         title: React.PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    onMouseOver: React.PropTypes.func,
+    onMouseOverPhase: React.PropTypes.func,
+    onMouseOut: React.PropTypes.func
 };

--- a/src/js/components/misc/actionlocations/ActionLocations.jsx
+++ b/src/js/components/misc/actionlocations/ActionLocations.jsx
@@ -28,6 +28,7 @@ export default class ActionLocations extends React.Component {
             var startTime = new Date(action.start_time);
             var hour = startTime.getUTCHours();
 
+            // TODO: Don't duplicate these constants in ActionStore
             if (hour <= 4 || hour > 22) {
                 locations[loc.id].numNightActions++;
             }
@@ -60,8 +61,11 @@ export default class ActionLocations extends React.Component {
                             numNoonActions={ counts.numNoonActions }
                             numAfternoonActions={ counts.numAfternoonActions }
                             numEveningActions={ counts.numEveningActions }
-                            numNightActions={ counts.numNightActions }/>
-                })}
+                            numNightActions={ counts.numNightActions }
+                            onMouseOver={ this.props.onMouseOver }
+                            onMouseOut={ this.props.onMouseOut }
+                            onMouseOverPhase={ this.props.onMouseOverPhase }/>
+                }, this)}
             </ul>
         );
     }

--- a/src/js/components/misc/actionlocations/DayCycleGraph.jsx
+++ b/src/js/components/misc/actionlocations/DayCycleGraph.jsx
@@ -25,10 +25,12 @@ export default class DayCycleGraph extends React.Component {
                 };
 
                 return (
-                    <li className={ className } style={ style }>
+                    <li key={ idx } className={ className } style={ style }
+                        onMouseOver={ this.onMouseOver.bind(this, idx) }
+                        onMouseOut={ this.onMouseOut.bind(this) }>
                         { count }</li>
                 );
-            });
+            }, this);
         }
 
         return (
@@ -37,8 +39,24 @@ export default class DayCycleGraph extends React.Component {
             </ul>
         );
     }
+
+    onMouseOver(phase, ev) {
+        ev.stopPropagation();
+
+        if (this.props.onMouseOver) {
+            this.props.onMouseOver(phase);
+        }
+    }
+
+    onMouseOut() {
+        if (this.props.onMouseOut) {
+            this.props.onMouseOut();
+        }
+    }
 }
 
 DayCycleGraph.propTypes = {
+    onMouseOver: React.PropTypes.func,
+    onMouseOut: React.PropTypes.func,
     phases: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
 };

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -68,8 +68,6 @@ export default class CampaignPlayer extends React.Component {
     }
 
     render() {
-        var d = new Date(this.state.time);
-
         const actions = this.props.actions;
         const startTime = actions.length?
             new Date(actions[0].start_time).getTime() : 0;
@@ -78,8 +76,6 @@ export default class CampaignPlayer extends React.Component {
 
         return (
             <div className="campaignplayer">
-                <h1>{ d.toUTCString() }</h1>
-                <div className="heatmap" ref="mapContainer"/>
                 <Transport time={ this.state.time } playing={ this.state.playing }
                     startTime={ startTime } endTime={ endTime }
                     onPlay={ this.onPlay.bind(this) }
@@ -87,6 +83,7 @@ export default class CampaignPlayer extends React.Component {
                     onScrubBegin={ this.onScrubBegin.bind(this) }
                     onScrubEnd={ this.onScrubEnd.bind(this) }
                     onScrub={ this.onScrub.bind(this) }/>
+                <div className="heatmap" ref="mapContainer"/>
             </div>
         );
     }

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -139,6 +139,7 @@ export default class CampaignPlayer extends React.Component {
 
         var i ;
         var locationWeights = {};
+        var filteredActions = [];
 
         for (i = 0; i < actions.length; i++) {
             var action = actions[i];
@@ -148,6 +149,7 @@ export default class CampaignPlayer extends React.Component {
 
             if (time > actionStartTime) {
                 if (time < (actionEndTime + cooldown)) {
+                    filteredActions.push(action);
                     locationWeights[loc.id] = 1.0 - (time - actionEndTime) / cooldown;
                 }
                 else {
@@ -169,6 +171,13 @@ export default class CampaignPlayer extends React.Component {
         }
 
         this.heatmap.setData(points);
+
+        if (this.props.onActionsChange
+            && !filteredActions.equals(this.lastActions)) {
+
+            this.props.onActionsChange(filteredActions);
+            this.lastActions = filteredActions;
+        }
     }
 
     play(startTime) {

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -27,6 +27,9 @@ export default class PaneBase extends FluxComponent {
         return (
             <div className={ classNames.join(' ') }>
                 <header>
+                    <div className="pane-top">
+                    { this.renderPaneTop(data) }
+                    </div>
                     <a className="section-pane-closelink"
                         onClick={ this.onCloseClick.bind(this) }/>
                     <h2>{ this.getPaneTitle(data) }</h2>
@@ -37,6 +40,10 @@ export default class PaneBase extends FluxComponent {
                 </div>
             </div>
         );
+    }
+
+    renderPaneTop(data) {
+        return null;
     }
 
     getPaneTitle(data) {

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -1,13 +1,13 @@
 import React from 'react/addons';
 
-import PaneBase from '../../panes/PaneBase';
+import PaneWithCalendar from './PaneWithCalendar';
 import ActionList from '../../misc/actionlist/ActionList';
 import CampaignSelect from '../../misc/CampaignSelect';
 import ActionCalendar from '../../misc/actioncal/ActionCalendar';
 import ViewSwitch from '../../misc/ViewSwitch';
 
 
-export default class AllActionsPane extends PaneBase {
+export default class AllActionsPane extends PaneWithCalendar {
     constructor(props) {
         super(props);
 
@@ -64,37 +64,6 @@ export default class AllActionsPane extends PaneBase {
         this.setState({
             viewMode: state
         });
-    }
-
-    onCalendarAddAction(date) {
-        // TODO: Pass date to new action somehow
-        this.gotoSubPane('addaction');
-    }
-
-    onCalendarMoveAction(action, date) {
-        const oldStartTime = new Date(action.start_time);
-        const oldEndTime = new Date(action.end_time);
-
-        const startTime = new Date(date);
-        startTime.setHours(oldStartTime.getHours());
-        startTime.setMinutes(oldStartTime.getMinutes());
-        startTime.setSeconds(oldStartTime.getSeconds());
-
-        const endTime = new Date(date);
-        endTime.setHours(oldEndTime.getHours());
-        endTime.setMinutes(oldEndTime.getMinutes());
-        endTime.setSeconds(oldEndTime.getSeconds());
-
-        const values = {
-            start_time: startTime.toISOString(),
-            end_time: endTime.toISOString()
-        };
-
-        this.getActions('action').updateAction(action.id, values);
-    }
-
-    onSelectAction(action) {
-        this.gotoSubPane('editaction', action.id);
     }
 
     onActionOperation(action, operation) {

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -22,6 +22,7 @@ export default class AllActionsPane extends PaneWithCalendar {
         const actions = actionStore.getActions();
 
         return <ActionMiniCalendar actions={ actions }
+                    onAddAction={ this.onCalendarAddAction.bind(this) }
                     onMoveAction={ this.onCalendarMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
     }

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -3,6 +3,7 @@ import React from 'react/addons';
 import PaneBase from '../../panes/PaneBase';
 import CampaignSelect from '../../misc/CampaignSelect';
 import ActionLocations from '../../misc/actionlocations/ActionLocations';
+import ActionMiniCalendar from '../../misc/actioncal/ActionMiniCalendar';
 
 
 export default class AllActionsPane extends PaneBase {
@@ -14,6 +15,13 @@ export default class AllActionsPane extends PaneBase {
         this.listenTo('action', this.forceUpdate);
         this.listenTo('campaign', this.forceUpdate);
         this.getActions('action').retrieveAllActions();
+    }
+
+    renderPaneTop() {
+        const actionStore = this.getStore('action');
+        const actions = actionStore.getActions();
+
+        return <ActionMiniCalendar actions={ actions }/>
     }
 
     renderPaneContent() {

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -1,12 +1,12 @@
 import React from 'react/addons';
 
-import PaneBase from '../../panes/PaneBase';
+import PaneWithCalendar from './PaneWithCalendar';
 import CampaignSelect from '../../misc/CampaignSelect';
 import ActionLocations from '../../misc/actionlocations/ActionLocations';
 import ActionMiniCalendar from '../../misc/actioncal/ActionMiniCalendar';
 
 
-export default class AllActionsPane extends PaneBase {
+export default class AllActionsPane extends PaneWithCalendar {
     getPaneTitle() {
         return 'Campaign locations';
     }
@@ -21,7 +21,9 @@ export default class AllActionsPane extends PaneBase {
         const actionStore = this.getStore('action');
         const actions = actionStore.getActions();
 
-        return <ActionMiniCalendar actions={ actions }/>
+        return <ActionMiniCalendar actions={ actions }
+                    onMoveAction={ this.onCalendarMoveAction.bind(this) }
+                    onSelectAction={ this.onSelectAction.bind(this) }/>
     }
 
     renderPaneContent() {

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -32,7 +32,22 @@ export default class AllActionsPane extends PaneWithCalendar {
 
         return [
             <CampaignSelect/>,
-            <ActionLocations actions={ actions }/>
+            <ActionLocations actions={ actions }
+                onMouseOver={ this.onMouseOver.bind(this) }
+                onMouseOverPhase={ this.onMouseOverPhase.bind(this) }
+                onMouseOut={ this.onMouseOut.bind(this) }/>
         ];
+    }
+
+    onMouseOver(loc) {
+        this.getActions('action').highlightActionLocation(loc.id);
+    }
+
+    onMouseOverPhase(loc, phase) {
+        this.getActions('action').highlightActionPhase(loc.id, phase);
+    }
+
+    onMouseOut() {
+        this.getActions('action').clearActionHighlights();
     }
 }

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -1,11 +1,12 @@
 import React from 'react/addons';
 
-import PaneBase from '../../panes/PaneBase';
+import PaneWithCalendar from './PaneWithCalendar';
 import CampaignSelect from '../../misc/CampaignSelect';
 import CampaignPlayer from '../../misc/campaignplayer/CampaignPlayer';
+import ActionMiniCalendar from '../../misc/actioncal/ActionMiniCalendar';
 
 
-export default class CampaignPlaybackPane extends PaneBase {
+export default class CampaignPlaybackPane extends PaneWithCalendar {
     getPaneTitle() {
         return 'Campaign playback';
     }
@@ -16,6 +17,16 @@ export default class CampaignPlaybackPane extends PaneBase {
         this.listenTo('location', this.forceUpdate);
         this.getActions('action').retrieveAllActions();
         this.getActions('location').retrieveLocations();
+    }
+
+    renderPaneTop() {
+        const actionStore = this.getStore('action');
+        const actions = actionStore.getActions();
+
+        return <ActionMiniCalendar actions={ actions }
+                    onAddAction={ this.onCalendarAddAction.bind(this) }
+                    onMoveAction={ this.onCalendarMoveAction.bind(this) }
+                    onSelectAction={ this.onSelectAction.bind(this) }/>
     }
 
     renderPaneContent() {
@@ -30,7 +41,16 @@ export default class CampaignPlaybackPane extends PaneBase {
             <CampaignSelect key="select"/>,
             <CampaignPlayer key="player"
                 actions={ actions } locations={ locations }
-                centerLat={ center.lat } centerLng={ center.lng }/>
+                centerLat={ center.lat } centerLng={ center.lng }
+                onActionsChange={ this.onActionsChange.bind(this) }/>
         ];
+    }
+
+    onActionsChange(actions) {
+        const actionActions = this.getActions('action');
+        const actionIds = actions.map(a => a.id);
+
+        actionActions.clearActionHighlights();
+        actionActions.highlightActions(actionIds);
     }
 }

--- a/src/js/components/sections/campaign/PaneWithCalendar.jsx
+++ b/src/js/components/sections/campaign/PaneWithCalendar.jsx
@@ -1,0 +1,37 @@
+import React from 'react/addons';
+
+import PaneBase from '../../panes/PaneBase';
+
+
+export default class PaneWithCalendar extends PaneBase {
+    onCalendarAddAction(date) {
+        // TODO: Pass date to new action somehow
+        this.gotoSubPane('addaction');
+    }
+
+    onCalendarMoveAction(action, date) {
+        const oldStartTime = new Date(action.start_time);
+        const oldEndTime = new Date(action.end_time);
+
+        const startTime = new Date(date);
+        startTime.setHours(oldStartTime.getHours());
+        startTime.setMinutes(oldStartTime.getMinutes());
+        startTime.setSeconds(oldStartTime.getSeconds());
+
+        const endTime = new Date(date);
+        endTime.setHours(oldEndTime.getHours());
+        endTime.setMinutes(oldEndTime.getMinutes());
+        endTime.setSeconds(oldEndTime.getSeconds());
+
+        const values = {
+            start_time: startTime.toISOString(),
+            end_time: endTime.toISOString()
+        };
+
+        this.getActions('action').updateAction(action.id, values);
+    }
+
+    onSelectAction(action) {
+        this.gotoSubPane('editaction', action.id);
+    }
+}

--- a/src/js/server/search.js
+++ b/src/js/server/search.js
@@ -80,7 +80,7 @@ function searchPeople(orgId, q, writeMatch) {
             var i;
             var people = result.data.data;
 
-            for (i in people) {
+            for (i = 0; i < people.length; i++) {
                 var p = people[i];
                 if (searchMatches(q, p)) {
                     writeMatch(q, 'person', p);
@@ -95,7 +95,7 @@ function searchLocations(orgId, q, writeMatch) {
             var i;
             var locations = result.data.data;
 
-            for (i in locations) {
+            for (i = 0; i < locations.length; i++) {
                 var loc = locations[i];
                 if (searchMatches(q, loc)) {
                     writeMatch(q, 'location', loc);
@@ -110,7 +110,7 @@ function searchCampaigns(orgId, q, writeMatch) {
             var i;
             var campaigns = result.data.data;
 
-            for (i in campaigns) {
+            for (i = 0; i < campaigns.length; i++) {
                 var campaign = campaigns[i];
                 if (searchMatches(q, campaign)) {
                     writeMatch(q, 'campaign', campaign);

--- a/src/js/stores/action.js
+++ b/src/js/stores/action.js
@@ -20,6 +20,13 @@ export default class ActionStore extends Store {
             this.onRetrieveActionComplete);
         this.register(actionActions.updateAction,
             this.onUpdateActionComplete);
+
+        this.register(actionActions.highlightActionPhase,
+            this.onHighlightActionPhase);
+        this.register(actionActions.highlightActionLocation,
+            this.onHighlightActionLocation);
+        this.register(actionActions.clearActionHighlights,
+            this.onClearActionHighlights);
     }
 
     getAction(id) {
@@ -69,11 +76,63 @@ export default class ActionStore extends Store {
         });
     }
 
+    onHighlightActionPhase(payload) {
+        this.setState({
+            actions: this.state.actions.map(function(action) {
+                action.highlight = (
+                    action.location.id == payload.locId &&
+                    actionIsPhase(action, payload.phase));
+
+                return action;
+            })
+        });
+    }
+
+    onHighlightActionLocation(locId) {
+        this.setState({
+            actions: this.state.actions.map(function(action) {
+                action.highlight = (action.location.id == locId);
+                return action;
+            })
+        });
+    }
+
+    onClearActionHighlights() {
+        this.setState({
+            actions: this.state.actions.map(function(action) {
+                action.highlight = false;
+                return action;
+            })
+        });
+    }
+
     static serialize(state) {
         return JSON.stringify(state);
     }
 
     static deserialize(stateStr) {
         return JSON.parse(stateStr);
+    }
+}
+
+function actionIsPhase(action, phase) {
+    // TODO: Don't duplicate these constants in ActionLocationItem component
+    const startTime = new Date(action.start_time);
+    const hour = startTime.getUTCHours();
+
+    if (hour <= 4 || hour > 22) {
+        return phase == 4;
+    }
+    else if (hour <= 9) {
+        return phase == 0;
+    }
+    else if (hour <= 13) {
+        return phase == 1;
+    }
+    else if (hour <= 17) {
+        return phase == 2;
+    }
+    else if (hour <= 22) {
+        return phase == 3;
     }
 }

--- a/src/js/stores/action.js
+++ b/src/js/stores/action.js
@@ -25,6 +25,8 @@ export default class ActionStore extends Store {
             this.onHighlightActionPhase);
         this.register(actionActions.highlightActionLocation,
             this.onHighlightActionLocation);
+        this.register(actionActions.highlightActions,
+            this.onHighlightActions);
         this.register(actionActions.clearActionHighlights,
             this.onClearActionHighlights);
     }
@@ -92,6 +94,15 @@ export default class ActionStore extends Store {
         this.setState({
             actions: this.state.actions.map(function(action) {
                 action.highlight = (action.location.id == locId);
+                return action;
+            })
+        });
+    }
+
+    onHighlightActions(actionIds) {
+        this.setState({
+            actions: this.state.actions.map(function(action) {
+                action.highlight = (actionIds.indexOf(action.id) >= 0);
                 return action;
             })
         });

--- a/src/js/stores/participant.js
+++ b/src/js/stores/participant.js
@@ -94,7 +94,7 @@ export default class ParticipantStore extends Store {
     moveBetweenArrays(personId, arr0, arr1) {
         var i, person;
 
-        for (i in arr0) {
+        for (i = 0; i < arr0.length; i++) {
             if (arr0[i].id == personId) {
                 person = arr0[i];
                 arr0.splice(i, 1);
@@ -114,7 +114,7 @@ export default class ParticipantStore extends Store {
         var moves = this.state.moves;
 
         // Search for inverses
-        for (i in moves) {
+        for (i = 0; i < moves.length; i++) {
             oldMove = moves[i];
             if (oldMove.person == move.person
                 && oldMove.from == move.to && oldMove.to == move.from) {

--- a/src/js/stores/person.js
+++ b/src/js/stores/person.js
@@ -92,7 +92,7 @@ export default class PersonStore extends Store {
         var i;
         const participants = res.data.data;
 
-        for (i in participants) {
+        for (i = 0; i < participants.length; i++) {
             var person = participants[i];
             StoreUtils.updateOrAdd(this.state.people, person.id, person);
         }

--- a/src/js/stores/user.js
+++ b/src/js/stores/user.js
@@ -57,7 +57,7 @@ export default class UserStore extends Store {
         var memberships = res.data.data;
         var officialMemberships = [];
 
-        for (i in memberships) {
+        for (i = 0; i < memberships.length; i++) {
             if (memberships[i].role != null) {
                 officialMemberships.push(memberships[i]);
             }

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -51,7 +51,7 @@ function run(paneElements, container) {
 function stop() {
     var i;
 
-    for (i in _panes) {
+    for (i = 0; i < _panes.length; i++) {
         _panes[i].stop();
     }
 

--- a/src/js/utils/polyfills.js
+++ b/src/js/utils/polyfills.js
@@ -6,3 +6,19 @@ Date.prototype.getWeekNumber = function(){
     d.setDate(d.getDate()+4-(d.getDay()||7));
     return Math.ceil((((d-new Date(d.getFullYear(),0,1))/8.64e7)+1)/7);
 };
+
+Array.prototype.equals = function(other) {
+    if (!other)
+        return false;
+
+    if (this.length != other.length)
+        return false;
+
+    for (var i = 0, l=this.length; i < l; i++) {
+        if (this[i] != other[i]) {
+            return false;
+        }
+    }
+
+    return true;
+};

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -95,9 +95,15 @@
 
 .actionminicalendar .actionday-actionitem {
     height: 2em;
+    transition: background-color 1.5s;
 
     span {
         display: none;
+    }
+
+    &.highlight {
+        transition: background-color 0.2s;
+        background-color: #fcc;
     }
 }
 

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -47,6 +47,7 @@
 .actionminicalendar .actionday {
     display: inline-block;
     width: 5em;
+    min-height: 8em;
     margin-left: 0.1em;
 
     .date {

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -51,11 +51,16 @@
     margin-left: 0.1em;
     vertical-align: top;
 
+    h3 {
+        margin: 0.5em 0;
+    }
+
     .date {
         display: block;
-        font-size: 1em;
+        font-size: 0.9em;
         font-weight: bold;
         text-align: center;
+        color: #999;
     }
 
     .weekday {

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -1,4 +1,14 @@
-.actionweek {
+.actionminicalendar {
+    background-color: rgba(0,0,0,0.05);
+
+    margin: 0 -2em 2em;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    white-space: nowrap;
+    padding-bottom: 2em;
+}
+
+.actioncalendar .actionweek {
     margin: 1em 0;
 
     h2 {
@@ -15,10 +25,10 @@
     }
 }
 
-.actionday {
+.actioncalendar .actionday {
+    float: left;
     width: 13%;
     margin-left: 0.5%;
-    float: left;
 
     h3 {
         margin: 0 0 0.1em;
@@ -34,12 +44,31 @@
     }
 }
 
+.actionminicalendar .actionday {
+    display: inline-block;
+    width: 5em;
+    margin-left: 0.1em;
+
+    .date {
+        display: block;
+        font-size: 1em;
+        font-weight: bold;
+        text-align: center;
+    }
+
+    .weekday {
+        display: none;
+    }
+}
+
 .actionday-actionitem {
     padding: 0.5em 1em;
     margin: 0 0 0.1em;
     background-color: white;
     box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+}
 
+.actioncalendar .actionday-actionitem {
     .activity {
         display: block;
         font-size: 1.2em;
@@ -63,7 +92,15 @@
     }
 }
 
-.actionday-addbutton {
+.actionminicalendar .actionday-actionitem {
+    height: 2em;
+
+    span {
+        display: none;
+    }
+}
+
+.actioncalendar .actionday-addbutton {
     visibility: hidden;
     display: block;
     width: 100%;
@@ -84,7 +121,11 @@
     }
 }
 
-.actionday:hover .actionday-addbutton {
+.actioncalendar .actionday:hover .actionday-addbutton {
     visibility: visible;
     opacity: 1;
+}
+
+.actionminicalendar .actionday-addbutton {
+    display: none;
 }

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -49,6 +49,7 @@
     width: 5em;
     min-height: 8em;
     margin-left: 0.1em;
+    vertical-align: top;
 
     .date {
         display: block;
@@ -67,6 +68,7 @@
     margin: 0 0 0.1em;
     background-color: white;
     box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+    cursor: pointer;
 }
 
 .actioncalendar .actionday-actionitem {
@@ -105,9 +107,18 @@
         transition: background-color 0.2s;
         background-color: #fcc;
     }
+
+    &:hover {
+        transition: background-color 0.1s;
+        background-color: #fff0f0;
+    }
 }
 
-.actioncalendar .actionday-addbutton {
+.actionminicalendar .actionday-pseudoitem {
+    height: 2em;
+}
+
+.actionday-addbutton {
     visibility: hidden;
     display: block;
     width: 100%;
@@ -128,11 +139,11 @@
     }
 }
 
-.actioncalendar .actionday:hover .actionday-addbutton {
-    visibility: visible;
-    opacity: 1;
+.actionminicalendar .actionday-addbutton {
+    background-color: #ddd;
 }
 
-.actionminicalendar .actionday-addbutton {
-    display: none;
+.actionday:hover .actionday-addbutton {
+    visibility: visible;
+    opacity: 1;
 }

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -2,6 +2,7 @@
     background-color: white;
     background-color: #f8f8f8;
     min-width: 400px;
+    z-index: 1000;
 }
 
 .section-pane-actions {


### PR DESCRIPTION
This creates a miniature calendar component, to be used at the top of various campaign panes, and adds it specifically to the sub-sections "Campaign locations" and "Playback".

The PR also implements highlighting of actions in the mini-calendar, and logic to toggle the highlight based on mouse-interaction with the ActionLocations component. It's now possible to hover a location (or a time-of-day bar) in the "Campaign locations" section and get feedback of relevant actions in the new
mini-calendar.

![image](https://cloud.githubusercontent.com/assets/550212/9547904/ad23a45e-4d9d-11e5-8674-c9b8c45b8595.png)
