### PR TITLE
Drag to clone action

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "merge": "^1.2.0",
     "moment": "^2.10.6",
     "react": "~0.13.0",
-    "react-dnd": "^1.1.4",
+    "react-dnd": "git://github.com/zetkin/react-dnd.git#gitinstall",
     "react-router-component": "^0.24.4",
     "sugar-date": "^1.5.1",
     "ws": "^0.7.2",

--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -54,6 +54,7 @@ export default class ActionCalendar extends React.Component {
                 <ActionDay date={ new Date(d) } actions={ dayActions }
                     onSelect={ this.props.onSelectDay }
                     onAddAction={ this.onAddAction.bind(this) }
+                    onCopyAction={ this.onCopyAction.bind(this) }
                     onMoveAction={ this.onMoveAction.bind(this) }
                     onSelectAction={ this.onSelectAction.bind(this) }/>
             );
@@ -93,6 +94,12 @@ export default class ActionCalendar extends React.Component {
     onMoveAction(action, date) {
         if (this.props.onMoveAction) {
             this.props.onMoveAction(action, date);
+        }
+    }
+
+    onCopyAction(action, date) {
+        if (this.props.onCopyAction) {
+            this.props.onCopyAction(action, date);
         }
     }
 }

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -60,6 +60,12 @@ export default class ActionDay extends React.Component {
             'dragover': this.props.isOver
         });
 
+        var dropHint = null;
+        if (this.props.isOver) {
+            dropHint = <span className="clonehint">
+                Hold <code>shift</code> to copy action.</span>;
+        }
+
         return this.props.connectDropTarget(
             <div className={ classes }>
                 <h3 onClick={ this.onDayClick.bind(this) }>
@@ -77,6 +83,7 @@ export default class ActionDay extends React.Component {
                             onClick={ this.onAddClick.bind(this) }/>
                     </li>
                 </CSSTransitionGroup>
+                { dropHint }
             </div>
         );
     }

--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -12,9 +12,12 @@ const dayTarget = {
         return true;
     },
 
-    drop(props) {
+    drop(props, monitor, component, meta) {
+        const callback = meta.shiftKey?
+            props.onCopyAction : props.onMoveAction;
+
         return {
-            onMoveAction: props.onMoveAction,
+            onMoveAction: callback,
             newDate: props.date
         };
     }

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -41,6 +41,7 @@ export default class AllActionsPane extends PaneWithCalendar {
                         onSelectDay={ this.onSelectDay.bind(this) }
                         onAddAction={ this.onCalendarAddAction.bind(this) }
                         onMoveAction={ this.onCalendarMoveAction.bind(this) }
+                        onCopyAction={ this.onCalendarCopyAction.bind(this) }
                         onSelectAction={ this.onSelectAction.bind(this) }/>
             }
             else {

--- a/src/js/components/sections/campaign/PaneWithCalendar.jsx
+++ b/src/js/components/sections/campaign/PaneWithCalendar.jsx
@@ -14,6 +14,34 @@ export default class PaneWithCalendar extends PaneBase {
         this.gotoSubPane('addaction', campParam, dateParam);
     }
 
+    onCalendarCopyAction(action, date) {
+        const oldStartTime = new Date(action.start_time);
+        const oldEndTime = new Date(action.end_time);
+
+        const startTime = new Date(date);
+        startTime.setHours(oldStartTime.getHours());
+        startTime.setMinutes(oldStartTime.getMinutes());
+        startTime.setSeconds(oldStartTime.getSeconds());
+
+        const endTime = new Date(date);
+        endTime.setHours(oldEndTime.getHours());
+        endTime.setMinutes(oldEndTime.getMinutes());
+        endTime.setSeconds(oldEndTime.getSeconds());
+
+        const newAction = {
+            activity_id: action.activity.id,
+            location_id: action.location.id,
+            info_text: action.info_text,
+            num_participants_required: action.num_participants_required,
+
+            // Use new start and end times
+            start_time: startTime.toISOString(),
+            end_time: endTime.toISOString()
+        };
+
+        this.getActions('action').createAction(action.campaign.id, newAction);
+    }
+
     onCalendarMoveAction(action, date) {
         const oldStartTime = new Date(action.start_time);
         const oldEndTime = new Date(action.end_time);

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -35,6 +35,7 @@
 }
 
 .actioncalendar .actionday {
+    position: relative;
     float: left;
     width: 13.7%;
     border-left: 1px solid #f4f4f4;
@@ -63,6 +64,22 @@
             font-size: 1.3em;
             font-weight: bold;
             padding-right: 0.5em;
+        }
+    }
+
+    .clonehint {
+        position: absolute;
+        left: 1em;
+        right: 1em;
+        bottom: 1em;
+        text-align: center;
+        color: #999;
+
+        code {
+            display: inline-block;
+            background-color: #ddd;
+            border-radius: 0.4em;
+            padding: 0.1em 0.3em;
         }
     }
 }
@@ -108,6 +125,10 @@
     }
 
     .weekday {
+        display: none;
+    }
+
+    .clonehint {
         display: none;
     }
 }
@@ -231,6 +252,10 @@
 .actionday:hover .actionday-addbutton {
     visibility: visible;
     opacity: 1;
+}
+
+.actionday.dragover .actionday-addbutton {
+    visibility: hidden;
 }
 
 // Transitions


### PR DESCRIPTION
This adds the possibility to clone actions instead of moving them by holding shift while dragging and dropping. This required some changes to the react-dnd library, for which we now have [our own fork](https://github.com/zetkin/react-dnd) (including it's [dnd-core requirement](https://github.com/zetkin/dnd-core)).

When dragging over a day, a small hint at the bottom of the day grid square instructs the user to hold shift to clone.

![image](https://cloud.githubusercontent.com/assets/550212/9607904/f5d90050-50cb-11e5-8e69-cf0c7a41ef9c.png)

Closes #97.