### PR TITLE
Help/about links

### DIFF
--- a/src/js/components/sections/SectionBase.jsx
+++ b/src/js/components/sections/SectionBase.jsx
@@ -117,8 +117,10 @@ export default class SectionBase extends FluxComponent {
             }
         }
 
-        var sectionType = this.constructor.name
+        const sectionType = this.constructor.name
             .replace(/Section$/, '').toLowerCase();
+
+        const helpUrl = '/help/sections/' + sectionType;
 
         return (
             <div className={ 'section section-' + sectionType }>
@@ -143,6 +145,10 @@ export default class SectionBase extends FluxComponent {
                             className='section-nav-item section-nav-back'>
                             <Link href="/">Back to <br />Dashboard</Link></li>
                     </ul>
+                    <div className="section-nav-misc">
+                        <a target="_blank" href="http://zetkin.org">About</a>
+                        <a target="_blank" href={ helpUrl }>Help</a>
+                    </div>
                 </nav>
                 <div className="section-content" ref="paneContainer">
                     { panes }

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -11,6 +11,34 @@
         padding: 0;
     }
 
+    .section-nav-misc {
+        position: absolute;
+        left: 0.5em;
+        right: 0.5em;
+        bottom: 1.5em;
+
+        text-align: center;
+
+        a {
+            color: #888;
+            padding-left: 1em;
+            padding-right: 1em;
+            border-left: 1px solid #888;
+
+            &:first-child {
+                border-left: 0;
+                padding-left: 0;
+            }
+
+            &:last-child {
+                padding-right: 0;
+            }
+
+            &:hover {
+                color: #ddd;
+            }
+        }
+    }
 }
 
 .section-nav-item a {


### PR DESCRIPTION
This PR adds "help" and "about" links at the bottom of the left-hand-side section nav menu.

![image](https://cloud.githubusercontent.com/assets/550212/9626988/7ebb5446-5161-11e5-8554-a794ece64c7e.png)


The help link links directly to the part of the documentation that is relevant to the current section (not yet available). The about link takes the user to the Zetkin Foundation website. 

Closes #99