### PR TITLE
Better search results

### DIFF
--- a/src/js/components/App.jsx
+++ b/src/js/components/App.jsx
@@ -32,7 +32,7 @@ export default class App extends FluxComponent {
                 </head>
                 <body>
                     <div id="app">
-                        <Header />
+                        <Header onSearchNavigate={ this.onSearchNavigate.bind(this) }/>
                         <Router.Locations id="main" ref="router"
                             onNavigation={ this.onNavigation.bind(this) }
                             path={ this.props.path }>
@@ -69,6 +69,11 @@ export default class App extends FluxComponent {
     }
 
     onSectionShortcut(path) {
+        this.refs.router.navigate(path);
+    }
+
+    onSearchNavigate(paneType, params, defaultBase) {
+        const path = defaultBase + '/' + paneType + ':' + params.join(',');
         this.refs.router.navigate(path);
     }
 

--- a/src/js/components/App.jsx
+++ b/src/js/components/App.jsx
@@ -73,8 +73,20 @@ export default class App extends FluxComponent {
     }
 
     onSearchNavigate(paneType, params, defaultBase) {
-        const path = defaultBase + '/' + paneType + ':' + params.join(',');
-        this.refs.router.navigate(path);
+        const router = this.refs.router;
+        const curMatch = router.getMatch();
+        const curMatchRef = curMatch.route.ref;
+
+        var path = paneType + ':' + params.join(',');
+
+        if (curMatchRef == 'dashboard') {
+            path = defaultBase + '/' + path;
+        }
+        else {
+            path = curMatch.path + '/' + path;
+        }
+
+        router.navigate(path);
     }
 
     onSubSectionShortcut(index) {

--- a/src/js/components/header/Header.jsx
+++ b/src/js/components/header/Header.jsx
@@ -10,9 +10,13 @@ export default class Header extends React.Component {
         return (
             <header className="appheader">
                 <Logo />
-                <Search />
+                <Search onMatchNavigate={ this.props.onSearchNavigate }/>
                 <UserMenu />
             </header>
         );
     }
 }
+
+Header.propTypes = {
+    onSearchNavigate: React.PropTypes.func
+};

--- a/src/js/components/header/search/CampaignMatch.jsx
+++ b/src/js/components/header/search/CampaignMatch.jsx
@@ -4,10 +4,6 @@ import MatchBase from './MatchBase';
 
 
 export default class CampaignMatch extends MatchBase {
-    getLinkTarget() {
-        return '/campaign/campaigns/campaign:' + this.props.data.id;
-    }
-
     getTitle() {
         return this.props.data.title;
     }

--- a/src/js/components/header/search/LocationMatch.jsx
+++ b/src/js/components/header/search/LocationMatch.jsx
@@ -5,10 +5,6 @@ import MatchBase from './MatchBase';
 
 
 export default class LocationMatch extends MatchBase {
-    getLinkTarget() {
-        return '/maps/locations/location:' + this.props.data.id;
-    }
-
     getTitle() {
         return this.props.data.title;
     }

--- a/src/js/components/header/search/MatchBase.jsx
+++ b/src/js/components/header/search/MatchBase.jsx
@@ -1,8 +1,6 @@
 import React from 'react/addons';
 import cx from 'classnames';
 
-import { Link } from 'react-router-component';
-
 
 export default class MatchBase extends React.Component {
     render() {
@@ -11,11 +9,10 @@ export default class MatchBase extends React.Component {
         });
 
         return (
-            <li className={ classes }>
-                <Link href={ this.getLinkTarget() }>
-                    { this.getImage() }
-                    { this.getTitle() }
-                </Link>
+            <li className={ classes }
+                onClick={ this.props.onSelect }>
+                { this.getImage() }
+                { this.getTitle() }
             </li>
         );
     }
@@ -27,6 +24,7 @@ export default class MatchBase extends React.Component {
 
 MatchBase.propTypes = {
     focused: React.PropTypes.bool,
+    onSelect: React.PropTypes.func,
     data: React.PropTypes.object.isRequired
 };
 

--- a/src/js/components/header/search/MatchBase.jsx
+++ b/src/js/components/header/search/MatchBase.jsx
@@ -12,7 +12,7 @@ export default class MatchBase extends React.Component {
             <li className={ classes }
                 onClick={ this.props.onSelect }>
                 { this.getImage() }
-                { this.getTitle() }
+                <span className="title">{ this.getTitle() }</span>
             </li>
         );
     }

--- a/src/js/components/header/search/MatchBase.jsx
+++ b/src/js/components/header/search/MatchBase.jsx
@@ -1,12 +1,17 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 import { Link } from 'react-router-component';
 
 
 export default class MatchBase extends React.Component {
     render() {
+        const classes = cx({
+            'focused': this.props.focused
+        });
+
         return (
-            <li>
+            <li className={ classes }>
                 <Link href={ this.getLinkTarget() }>
                     { this.getImage() }
                     { this.getTitle() }
@@ -21,5 +26,10 @@ export default class MatchBase extends React.Component {
 }
 
 MatchBase.propTypes = {
+    focused: React.PropTypes.bool,
     data: React.PropTypes.object.isRequired
+};
+
+MatchBase.defaultProps = {
+    focused: false
 };

--- a/src/js/components/header/search/PersonMatch.jsx
+++ b/src/js/components/header/search/PersonMatch.jsx
@@ -1,14 +1,15 @@
 import React from 'react/addons';
 
 import MatchBase from './MatchBase';
+import Avatar from '../../misc/Avatar';
 
 
 export default class PersonMatch extends MatchBase {
-    getLinkTarget() {
-        return '/people/list/person:' + this.props.data.id;
-    }
-
     getTitle() {
         return this.props.data.first_name + ' ' + this.props.data.last_name;
+    }
+
+    getImage() {
+        return <Avatar person={ this.props.data }/>;
     }
 }

--- a/src/js/components/header/search/Search.jsx
+++ b/src/js/components/header/search/Search.jsx
@@ -63,6 +63,7 @@ export default class Search extends FluxComponent {
                     }
 
                     return <Match key={ key } data={ match.data }
+                        onSelect={ this.onMatchSelect.bind(this, match) }
                         focused={ focused }/>;
                 }, this)}
                 </ul>
@@ -88,6 +89,38 @@ export default class Search extends FluxComponent {
 
     onScopeSelect(scope) {
         this.getActions('search').changeScope(scope);
+    }
+
+    onMatchSelect(match) {
+        var defaultBase;
+        var paneType;
+        var params;
+
+        switch (match.type) {
+            case 'campaign':
+                defaultBase = '/campaign/actions';
+                paneType = 'editcampaign';
+                params = [ match.data.id ];
+                break;
+            case 'location':
+                defaultBase = '/maps/locations';
+                paneType = 'editlocation';
+                params = [ match.data.id ];
+                break;
+            case 'person':
+                defaultBase = '/people/list';
+                paneType = 'person';
+                params = [ match.data.id ];
+                break;
+            default:
+                // TODO: Deal with this? Should never happen
+                console.log('UNKNOWN MATCH TYPE');
+                return;
+        }
+
+        if (this.props.onMatchNavigate) {
+            this.props.onMatchNavigate(paneType, params, defaultBase);
+        }
     }
 
     onKeyDown(ev) {
@@ -121,8 +154,7 @@ export default class Search extends FluxComponent {
         else if (ev.keyCode == 13 && focusedIndex >= 0) {
             const selected = results[focusedIndex];
 
-            // TODO: Navigate
-            console.log(selected);
+            this.onMatchSelect(selected);
 
             ev.preventDefault();
             inputDOMNode.blur();
@@ -149,3 +181,7 @@ export default class Search extends FluxComponent {
         this.getActions('search').endSearch();
     }
 }
+
+Search.propTypes = {
+    onMatchNavigate: React.PropTypes.func
+};

--- a/src/js/components/header/search/Search.jsx
+++ b/src/js/components/header/search/Search.jsx
@@ -8,6 +8,14 @@ import PersonMatch from './PersonMatch';
 
 
 export default class Search extends FluxComponent {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            focusedIndex: undefined
+        };
+    }
+
     componentDidMount() {
         this.listenTo('search', this.forceUpdate);
         document.addEventListener('keydown', this.onKeyDown.bind(this));
@@ -36,9 +44,11 @@ export default class Search extends FluxComponent {
         if (results.length) {
             resultList = (
                 <ul className="search-form-results">
-                {results.map(function(match) {
+                {results.map(function(match, idx) {
+                    const key = match.type + ':' + match.data.id;
+                    const focused = (this.state.focusedIndex === idx);
+
                     var Match;
-                    var key = match.type + ':' + match.data.id;
 
                     switch(match.type) {
                         case 'campaign':
@@ -52,8 +62,9 @@ export default class Search extends FluxComponent {
                             break;
                     }
 
-                    return <Match key={ key } data={ match.data }/>;
-                })}
+                    return <Match key={ key } data={ match.data }
+                        focused={ focused }/>;
+                }, this)}
                 </ul>
             );
         }
@@ -80,14 +91,50 @@ export default class Search extends FluxComponent {
     }
 
     onKeyDown(ev) {
-        var inputDOMNode = React.findDOMNode(this.refs.searchField);
+        const searchStore = this.getStore('search');
+        const results = searchStore.getResults();
+        const inputDOMNode = React.findDOMNode(this.refs.searchField);
+        const focusedIndex = this.state.focusedIndex;
+
         if (ev.keyCode == 27 && ev.target == inputDOMNode) {
+            inputDOMNode.blur();
+            this.getActions('search').clearSearch();
+        }
+        else if (ev.keyCode == 40) {
+            // Down
+            this.setState({
+                focusedIndex: Math.min(results.length,
+                    (focusedIndex === undefined)? 0 : focusedIndex + 1)
+            });
+
+            ev.preventDefault();
+        }
+        else if (ev.keyCode == 38) {
+            // Up
+            this.setState({
+                focusedIndex: Math.max(0, (focusedIndex === undefined)?
+                    results.length - 1 : focusedIndex - 1)
+            });
+
+            ev.preventDefault();
+        }
+        else if (ev.keyCode == 13 && focusedIndex >= 0) {
+            const selected = results[focusedIndex];
+
+            // TODO: Navigate
+            console.log(selected);
+
+            ev.preventDefault();
             inputDOMNode.blur();
             this.getActions('search').clearSearch();
         }
     }
 
     onChange(ev) {
+        this.setState({
+            focusedIndex: undefined
+        });
+
         this.getActions('search').search(ev.target.value);
     }
 

--- a/src/js/components/sections/SectionBase.jsx
+++ b/src/js/components/sections/SectionBase.jsx
@@ -58,6 +58,8 @@ export default class SectionBase extends FluxComponent {
                     paneType={ subSections[0].path } panePath={ panePath }/>);
         }
         else {
+            var subRefIndex = 1;
+            var subStartIndex = 1;
             var subPathSegments = subPath.split('/');
 
             for (i = 0; i < subSections.length; i++) {
@@ -73,7 +75,26 @@ export default class SectionBase extends FluxComponent {
                 }
             }
 
-            for (i = 1; i < subPathSegments.length; i++) {
+            // No base pane could be found. For most sub-sections, the first
+            // URL segment after the section references the sub-section. But
+            // for the start sub-section this might not be defined, e.g. the
+            // sub-section at /people/list can also be found at /people. Since
+            // no sub-section could be found, the segment at 0 probably really
+            // references the next pane, so we should fall back to use the
+            // default/home pane of this sub-section first.
+            if (panes.length == 0) {
+                curSubSectionIndex = 0;
+                section = subSections[0];
+                Pane = section.startPane;
+                panePath = basePath + '/' + section.path;
+                panes.push(
+                    <Pane ref="pane0" key={ section.path }
+                        paneType={ section.path } panePath={ panePath }/>);
+
+                subStartIndex = 0;
+            }
+
+            for (i = subStartIndex; i < subPathSegments.length; i++) {
                 var segment = subPathSegments[i];
                 var segmentData = segment.split(':');
                 var paneName = segmentData[0];
@@ -87,10 +108,12 @@ export default class SectionBase extends FluxComponent {
 
                 Pane = PaneUtils.resolve(paneName);
                 panes.push(
-                    <Pane ref={ 'pane' + i } key={ segment }
+                    <Pane ref={ 'pane' + subRefIndex } key={ segment }
                         paneType={ paneName }
                         panePath={ panePath } params={ paneParams }/>
                 );
+
+                subRefIndex++;
             }
         }
 

--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -167,11 +167,28 @@
             background-color: white;
 
             li {
-                padding: 1em;
+                position: relative;
                 list-style-type: none;
+                height: 4em;
+                padding: 0.5em;
+                cursor: pointer;
 
-                &.focused {
+                &.focused, &:hover {
                     background-color: #eee;
+                }
+
+                .title {
+                    position: absolute;
+                    top: 10px;
+                    left: 50px;
+                    right: 20px;
+                    font-weight: bold;
+                    font-size: 1.5em;
+                }
+
+                img {
+                    max-height: 3em;
+                    width: auto;
                 }
             }
         }

--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -165,12 +165,14 @@
             left: 0;
             right: 0;
             background-color: white;
-            padding: 1em 0;
 
             li {
-                margin: 0.5em;
-                padding: 0.5em;
+                padding: 1em;
                 list-style-type: none;
+
+                &.focused {
+                    background-color: #eee;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR improves the search results in the live search. It adds some styling to make them look and feel nicer, but mostly it revamps the way matches are opened so that they are (when possible) opened in the current context, i.e. with all open panes intact. This allows the user to search and open something while
working on something else, without having to go back and forth.

To achieve this, some changes to the way panes work had to be made, as described in the commits and code comments.