### PR TITLE
Display overflow in calendar days

### DIFF
--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -43,7 +43,8 @@ export default class ActionDay extends React.Component {
         if (actions.length > maxVisible) {
             const overflowActions = actions.slice(maxVisible);
 
-            overflow = <ActionDayOverflow actions={ overflowActions }/>;
+            overflow = <ActionDayOverflow actions={ overflowActions }
+                onClick={ this.onDayClick.bind(this) }/>;
         }
 
 

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -2,6 +2,7 @@ import React from 'react/addons';
 import { DropTarget } from 'react-dnd';
 
 import ActionItem from './ActionItem';
+import ActionDayOverflow from './ActionDayOverflow';
 
 
 const dayTarget = {
@@ -34,6 +35,18 @@ export default class ActionDay extends React.Component {
         const dateLabel = date.getDate() + '/' + (date.getMonth() + 1);
         const dayLabel = DAY_LABELS[date.getDay()];
 
+        const maxVisible = this.props.maxVisible;
+        const actions = this.props.actions;
+        const cappedActions = actions.slice(0, maxVisible);
+
+        var overflow = null;
+        if (actions.length > maxVisible) {
+            const overflowActions = actions.slice(maxVisible);
+
+            overflow = <ActionDayOverflow actions={ overflowActions }/>;
+        }
+
+
         return this.props.connectDropTarget(
             <div className="actionday">
                 <h3 onClick={ this.onDayClick.bind(this) }>
@@ -41,10 +54,11 @@ export default class ActionDay extends React.Component {
                     <span className="weekday">{ dayLabel }</span>
                 </h3>
                 <ul>
-                { this.props.actions.map(function(action) {
+                { cappedActions.map(function(action) {
                     return <ActionItem key={ action.id } action={ action }
                             onClick={ this.onActionClick.bind(this, action) }/>
                 }, this) }
+                    { overflow }
                     <li className="actionday-pseudoitem">
                         <button className="actionday-addbutton"
                             onClick={ this.onAddClick.bind(this) }/>
@@ -74,6 +88,11 @@ export default class ActionDay extends React.Component {
 }
 
 ActionDay.propTypes = {
+    maxVisible: React.PropTypes.number,
     onSelectAction: React.PropTypes.func,
     onAddAction: React.PropTypes.func
+};
+
+ActionDay.defaultProps = {
+    maxVisible: 5
 };

--- a/src/js/components/misc/actioncal/ActionDayOverflow.jsx
+++ b/src/js/components/misc/actioncal/ActionDayOverflow.jsx
@@ -1,15 +1,24 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 
 export default class ActionDayOverflow extends React.Component {
     render() {
         const actions = this.props.actions;
         const actionCount = actions.length;
+        const highlightActions = actions.filter(a => a.highlight);
+        const highlightCount = highlightActions.length;
+
+        const label = highlightCount || actionCount;
+
+        const classes = cx({
+            'actionday-overflow': true,
+            'highlight': (highlightCount > 0)
+        });
 
         return (
-            <li className="actionday-pseudoitem actionday-overflow"
-                onClick={ this.props.onClick }>
-                { actionCount }
+            <li className={ classes } onClick={ this.props.onClick }>
+                { label }
             </li>
         );
     }

--- a/src/js/components/misc/actioncal/ActionDayOverflow.jsx
+++ b/src/js/components/misc/actioncal/ActionDayOverflow.jsx
@@ -1,0 +1,21 @@
+import React from 'react/addons';
+
+
+export default class ActionDayOverflow extends React.Component {
+    render() {
+        const actions = this.props.actions;
+        const actionCount = actions.length;
+
+        return (
+            <li className="actionday-pseudoitem actionday-overflow"
+                onClick={ this.props.onClick }>
+                { actionCount }
+            </li>
+        );
+    }
+}
+
+ActionDayOverflow.propTypes = {
+    actions: React.PropTypes.array.isRequired,
+    onClick: React.PropTypes.func
+};

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -44,6 +44,7 @@ export default class ActionMiniCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
+                    maxVisible={ 2 }
                     onSelect={ this.props.onSelectDay }
                     onAddAction={ this.props.onAddAction }
                     onMoveAction={ this.props.onMoveAction }

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -77,12 +77,22 @@
     }
 }
 
-.actionday-actionitem {
+.actionday-actionitem, .actionday-overflow {
     padding: 0.5em 1em;
     margin: 0 0 0.1em;
     background-color: white;
     box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
     cursor: pointer;
+}
+
+.actionday-overflow {
+    text-align: center;
+    font-weight: bold;
+    color: #aaa;
+
+    &::before {
+        content: "+";
+    }
 }
 
 .actioncalendar .actionday-actionitem {
@@ -109,7 +119,7 @@
     }
 }
 
-.actionminicalendar .actionday-actionitem {
+.actionminicalendar .actionday-actionitem, .actionminicalendar .actionday-overflow {
     height: 2em;
     transition: background-color 1.5s;
 

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -93,6 +93,10 @@
     &::before {
         content: "+";
     }
+
+    &.highlight {
+        color: #c88;
+    }
 }
 
 .actioncalendar .actionday-actionitem {
@@ -121,14 +125,14 @@
 
 .actionminicalendar .actionday-actionitem, .actionminicalendar .actionday-overflow {
     height: 2em;
-    transition: background-color 1.5s;
+    transition: color 1.5s, background-color 1.5s;
 
     span {
         display: none;
     }
 
     &.highlight {
-        transition: background-color 0.2s;
+        transition: color 0.2s, background-color 0.2s;
         background-color: #fcc;
     }
 


### PR DESCRIPTION
When there are more actions in a day than can nicely be shown in a calendar day, the overflow (i.e. number of actions) will be displayed in a separate box which can be clicked to open the ActionDayPane.

In the mini-calendar, the special box will highlight just like normal actions when there are one or more highlight actions. In these cases, the number will instead display the number of highlights.

![image](https://cloud.githubusercontent.com/assets/550212/9568499/8c1ad8ae-4f4b-11e5-9f0d-d7579607c47d.png)
