### PR TITLE
Action calendar look & feel

### DIFF
--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import ActionItem from './ActionItem';
 import ActionDayOverflow from './ActionDayOverflow';
 
+const CSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 const dayTarget = {
     canDrop(props, monitor) {
@@ -61,7 +62,7 @@ export default class ActionDay extends React.Component {
                     <span className="date">{ dateLabel }</span>
                     <span className="weekday">{ dayLabel }</span>
                 </h3>
-                <ul>
+                <CSSTransitionGroup transitionName="actionitem" component="ul">
                 { actions.map(function(action) {
                     return <ActionItem key={ action.id } action={ action }
                             onClick={ this.onActionClick.bind(this, action) }/>
@@ -71,7 +72,7 @@ export default class ActionDay extends React.Component {
                         <button className="actionday-addbutton"
                             onClick={ this.onAddClick.bind(this) }/>
                     </li>
-                </ul>
+                </CSSTransitionGroup>
             </div>
         );
     }

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -37,15 +37,17 @@ export default class ActionDay extends React.Component {
         const dayLabel = DAY_LABELS[date.getDay()];
 
         const maxVisible = this.props.maxVisible;
-        const actions = this.props.actions;
-        const cappedActions = actions.slice(0, maxVisible);
 
+        var actions = this.props.actions;
         var overflow = null;
+
         if (actions.length > maxVisible) {
-            const overflowActions = actions.slice(maxVisible);
+            const overflowActions = actions.slice(maxVisible - 1);
 
             overflow = <ActionDayOverflow actions={ overflowActions }
                 onClick={ this.onDayClick.bind(this) }/>;
+
+            actions = actions.slice(0, maxVisible - 1);
         }
 
         const classes = cx({
@@ -60,7 +62,7 @@ export default class ActionDay extends React.Component {
                     <span className="weekday">{ dayLabel }</span>
                 </h3>
                 <ul>
-                { cappedActions.map(function(action) {
+                { actions.map(function(action) {
                     return <ActionItem key={ action.id } action={ action }
                             onClick={ this.onActionClick.bind(this, action) }/>
                 }, this) }

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -53,6 +53,7 @@ export default class ActionDay extends React.Component {
 
         const classes = cx({
             'actionday': true,
+            'today': date.is('today'),
             'dragover': this.props.isOver
         });
 

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -1,5 +1,6 @@
 import React from 'react/addons';
 import { DropTarget } from 'react-dnd';
+import cx from 'classnames';
 
 import ActionItem from './ActionItem';
 import ActionDayOverflow from './ActionDayOverflow';
@@ -47,9 +48,13 @@ export default class ActionDay extends React.Component {
                 onClick={ this.onDayClick.bind(this) }/>;
         }
 
+        const classes = cx({
+            'actionday': true,
+            'dragover': this.props.isOver
+        });
 
         return this.props.connectDropTarget(
-            <div className="actionday">
+            <div className={ classes }>
                 <h3 onClick={ this.onDayClick.bind(this) }>
                     <span className="date">{ dateLabel }</span>
                     <span className="weekday">{ dayLabel }</span>

--- a/src/js/components/misc/actioncal/ActionItem.jsx
+++ b/src/js/components/misc/actioncal/ActionItem.jsx
@@ -34,19 +34,22 @@ function collect(connect, monitor) {
 export default class ActionItem extends React.Component {
     render() {
         const action = this.props.action;
+        const startDate = Date.utc.create(action.start_time);
+        const timeLabel = startDate.setUTC(true).format('{HH}:{mm}');
         const className = cx({
             'actionday-actionitem': true,
             'highlight': action.highlight
         });
 
-
         return this.props.connectDragSource(
             <li className={ className }
                 onClick={ this.onClick.bind(this) }>
-                <span className="activity">
-                    { action.activity.title }</span>
                 <span className="location">
                     { action.location.title }</span>
+                <span className="time">
+                    { timeLabel }</span>
+                <span className="activity">
+                    { action.activity.title }</span>
             </li>
         );
     }

--- a/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionMiniCalendar.jsx
@@ -44,7 +44,7 @@ export default class ActionMiniCalendar extends React.Component {
 
             days.push(
                 <ActionDay date={ new Date(d) } actions={ dayActions }
-                    maxVisible={ 2 }
+                    maxVisible={ 3 }
                     onSelect={ this.props.onSelectDay }
                     onAddAction={ this.props.onAddAction }
                     onMoveAction={ this.props.onMoveAction }

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -9,13 +9,14 @@
 }
 
 .actioncalendar .actionweek {
-    margin: 1em 0;
+    display: flex;
+    align-items: stretch;
 
     h2 {
         float: left;
         font-size: 1em;
         font-weight: normal;
-        width: 5%;
+        width: 4%;
     }
     
     &::after {
@@ -27,8 +28,17 @@
 
 .actioncalendar .actionday {
     float: left;
-    width: 13%;
-    margin-left: 0.5%;
+    width: 13.7%;
+    border-left: 1px solid #f4f4f4;
+    padding-bottom: 2em;
+
+    &:last-child {
+        border-right: 1px solid #f4f4f4;
+    }
+
+    &.dragover {
+        background-color: #eee;
+    }
 
     h3 {
         margin: 0 0 0.1em;

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -40,6 +40,10 @@
         background-color: #eee;
     }
 
+    &.today h3 {
+        border: 1px solid #aaa;
+    }
+
     h3 {
         margin: 0 0 0.1em;
         padding: 0.5em 1em;
@@ -64,6 +68,15 @@
 
     &.dragover {
         background-color: #e6e6e6;
+    }
+
+    &.today {
+        border-left: 1px solid #ddd;
+        border-right: 1px solid #ddd;
+
+        hr {
+            color: #333;
+        }
     }
 
     h3 {

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -110,6 +110,8 @@
 }
 
 .actioncalendar .actionday-actionitem {
+    position: relative;
+
     .activity {
         display: block;
         font-size: 1.2em;
@@ -130,6 +132,18 @@
             height: 0.5em;
             margin: 0.1em;
         }
+    }
+
+    &::after {
+        content: "";
+        display: block;
+        position: absolute;
+        width: 1em;
+        top: 0.5em;
+        right: 0.5em;
+        bottom: 0.5em;
+        background-color: #f0f0f0;
+        cursor: move;
     }
 }
 

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -1,11 +1,11 @@
 .actionminicalendar {
     background-color: rgba(0,0,0,0.05);
+    height: 13em;
 
     margin: 0 -2em 2em;
     overflow-x: scroll;
     overflow-y: hidden;
     white-space: nowrap;
-    padding-bottom: 2em;
 }
 
 .actioncalendar .actionweek {
@@ -58,9 +58,13 @@
 .actionminicalendar .actionday {
     display: inline-block;
     width: 5em;
-    min-height: 8em;
+    height: 100%;
     margin-left: 0.1em;
     vertical-align: top;
+
+    &.dragover {
+        background-color: #e6e6e6;
+    }
 
     h3 {
         cursor: pointer;
@@ -193,6 +197,7 @@
 
 .actionminicalendar .actionday-addbutton {
     background-color: #ddd;
+    font-size: 0.8em;
 }
 
 .actionday:hover .actionday-addbutton {

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -26,6 +26,14 @@
     }
 }
 
+.actionday {
+    &.dragover {
+        .actionday-addbuton {
+            visibility: hidden;
+        }
+    }
+}
+
 .actioncalendar .actionday {
     float: left;
     width: 13.7%;

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -129,16 +129,11 @@
 .actioncalendar .actionday-actionitem {
     position: relative;
 
-    .activity {
+    .location {
         display: block;
         font-size: 1.2em;
         font-weight: bold;
         margin: 0 0 0.2em;
-    }
-
-    .location {
-        display: block;
-        font-size: 1.1em;
 
         &::before {
             content: "";
@@ -146,9 +141,21 @@
             float: left;
             background-color: #888;
             width: 0.5em;
-            height: 0.5em;
-            margin: 0.1em;
+            height: 0.8em;
+            margin: 0.2em 0.2em 0 0;
         }
+    }
+
+    .activity {
+        display: inline-block;
+        font-size: 1.1em;
+    }
+
+    .time {
+        display: inline-block;
+        font-size: 1.1em;
+        margin-right: 0.5em;
+        float: left;
     }
 
     &::after {

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -199,3 +199,24 @@
     visibility: visible;
     opacity: 1;
 }
+
+// Transitions
+.actioncalendar, .actionminicalendar {
+    .actionitem-enter {
+        background-color: #fcc;
+    }
+
+    .actionitem-enter.actionitem-enter-active {
+        background-color: white;
+        transition: background-color 0.4s ease-in;
+    }
+
+    .actionitem-leave {
+        opacity: 1;
+    }
+
+    .actionitem-leave.actionitem-leave-active {
+        opacity: 0.01;
+        transition: opacity 0.1s;
+    }
+}


### PR DESCRIPTION
This PR contains several minor improvements to the look and feel of the `ActionCalendar` and `ActionMiniCalendar` components.

* General styling improvements
* Add time label to action items
* Hover-effect on days when dragging an action over it
* Fix bug related to display cap on number of actions in a day
* CSS transitions for when an action is added to and removed from a day
* Highlight today

![image](https://cloud.githubusercontent.com/assets/550212/9589453/c1be5c18-502e-11e5-990d-6e51e1e2ff75.png)
