### PR TITLE
Action day pane

### DIFF
--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -52,6 +52,7 @@ export default class ActionCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
+                    onSelect={ this.props.onSelectDay }
                     onAddAction={ this.onAddAction.bind(this) }
                     onMoveAction={ this.onMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
@@ -97,6 +98,7 @@ export default class ActionCalendar extends React.Component {
 }
 
 ActionCalendar.propTypes = {
+    onSelectDay: React.PropTypes.func,
     onAddAction: React.PropTypes.func,
     onSelectAction: React.PropTypes.func,
     onMoveAction: React.PropTypes.func

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -36,7 +36,7 @@ export default class ActionDay extends React.Component {
 
         return this.props.connectDropTarget(
             <div className="actionday">
-                <h3>
+                <h3 onClick={ this.onDayClick.bind(this) }>
                     <span className="date">{ dateLabel }</span>
                     <span className="weekday">{ dayLabel }</span>
                 </h3>
@@ -52,6 +52,12 @@ export default class ActionDay extends React.Component {
                 </ul>
             </div>
         );
+    }
+
+    onDayClick() {
+        if (this.props.onSelect) {
+            this.props.onSelect(this.props.date);
+        }
     }
 
     onActionClick(action) {

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -44,6 +44,7 @@ export default class ActionMiniCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
+                    onSelect={ this.props.onSelectDay }
                     onAddAction={ this.props.onAddAction }
                     onMoveAction={ this.props.onMoveAction }
                     onSelectAction={ this.props.onSelectAction }/>

--- a/src/js/components/panes/ActionDayPane.jsx
+++ b/src/js/components/panes/ActionDayPane.jsx
@@ -1,0 +1,50 @@
+import React from 'react/addons';
+import moment from 'moment';
+
+import PaneBase from './PaneBase';
+import ActionList from '../misc/actionlist/ActionList';
+
+
+export default class EditActionPane extends PaneBase {
+    componentDidMount() {
+        this.listenTo('action', this.forceUpdate);
+    }
+
+    getPaneTitle(data) {
+        const d = moment(this.getParam(0));
+
+        return 'Actions on ' + d.format('YYYY-MM-DD');
+    }
+
+    renderPaneContent(data) {
+        const date = moment(this.getParam(0));
+        const actionStore = this.getStore('action');
+        const actions = actionStore.getActions().filter(a =>
+            moment(a.start_time).isSame(date, 'day'));
+
+        return (
+            <ActionList actions={ actions }/>
+        );
+    }
+
+    onSubmit(ev) {
+        ev.preventDefault();
+
+        var values = this.refs.form.getChangedValues();
+        var actionId = this.props.params[0];
+
+        this.getActions('action').updateAction(actionId, values);
+    }
+
+    onCreateCampaign(title) {
+        this.gotoSubPane('addcampaign', title);
+    }
+
+    onCreateLocation(title) {
+        this.gotoSubPane('addlocation', title);
+    }
+
+    onCreateActivity(title) {
+        this.gotoSubPane('addactivity', title);
+    }
+}

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -38,6 +38,7 @@ export default class AllActionsPane extends PaneWithCalendar {
         if (actions.length) {
             if (this.state.viewMode == 'cal') {
                 viewComponent = <ActionCalendar actions={ actions }
+                        onSelectDay={ this.onSelectDay.bind(this) }
                         onAddAction={ this.onCalendarAddAction.bind(this) }
                         onMoveAction={ this.onCalendarMoveAction.bind(this) }
                         onSelectAction={ this.onSelectAction.bind(this) }/>

--- a/src/js/components/sections/campaign/CampaignLocationsPane.jsx
+++ b/src/js/components/sections/campaign/CampaignLocationsPane.jsx
@@ -23,6 +23,7 @@ export default class AllActionsPane extends PaneWithCalendar {
         const actions = actionStore.getActions();
 
         return <ActionMiniCalendar actions={ actions }
+                    onSelectDay={ this.onSelectDay.bind(this) }
                     onAddAction={ this.onCalendarAddAction.bind(this) }
                     onMoveAction={ this.onCalendarMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -24,6 +24,7 @@ export default class CampaignPlaybackPane extends PaneWithCalendar {
         const actions = actionStore.getActions();
 
         return <ActionMiniCalendar actions={ actions }
+                    onSelectDay={ this.onSelectDay.bind(this) }
                     onAddAction={ this.onCalendarAddAction.bind(this) }
                     onMoveAction={ this.onCalendarMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>

--- a/src/js/components/sections/campaign/PaneWithCalendar.jsx
+++ b/src/js/components/sections/campaign/PaneWithCalendar.jsx
@@ -36,6 +36,11 @@ export default class PaneWithCalendar extends PaneBase {
         this.getActions('action').updateAction(action.id, values);
     }
 
+    onSelectDay(date) {
+        const dateStr = moment(date).format('YYYY-MM-DD');
+        this.gotoSubPane('actionday', dateStr);
+    }
+
     onSelectAction(action) {
         this.gotoSubPane('editaction', action.id);
     }

--- a/src/js/utils/PaneUtils.js
+++ b/src/js/utils/PaneUtils.js
@@ -1,3 +1,4 @@
+import ActionDayPane from '../components/panes/ActionDayPane';
 import AddActionPane from '../components/panes/AddActionPane';
 import AddActivityPane from '../components/panes/AddActivityPane';
 import AddCampaignPane from '../components/panes/AddCampaignPane';
@@ -13,6 +14,7 @@ import MoveParticipantsPane from '../components/panes/MoveParticipantsPane';
 import PersonPane from '../components/panes/PersonPane';
 
 var _panes = {
+    'actionday': ActionDayPane,
     'addaction': AddActionPane,
     'addactivity': AddActivityPane,
     'addperson': AddPersonPane,

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -35,6 +35,7 @@
         padding: 0.5em 1em;
         background-color: white;
         box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
+        cursor: pointer;
 
         .date {
             font-size: 1.3em;
@@ -52,7 +53,16 @@
     vertical-align: top;
 
     h3 {
+        cursor: pointer;
         margin: 0.5em 0;
+        color: #999;
+
+        transition: color 0.3s;
+
+        &:hover {
+            color: #666;
+            transition: color 0.1s;
+        }
     }
 
     .date {
@@ -60,7 +70,6 @@
         font-size: 0.9em;
         font-weight: bold;
         text-align: center;
-        color: #999;
     }
 
     .weekday {


### PR DESCRIPTION
Creates a pane that displays the actions on a specific date, to be opened mainly from calendar views. The new pane renders the actions using the regular `ActionList` component.

![image](https://cloud.githubusercontent.com/assets/550212/9568232/bdf26372-4f43-11e5-893e-64ac8738924a.png)
