### PR TITLE
Add action pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "flummox": "^3.5.0",
     "flux": "^2.0.3",
     "merge": "^1.2.0",
+    "moment": "^2.10.6",
     "react": "~0.13.0",
     "react-dnd": "^1.1.4",
     "react-router-component": "^0.24.4",

--- a/src/js/actions/action.js
+++ b/src/js/actions/action.js
@@ -42,4 +42,10 @@ export default class ActionActions extends Actions {
     highlightActions(actionIds) {
         return actionIds;
     }
+
+    createAction(campId, data) {
+        const orgId = this.flux.getStore('org').getActiveId();
+        const res = Z.resource('orgs', orgId, 'campaigns', campId, 'actions');
+        return res.post(data);
+    }
 }

--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -2,8 +2,9 @@ import React from 'react/addons';
 
 import FluxComponent from '../FluxComponent';
 import Form from './Form';
+import DateInput from './inputs/DateInput';
 import TextArea from './inputs/TextArea';
-import TextInput from './inputs/TextInput';
+import TimeInput from './inputs/TimeInput';
 import RelSelectInput from './inputs/RelSelectInput';
 
 
@@ -28,15 +29,22 @@ export default class ActionForm extends FluxComponent {
         const locations = this.getStore('location').getLocations();
         const activities = this.getStore('activity').getActivities();
 
+        const date = action.start_time? new Date(action.start_time) : undefined;
+        const startTime = date? formatTime(date) : undefined;
+        const endTime = action.end_time?
+            formatTime(new Date(action.end_time)) : undefined;
+
         return (
             <Form ref="form" {...this.props }>
                 <RelSelectInput label="Campaign" name="campaign_id"
                     objects={ campaigns }
                     initialValue={ action.campaign.id }/>
-                <TextInput label="Start" name="start_time"
-                    initialValue={ action.start_time }/>
-                <TextInput label="End" name="end_time"
-                    initialValue={ action.end_time }/>
+                <DateInput label="Date" name="date"
+                    initialValue={ date }/>
+                <TimeInput label="Start" name="start_time"
+                    initialValue={ startTime }/>
+                <TimeInput label="End" name="end_time"
+                    initialValue={ endTime }/>
                 <RelSelectInput label="Location" name="location_id"
                     objects={ locations }
                     initialValue={ action.location.id }/>
@@ -52,10 +60,60 @@ export default class ActionForm extends FluxComponent {
     }
 
     getValues() {
-        return this.refs.form.getValues();
+        const values = this.refs.form.getValues();
+        const date = new Date(values.date);
+
+        updateTime(values, 'start_time', date);
+        updateTime(values, 'end_time', date);
+        delete values.date;
+
+        return values;
     }
 
     getChangedValues() {
-        return this.refs.form.getChangedValues();
+        const values = this.refs.form.getChangedValues();
+        const date = new Date(this.refs.form.getValues().date);
+
+        if ('date' in values) {
+            const allValues = this.getValues();
+            values.start_time = allValues.start_time;
+            values.end_time = allValues.end_time;
+
+            delete values.date;
+        }
+        else {
+            if ('start_time' in values) {
+                updateTime(values, 'start_time', date);
+            }
+            if ('end_time' in values) {
+                updateTime(values, 'end_time', date);
+            }
+        }
+
+        return values;
     }
+}
+
+function pad(n) {
+    return (n<10)? '0' + n : n.toString();
+}
+
+function formatTime(d) {
+    return pad(d.getUTCHours()) + ':'
+        + pad(d.getUTCMinutes());
+}
+
+function updateTime(values, field, date) {
+    const val = values[field];
+
+    const fields = val.split(':');
+    const hours = parseInt(fields[0]);
+    const minutes = parseInt(fields[1]);
+    const tmp = new Date(date);
+
+    tmp.setHours(hours);
+    tmp.setMinutes(minutes);
+    tmp.setSeconds(0);
+
+    values[field] = tmp.toISOString();
 }

--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react/addons';
+import moment from 'moment';
 
 import FluxComponent from '../FluxComponent';
 import Form from './Form';
@@ -29,10 +30,14 @@ export default class ActionForm extends FluxComponent {
         const locations = this.getStore('location').getLocations();
         const activities = this.getStore('activity').getActivities();
 
-        const date = action.start_time? new Date(action.start_time) : undefined;
-        const startTime = date? formatTime(date) : undefined;
+        const date = action.start_time?
+            moment(new Date(action.start_time)).format('YYYY-MM-DD') : undefined;
+
+        const startTime = action.start_time?
+            moment(new Date(action.start_time)).format('HH:mm') : undefined;
+
         const endTime = action.end_time?
-            formatTime(new Date(action.end_time)) : undefined;
+            moment(new Date(action.end_time)).format('HH:mm') : undefined;
 
         return (
             <Form ref="form" {...this.props }>
@@ -92,15 +97,6 @@ export default class ActionForm extends FluxComponent {
 
         return values;
     }
-}
-
-function pad(n) {
-    return (n<10)? '0' + n : n.toString();
-}
-
-function formatTime(d) {
-    return pad(d.getUTCHours()) + ':'
-        + pad(d.getUTCMinutes());
 }
 
 function updateTime(values, field, date) {

--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -11,17 +11,28 @@ export default class ActionForm extends FluxComponent {
     componentDidMount() {
         this.listenTo('activity', this.forceUpdate);
         this.listenTo('location', this.forceUpdate);
+        this.listenTo('campaign', this.forceUpdate);
         this.getActions('activity').retrieveActivities();
         this.getActions('location').retrieveLocations();
+        this.getActions('campaign').retrieveCampaigns();
     }
 
     render() {
-        var action = this.props.action;
-        var locations = this.getStore('location').getLocations();
-        var activities = this.getStore('activity').getActivities();
+        const action = this.props.action || {
+            campaign: {},
+            location: {},
+            activity: {}
+        };
+
+        const campaigns = this.getStore('campaign').getCampaigns();
+        const locations = this.getStore('location').getLocations();
+        const activities = this.getStore('activity').getActivities();
 
         return (
             <Form ref="form" {...this.props }>
+                <RelSelectInput label="Campaign" name="campaign_id"
+                    objects={ campaigns }
+                    initialValue={ action.campaign.id }/>
                 <TextInput label="Start" name="start_time"
                     initialValue={ action.start_time }/>
                 <TextInput label="End" name="end_time"

--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 import FluxComponent from '../FluxComponent';
 import Form from './Form';
+import IntInput from './inputs/IntInput';
 import DateInput from './inputs/DateInput';
 import TextArea from './inputs/TextArea';
 import TimeInput from './inputs/TimeInput';
@@ -50,6 +51,9 @@ export default class ActionForm extends FluxComponent {
                     initialValue={ startTime }/>
                 <TimeInput label="End" name="end_time"
                     initialValue={ endTime }/>
+                <IntInput label="Minimum participants"
+                    name="num_participants_required"
+                    initialValue={ action.num_participants_required || 2 }/>
                 <RelSelectInput label="Location" name="location_id"
                     objects={ locations }
                     initialValue={ action.location.id }/>

--- a/src/js/components/forms/Form.jsx
+++ b/src/js/components/forms/Form.jsx
@@ -44,11 +44,23 @@ export default class Form extends React.Component {
     }
 
     getValues() {
-        return this.state.values;
+        var values = {};
+
+        for (var key in this.state.values) {
+            values[key] = this.state.values[key];
+        }
+
+        return values;
     }
 
     getChangedValues() {
-        return this.state.changedValues;
+        var values = {};
+
+        for (var key in this.state.changedValues) {
+            values[key] = this.state.changedValues[key];
+        }
+
+        return values;
     }
 
     onValueChange(name, value) {

--- a/src/js/components/forms/inputs/DateInput.jsx
+++ b/src/js/components/forms/inputs/DateInput.jsx
@@ -1,0 +1,25 @@
+import React from 'react/addons';
+
+import InputBase from './InputBase';
+
+
+export default class DateInput extends InputBase {
+    renderInput() {
+        var value = this.props.value;
+
+        function pad(n) {
+            return (n<10)? '0' + n : n.toString();
+        }
+
+        if (value instanceof Date) {
+            value = value.getFullYear() + '-'
+                + pad(value.getMonth() + 1) + '-'
+                + pad(value.getDate());
+        }
+
+        return (
+            <input type="date" value={ value }
+                onChange={ this.onChange.bind(this) }/>
+        );
+    }
+}

--- a/src/js/components/forms/inputs/DateInput.jsx
+++ b/src/js/components/forms/inputs/DateInput.jsx
@@ -5,17 +5,7 @@ import InputBase from './InputBase';
 
 export default class DateInput extends InputBase {
     renderInput() {
-        var value = this.props.value;
-
-        function pad(n) {
-            return (n<10)? '0' + n : n.toString();
-        }
-
-        if (value instanceof Date) {
-            value = value.getFullYear() + '-'
-                + pad(value.getMonth() + 1) + '-'
-                + pad(value.getDate());
-        }
+        const value = this.props.value;
 
         return (
             <input type="date" value={ value }

--- a/src/js/components/forms/inputs/IntInput.jsx
+++ b/src/js/components/forms/inputs/IntInput.jsx
@@ -1,0 +1,13 @@
+import React from 'react/addons';
+
+import InputBase from './InputBase';
+
+
+export default class IntInput extends InputBase {
+    renderInput() {
+        return (
+            <input type="number" step="1" min="0" value={ this.props.value }
+                onChange={ this.onChange.bind(this) }/>
+        );
+    }
+}

--- a/src/js/components/forms/inputs/RelSelectInput.jsx
+++ b/src/js/components/forms/inputs/RelSelectInput.jsx
@@ -9,6 +9,7 @@ export default class RelSelectInput extends InputBase {
             <select value={ this.props.value }
                 onChange={ this.onChange.bind(this) }>
 
+                <option key="0" value="0">---</option>
                 {this.props.objects.map(function(obj) {
                     var value = obj[this.props.valueField];
                     var label = obj[this.props.labelField];

--- a/src/js/components/forms/inputs/TimeInput.jsx
+++ b/src/js/components/forms/inputs/TimeInput.jsx
@@ -5,16 +5,7 @@ import InputBase from './InputBase';
 
 export default class TimeInput extends InputBase {
     renderInput() {
-        var value = this.props.value;
-
-        function pad(n) {
-            return (n<10)? '0' + n : n.toString();
-        }
-
-        if (value instanceof Date) {
-            value = pad(value.getUTCHours()) + ':'
-                + pad(value.getUTCMinutes());
-        }
+        const value = this.props.value;
 
         return (
             <input type="time" value={ value }

--- a/src/js/components/forms/inputs/TimeInput.jsx
+++ b/src/js/components/forms/inputs/TimeInput.jsx
@@ -1,0 +1,24 @@
+import React from 'react/addons';
+
+import InputBase from './InputBase';
+
+
+export default class TimeInput extends InputBase {
+    renderInput() {
+        var value = this.props.value;
+
+        function pad(n) {
+            return (n<10)? '0' + n : n.toString();
+        }
+
+        if (value instanceof Date) {
+            value = pad(value.getUTCHours()) + ':'
+                + pad(value.getUTCMinutes());
+        }
+
+        return (
+            <input type="time" value={ value }
+                onChange={ this.onChange.bind(this) }/>
+        );
+    }
+}

--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -52,7 +52,7 @@ export default class ActionCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
-                    onAddAction={ this.onAddAction.bind(this, new Date(d)) }
+                    onAddAction={ this.onAddAction.bind(this) }
                     onMoveAction={ this.onMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
             );

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -62,7 +62,7 @@ export default class ActionDay extends React.Component {
 
     onAddClick() {
         if (this.props.onAddAction) {
-            this.props.onAddAction();
+            this.props.onAddAction(this.props.date);
         }
     }
 }

--- a/src/js/components/panes/AddActionPane.jsx
+++ b/src/js/components/panes/AddActionPane.jsx
@@ -1,7 +1,7 @@
 import React from 'react/addons';
 
 import PaneBase from './PaneBase';
-import PersonForm from '../forms/PersonForm';
+import ActionForm from '../forms/ActionForm';
 
 
 export default class AddActionPane extends PaneBase {
@@ -10,7 +10,18 @@ export default class AddActionPane extends PaneBase {
     }
 
     renderPaneContent(data) {
-        // TODO: Implement pane content
-        return null;
+        return (
+            <ActionForm ref="actionForm"
+                onSubmit={ this.onSubmit.bind(this) }/>
+        );
+    }
+
+    onSubmit(ev) {
+        ev.preventDefault();
+
+        const values = this.refs.actionForm.getValues();
+        const campaignId = values.campaign_id;
+
+        this.getActions('action').createAction(campaignId, values);
     }
 }

--- a/src/js/components/panes/AddActionPane.jsx
+++ b/src/js/components/panes/AddActionPane.jsx
@@ -10,8 +10,27 @@ export default class AddActionPane extends PaneBase {
     }
 
     renderPaneContent(data) {
+        const initialData = {
+            campaign: {
+                id: this.getParam(0, 0)
+            },
+            location: { id: 0 },
+            activity: { id: 0 }
+        };
+
+        const dateParam = this.getParam(1);
+        if (dateParam) {
+            const date = new Date(dateParam);
+
+            date.setHours(9);
+            initialData.start_time = date.toISOString();
+
+            date.setHours(11);
+            initialData.end_time = date.toISOString();
+        }
+
         return (
-            <ActionForm ref="actionForm"
+            <ActionForm ref="actionForm" action={ initialData }
                 onSubmit={ this.onSubmit.bind(this) }/>
         );
     }

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -62,6 +62,15 @@ export default class PaneBase extends FluxComponent {
         return {};
     }
 
+    getParam(idx, defaultValue) {
+        if (this.props.params.length > idx) {
+            return this.props.params[idx];
+        }
+        else {
+            return defaultValue;
+        }
+    }
+
     subPath(path) {
         return this.props.panePath + '/' + path;
     }

--- a/src/js/components/sections/campaign/PaneWithCalendar.jsx
+++ b/src/js/components/sections/campaign/PaneWithCalendar.jsx
@@ -1,12 +1,17 @@
 import React from 'react/addons';
+import moment from 'moment';
 
 import PaneBase from '../../panes/PaneBase';
 
 
 export default class PaneWithCalendar extends PaneBase {
     onCalendarAddAction(date) {
-        // TODO: Pass date to new action somehow
-        this.gotoSubPane('addaction');
+        const campaignStore = this.getStore('campaign');
+        const selectedCampaign = campaignStore.getSelectedCampaign();
+        const campParam = selectedCampaign? selectedCampaign.id : 0;
+        const dateParam = moment(date).format('YYYY-MM-DD');
+
+        this.gotoSubPane('addaction', campParam, dateParam);
     }
 
     onCalendarMoveAction(action, date) {

--- a/src/js/stores/action.js
+++ b/src/js/stores/action.js
@@ -14,6 +14,8 @@ export default class ActionStore extends Store {
         });
 
         var actionActions = flux.getActions('action');
+        this.register(actionActions.createAction,
+            this.onCreateActionComplete);
         this.register(actionActions.retrieveAllActions,
             this.onRetrieveAllActionsComplete);
         this.register(actionActions.retrieveAction,
@@ -46,6 +48,16 @@ export default class ActionStore extends Store {
         else {
             return this.state.actions;
         }
+    }
+
+    onCreateActionComplete(res) {
+        const action = res.data.data;
+
+        this.setState({
+            actions: this.state.actions.concat([ action ]).sort((a0, a1) =>
+                (new Date(a0.start_time)).getTime() -
+                (new Date(a1.start_time)).getTime())
+        });
     }
 
     onRetrieveAllActionsComplete(res) {


### PR DESCRIPTION
This adds a pane to create actions. It also implements a bunch of logic around this cause, and improves the pre-existing ActionForm with better widgets.

Clicking add in a calendar will pre-fill the date and time. And if a campaign was already selected in the interface, that campaign will be pre-selected in the action pane as well.