### PR TITLE
Better RelSelectInput

### DIFF
--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -56,9 +56,11 @@ export default class ActionForm extends FluxComponent {
                     initialValue={ action.num_participants_required || 2 }/>
                 <RelSelectInput label="Location" name="location_id"
                     objects={ locations }
+                    onCreate={ this.props.onCreateLocation }
                     initialValue={ action.location.id }/>
                 <RelSelectInput label="Activity" name="activity_id"
                     objects={ activities }
+                    onCreate={ this.props.onCreateActivity }
                     initialValue={ action.activity.id }/>
                 <TextArea label="Information" name="info_text"
                     initialValue={ action.info_text }/>
@@ -102,6 +104,11 @@ export default class ActionForm extends FluxComponent {
         return values;
     }
 }
+
+ActionForm.propTypes = {
+    onCreateLocation: React.PropTypes.func,
+    onCreateActivity: React.PropTypes.func
+};
 
 function updateTime(values, field, date) {
     const val = values[field];

--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -44,6 +44,7 @@ export default class ActionForm extends FluxComponent {
             <Form ref="form" {...this.props }>
                 <RelSelectInput label="Campaign" name="campaign_id"
                     objects={ campaigns }
+                    onCreate={ this.props.onCreateCampaign }
                     initialValue={ action.campaign.id }/>
                 <DateInput label="Date" name="date"
                     initialValue={ date }/>
@@ -106,6 +107,7 @@ export default class ActionForm extends FluxComponent {
 }
 
 ActionForm.propTypes = {
+    onCreateCampaign: React.PropTypes.func,
     onCreateLocation: React.PropTypes.func,
     onCreateActivity: React.PropTypes.func
 };

--- a/src/js/components/forms/inputs/RelSelectInput.jsx
+++ b/src/js/components/forms/inputs/RelSelectInput.jsx
@@ -9,8 +9,17 @@ export default class RelSelectInput extends InputBase {
         super(props);
 
         this.state = {
-            focused: false
+            focused: false,
+            inputValue: undefined
         };
+    }
+
+    componentWillReceiveProps(newProps) {
+        if ('value' in newProps) {
+            this.setState({
+                inputValue: undefined
+            });
+        }
     }
 
     renderInput() {
@@ -20,7 +29,17 @@ export default class RelSelectInput extends InputBase {
         const labelField = this.props.labelField;
         const selected = (value && objects)?
             objects.find(o => o[valueField] == value) : null;
-        const selectedLabel = selected? selected[labelField] : '';
+
+        // Filter objects based on input value, unless it's undefined or
+        // an empty string in which case all objects should be displayed.
+        var inputValue = this.state.inputValue;
+        var filteredObjects = objects.filter(o =>
+            (!inputValue || o[labelField].toLowerCase()
+                .indexOf(inputValue.toLowerCase()) >= 0));
+
+        if (inputValue === undefined) {
+            inputValue = (selected? selected[labelField] : '');
+        }
 
         const classes = cx({
             'relselectinput': true,
@@ -29,11 +48,12 @@ export default class RelSelectInput extends InputBase {
 
         return (
             <div className={ classes }>
-                <input type="text" value={ selectedLabel }
+                <input type="text" value={ inputValue }
+                    onChange={ this.onInputChange.bind(this) }
                     onFocus={ this.onFocus.bind(this) }
                     onBlur={ this.onBlur.bind(this) }/>
                 <ul>
-                {objects.map(function(obj) {
+                {filteredObjects.map(function(obj) {
                     const value = obj[valueField];
                     const label = obj[labelField];
                     const classes = cx({
@@ -52,8 +72,13 @@ export default class RelSelectInput extends InputBase {
         );
     }
 
+    onInputChange(ev) {
+        this.setState({
+            inputValue: ev.target.value
+        });
+    }
+
     onClickOption(obj) {
-        console.log('clicked', obj);
         if (this.props.onValueChange) {
             const name = this.props.name;
             const value = obj[this.props.valueField];
@@ -64,12 +89,12 @@ export default class RelSelectInput extends InputBase {
 
     onFocus(ev) {
         this.setState({
+            inputValue: undefined,
             focused: true
         });
     }
 
     onBlur(ev) {
-        console.log('blurred');
         this.setState({
             focused: false
         });

--- a/src/js/components/forms/inputs/RelSelectInput.jsx
+++ b/src/js/components/forms/inputs/RelSelectInput.jsx
@@ -1,24 +1,78 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 import InputBase from './InputBase';
 
 
 export default class RelSelectInput extends InputBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            focused: false
+        };
+    }
+
     renderInput() {
+        const value = this.props.value;
+        const objects = this.props.objects;
+        const valueField = this.props.valueField;
+        const labelField = this.props.labelField;
+        const selected = (value && objects)?
+            objects.find(o => o[valueField] == value) : null;
+        const selectedLabel = selected? selected[labelField] : '';
+
+        const classes = cx({
+            'relselectinput': true,
+            'focused': this.state.focused
+        });
+
         return (
-            <select value={ this.props.value }
-                onChange={ this.onChange.bind(this) }>
+            <div className={ classes }>
+                <input type="text" value={ selectedLabel }
+                    onFocus={ this.onFocus.bind(this) }
+                    onBlur={ this.onBlur.bind(this) }/>
+                <ul>
+                {objects.map(function(obj) {
+                    const value = obj[valueField];
+                    const label = obj[labelField];
+                    const classes = cx({
+                        'selected': (obj == selected)
+                    });
 
-                <option key="0" value="0">---</option>
-                {this.props.objects.map(function(obj) {
-                    var value = obj[this.props.valueField];
-                    var label = obj[this.props.labelField];
-
-                    return <option key={ value } value={ value }>
-                        { label }</option>;
+                    return (
+                        <li key={ value } className={ classes }
+                            onMouseDown={ this.onClickOption.bind(this, obj) }>
+                            { label }
+                        </li>
+                    );
                 }, this)}
-            </select>
+                </ul>
+            </div>
         );
+    }
+
+    onClickOption(obj) {
+        console.log('clicked', obj);
+        if (this.props.onValueChange) {
+            const name = this.props.name;
+            const value = obj[this.props.valueField];
+
+            this.props.onValueChange(name, value);
+        }
+    }
+
+    onFocus(ev) {
+        this.setState({
+            focused: true
+        });
+    }
+
+    onBlur(ev) {
+        console.log('blurred');
+        this.setState({
+            focused: false
+        });
     }
 }
 

--- a/src/js/components/panes/AddActionPane.jsx
+++ b/src/js/components/panes/AddActionPane.jsx
@@ -31,6 +31,8 @@ export default class AddActionPane extends PaneBase {
 
         return (
             <ActionForm ref="actionForm" action={ initialData }
+                onCreateLocation={ this.onCreateLocation.bind(this) }
+                onCreateActivity={ this.onCreateActivity.bind(this) }
                 onSubmit={ this.onSubmit.bind(this) }/>
         );
     }
@@ -42,5 +44,13 @@ export default class AddActionPane extends PaneBase {
         const campaignId = values.campaign_id;
 
         this.getActions('action').createAction(campaignId, values);
+    }
+
+    onCreateLocation(title) {
+        this.gotoSubPane('addlocation', title);
+    }
+
+    onCreateActivity(title) {
+        this.gotoSubPane('addactivity', title);
     }
 }

--- a/src/js/components/panes/AddActionPane.jsx
+++ b/src/js/components/panes/AddActionPane.jsx
@@ -31,6 +31,7 @@ export default class AddActionPane extends PaneBase {
 
         return (
             <ActionForm ref="actionForm" action={ initialData }
+                onCreateCampaign={ this.onCreateCampaign.bind(this) }
                 onCreateLocation={ this.onCreateLocation.bind(this) }
                 onCreateActivity={ this.onCreateActivity.bind(this) }
                 onSubmit={ this.onSubmit.bind(this) }/>
@@ -44,6 +45,10 @@ export default class AddActionPane extends PaneBase {
         const campaignId = values.campaign_id;
 
         this.getActions('action').createAction(campaignId, values);
+    }
+
+    onCreateCampaign(title) {
+        this.gotoSubPane('addcampaign', title);
     }
 
     onCreateLocation(title) {

--- a/src/js/components/panes/AddActivityPane.jsx
+++ b/src/js/components/panes/AddActivityPane.jsx
@@ -10,8 +10,12 @@ export default class AddActivityPane extends PaneBase {
     }
 
     renderPaneContent(data) {
+        const initialData = {
+            title: this.getParam(0)
+        };
+
         return (
-            <ActivityForm ref="form"
+            <ActivityForm ref="form" activity={ initialData }
                 onSubmit={ this.onSubmit.bind(this) }/>
         );
     }

--- a/src/js/components/panes/AddCampaignPane.jsx
+++ b/src/js/components/panes/AddCampaignPane.jsx
@@ -10,8 +10,12 @@ export default class AddCampaignPane extends PaneBase {
     }
 
     renderPaneContent(data) {
+        const initialData = {
+            title: this.getParam(0)
+        };
+
         return (
-            <CampaignForm ref="form"
+            <CampaignForm ref="form" campaign={ initialData }
                 onSubmit={ this.onSubmit.bind(this) }/>
         );
     }

--- a/src/js/components/panes/AddLocationPane.jsx
+++ b/src/js/components/panes/AddLocationPane.jsx
@@ -23,14 +23,18 @@ export default class AddLocationPane extends PaneBase {
     }
 
     renderPaneContent(data) {
+        const initialData = {
+            title: this.getParam(0)
+        };
+
         return [ 
             <h3>1. Move highlighted marker to the position of location</h3>,
             <h3>2. Enter information about the location and press save</h3>,
-            <LocationForm key="form" ref="form" loc={ data.loc }
+            <LocationForm key="form" ref="form" loc={ initialData }
                 onSubmit={ this.onSubmit.bind(this) }/>,
             <input key="delete" type="button" value="Cancel"
                     onClick={ this.onDeleteClick.bind(this) }/>
-        ]
+        ];
     }
 
     onSubmit(ev) {

--- a/src/js/components/panes/AddLocationPane.jsx
+++ b/src/js/components/panes/AddLocationPane.jsx
@@ -39,7 +39,7 @@ export default class AddLocationPane extends PaneBase {
 
     onSubmit(ev) {
         ev.preventDefault();
-        var values = this.refs.form.getChangedValues();
+        var values = this.refs.form.getValues();
         var pendingLatLng = this.getStore('location').getPendingLocation();
         if (pendingLatLng) {
             values.lat = pendingLatLng.lat;

--- a/src/js/components/panes/EditActionPane.jsx
+++ b/src/js/components/panes/EditActionPane.jsx
@@ -26,6 +26,8 @@ export default class EditActionPane extends PaneBase {
         if (data.action) {
             return (
                 <ActionForm ref="form" action={ data.action }
+                    onCreateLocation={ this.onCreateLocation.bind(this) }
+                    onCreateActivity={ this.onCreateActivity.bind(this) }
                     onSubmit={ this.onSubmit.bind(this) }/>
             );
         }
@@ -42,5 +44,13 @@ export default class EditActionPane extends PaneBase {
         var actionId = this.props.params[0];
 
         this.getActions('action').updateAction(actionId, values);
+    }
+
+    onCreateLocation(title) {
+        this.gotoSubPane('addlocation', title);
+    }
+
+    onCreateActivity(title) {
+        this.gotoSubPane('addactivity', title);
     }
 }

--- a/src/js/components/panes/EditActionPane.jsx
+++ b/src/js/components/panes/EditActionPane.jsx
@@ -26,6 +26,7 @@ export default class EditActionPane extends PaneBase {
         if (data.action) {
             return (
                 <ActionForm ref="form" action={ data.action }
+                    onCreateCampaign={ this.onCreateCampaign.bind(this) }
                     onCreateLocation={ this.onCreateLocation.bind(this) }
                     onCreateActivity={ this.onCreateActivity.bind(this) }
                     onSubmit={ this.onSubmit.bind(this) }/>
@@ -44,6 +45,10 @@ export default class EditActionPane extends PaneBase {
         var actionId = this.props.params[0];
 
         this.getActions('action').updateAction(actionId, values);
+    }
+
+    onCreateCampaign(title) {
+        this.gotoSubPane('addcampaign', title);
     }
 
     onCreateLocation(title) {

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -94,7 +94,7 @@ export default class PaneBase extends FluxComponent {
 
     closePane() {
         var pathElements = this.props.panePath.split('/');
-        var parentPathElements = pathElements.slice(0, pathElements.length);
+        var parentPathElements = pathElements.slice(0, pathElements.length - 1);
         var parentPath = parentPathElements.join('/');
 
         this.context.router.navigate(parentPath);

--- a/src/js/components/sections/SectionBase.jsx
+++ b/src/js/components/sections/SectionBase.jsx
@@ -83,7 +83,7 @@ export default class SectionBase extends FluxComponent {
                     paneParams = segmentData[1].split(',');
                 }
 
-                panePath = basePath + '/' + subPathSegments.slice(0, i).join('/');
+                panePath = basePath + '/' + subPathSegments.slice(0, i+1).join('/');
 
                 Pane = PaneUtils.resolve(paneName);
                 panes.push(

--- a/src/scss/inputs/_base.scss
+++ b/src/scss/inputs/_base.scss
@@ -12,6 +12,10 @@
         background-color: white;
         box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
 
+        max-height: 10em;
+        overflow-y: scroll;
+        overflow-x: hidden;
+
         li {
             cursor: pointer;
             padding: 0.5em 2em;

--- a/src/scss/inputs/_base.scss
+++ b/src/scss/inputs/_base.scss
@@ -1,0 +1,57 @@
+.relselectinput {
+    position: relative;
+
+    ul {
+        position: absolute;
+        top: 2em;
+        left: 0;
+        right: 0;
+        z-index: 2000;
+
+        display: none;
+        background-color: white;
+        box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+
+        li {
+            cursor: pointer;
+            padding: 0.5em 2em;
+            
+            &::before {
+                content: "";
+                display: block;
+                float: left;
+                width: 1em;
+                height: 1em;
+                margin-left: -1.5em;
+            }
+
+            &:hover {
+                font-weight: bold;
+
+                &::before {
+                    background-color: #eee;
+                }
+            }
+
+            &.selected {
+                font-weight: bold;
+
+                &::before {
+                    background-color: red;
+                }
+            }
+        }
+    }
+
+    &.focused {
+        input {
+            // Input over list to obscure top shadow
+            position: relative;
+            z-index: 2001;
+        }
+
+        ul {
+            display: block;
+        }
+    }
+}

--- a/src/scss/inputs/_base.scss
+++ b/src/scss/inputs/_base.scss
@@ -25,11 +25,11 @@
                 margin-left: -1.5em;
             }
 
-            &:hover {
-                font-weight: bold;
+            &:hover, &.focused {
+                background-color: #eee;
 
                 &::before {
-                    background-color: #eee;
+                    background-color: #ddd;
                 }
             }
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,6 +1,7 @@
 @import "_variables";
 @import "_mixins";
 @import "_base";
+@import "inputs/_base";
 @import "header/_base";
 @import "section/_base";
 @import "dashboard/_base";


### PR DESCRIPTION
This is a total revamp of the RelSelectInput component, the purpose of which is to let a user select between a list of objects (e.g. choose the location for an action or the manager (person) of a campaign).

This used to be a simple `<select>` but is now a custom widget which allows you to filter/search for the object you want, navigate with your up/down keys and create a new object if you cannot find what you're looking for.

Selecting the "create" option invokes a callback which can be used to open the relevant add pane. This PR implements this logic for locations, activities and campaigns in the panes containing an `ActionForm`.

![image](https://cloud.githubusercontent.com/assets/550212/9562523/8c2d7fe6-4e6e-11e5-93f0-abc0bf54f91f.png)
