### PR TITLE
Person query framework

### DIFF
--- a/src/js/actions/query.js
+++ b/src/js/actions/query.js
@@ -2,6 +2,10 @@ import { Actions } from 'flummox';
 
 
 export default class QueryActions extends Actions {
+    createQuery(title) {
+        return title;
+    }
+
     updateFilter(queryId, filterIndex, filterConfig) {
         return { queryId, filterIndex, filterConfig };
     }

--- a/src/js/actions/query.js
+++ b/src/js/actions/query.js
@@ -1,0 +1,8 @@
+import { Actions } from 'flummox';
+
+
+export default class QueryActions extends Actions {
+    updateFilter(queryId, filterIndex, filterConfig) {
+        return { queryId, filterIndex, filterConfig };
+    }
+}

--- a/src/js/actions/query.js
+++ b/src/js/actions/query.js
@@ -5,4 +5,8 @@ export default class QueryActions extends Actions {
     updateFilter(queryId, filterIndex, filterConfig) {
         return { queryId, filterIndex, filterConfig };
     }
+
+    addFilter(queryId, filterType) {
+        return { queryId, filterType };
+    }
 }

--- a/src/js/actions/query.js
+++ b/src/js/actions/query.js
@@ -9,4 +9,8 @@ export default class QueryActions extends Actions {
     addFilter(queryId, filterType) {
         return { queryId, filterType };
     }
+
+    removeFilter(queryId, filterIndex) {
+        return { queryId, filterIndex };
+    }
 }

--- a/src/js/components/filters/CampaignFilter.jsx
+++ b/src/js/components/filters/CampaignFilter.jsx
@@ -1,0 +1,40 @@
+import React from 'react/addons';
+
+import FilterBase from './FilterBase';
+import Form from '../forms/Form';
+import SelectInput from '../forms/inputs/SelectInput';
+import RelSelectInput from '../forms/inputs/RelSelectInput';
+
+
+export default class CampaignFilter extends FilterBase {
+    componentDidMount() {
+        this.listenTo('campaign', this.forceUpdate);
+
+        const campaignStore = this.getStore('campaign');
+        const campaigns = campaignStore.getCampaigns();
+
+        if (campaigns.length == 0) {
+            this.getActions('campaign').retrieveCampaigns();
+        }
+    }
+
+    renderFilterForm(config) {
+        const campaignStore = this.getStore('campaign');
+        const campaigns = campaignStore.getCampaigns();
+        const operatorOptions = {
+            'in': 'Participated in',
+            'notin': 'Did not participate in'
+        };
+
+        return (
+            <Form ref="form" onSubmit={ this.onFormSubmit.bind(this) }>
+                <SelectInput label="People who" name="operator"
+                    options={ operatorOptions }
+                    initialValue={ config.operator }/>
+                <RelSelectInput label="Which campaign?" name="campaign"
+                    showCreateOption={ false } objects={ campaigns }/>
+                <input type="submit"/>
+            </Form>
+        );
+    }
+}

--- a/src/js/components/filters/FilterBase.jsx
+++ b/src/js/components/filters/FilterBase.jsx
@@ -1,7 +1,9 @@
 import React from 'react/addons';
 
+import FluxComponent from '../FluxComponent';
 
-export default class FilterBase extends React.Component {
+
+export default class FilterBase extends FluxComponent {
     render() {
         const config = this.props.config;
         const classes = "filter filter-" + config.type;

--- a/src/js/components/filters/FilterBase.jsx
+++ b/src/js/components/filters/FilterBase.jsx
@@ -8,6 +8,8 @@ export default class FilterBase extends React.Component {
 
         return (
             <div className={ classes }>
+                <a className="filter-remove"
+                    onClick={ this.onClickRemove.bind(this) }>x</a>
                 { this.renderFilterForm(config) }
             </div>
         );
@@ -19,6 +21,12 @@ export default class FilterBase extends React.Component {
 
     getConfig() {
         return this.refs.form.getValues();
+    }
+
+    onClickRemove(ev) {
+        if (this.props.onFilterRemove) {
+            this.props.onFilterRemove();
+        }
     }
 
     onFormSubmit(ev) {

--- a/src/js/components/filters/FilterBase.jsx
+++ b/src/js/components/filters/FilterBase.jsx
@@ -1,0 +1,36 @@
+import React from 'react/addons';
+
+
+export default class FilterBase extends React.Component {
+    render() {
+        const config = this.props.config;
+        const classes = "filter filter-" + config.type;
+
+        return (
+            <div className={ classes }>
+                { this.renderFilterForm(config) }
+            </div>
+        );
+    }
+
+    renderFilterForm(config) {
+        return null;
+    }
+
+    getConfig() {
+        return this.refs.form.getValues();
+    }
+
+    onFormSubmit(ev) {
+        ev.preventDefault();
+
+        if (this.props.onFilterChange) {
+            const config = this.getConfig();
+            this.props.onFilterChange(config);
+        }
+    }
+}
+
+FilterBase.propTypes = {
+    config: React.PropTypes.object.isRequired
+};

--- a/src/js/components/filters/JoinDateFilter.jsx
+++ b/src/js/components/filters/JoinDateFilter.jsx
@@ -1,0 +1,28 @@
+import React from 'react/addons';
+
+import FilterBase from './FilterBase';
+import Form from '../forms/Form';
+import SelectInput from '../forms/inputs/SelectInput';
+import DateInput from '../forms/inputs/DateInput';
+
+
+export default class JoinDateFilter extends FilterBase {
+    renderFilterForm(config) {
+        const operatorOptions = {
+            'lt': 'Before',
+            'gt': 'After',
+            'eq': 'Exactly on'
+        };
+
+        return (
+            <Form ref="form" onSubmit={ this.onFormSubmit.bind(this) }>
+                <SelectInput label="People who joined" name="operator"
+                    options={ operatorOptions }
+                    initialValue={ config.operator }/>
+                <DateInput label="Date" name="date"
+                    initialValue={ config.date }/>
+                <input type="submit"/>
+            </Form>
+        );
+    }
+}

--- a/src/js/components/filters/PersonDataFilter.jsx
+++ b/src/js/components/filters/PersonDataFilter.jsx
@@ -1,0 +1,34 @@
+import React from 'react/addons';
+
+import FilterBase from './FilterBase';
+import Form from '../forms/Form';
+import SelectInput from '../forms/inputs/SelectInput';
+import TextInput from '../forms/inputs/TextInput';
+
+
+export default class PersonDataFilter extends FilterBase {
+    renderFilterForm(config) {
+        const fieldOptions = {
+            '*': 'Any field',
+            'first_name': 'First name',
+            'last_name': 'Last name',
+            'email': 'E-mail address',
+            'phone': 'Phone number',
+            'co_address': 'C/o address',
+            'street_address': 'Street address',
+            'zip': 'Zip code',
+            'city': 'City'
+        };
+
+        return (
+            <Form ref="form" onSubmit={ this.onFormSubmit.bind(this) }>
+                <SelectInput label="Match" name="field"
+                    options={ fieldOptions }
+                    initialValue={ config.field }/>
+                <TextInput label="Against" name="text"
+                    initialValue={ config.text }/>
+                <input type="submit"/>
+            </Form>
+        );
+    }
+}

--- a/src/js/components/filters/index.js
+++ b/src/js/components/filters/index.js
@@ -1,7 +1,9 @@
+import CampaignFilter from './CampaignFilter';
 import JoinDateFilter from './JoinDateFilter';
 import PersonDataFilter from './PersonDataFilter';
 
 const filterComponents = {
+    'campaign': CampaignFilter,
     'join_date': JoinDateFilter,
     'person_data': PersonDataFilter
 };

--- a/src/js/components/filters/index.js
+++ b/src/js/components/filters/index.js
@@ -1,6 +1,8 @@
+import JoinDateFilter from './JoinDateFilter';
 import PersonDataFilter from './PersonDataFilter';
 
 const filterComponents = {
+    'join_date': JoinDateFilter,
     'person_data': PersonDataFilter
 };
 

--- a/src/js/components/filters/index.js
+++ b/src/js/components/filters/index.js
@@ -1,0 +1,9 @@
+import PersonDataFilter from './PersonDataFilter';
+
+const filterComponents = {
+    'person_data': PersonDataFilter
+};
+
+export function resolveFilterComponent(type) {
+    return filterComponents[type];
+}

--- a/src/js/components/forms/inputs/RelSelectInput.jsx
+++ b/src/js/components/forms/inputs/RelSelectInput.jsx
@@ -27,6 +27,7 @@ export default class RelSelectInput extends InputBase {
     renderInput() {
         const value = this.props.value;
         const objects = this.props.objects;
+        const showEditLink = this.props.showEditLink;
         const valueField = this.props.valueField;
         const labelField = this.props.labelField;
         const selected = (value && objects)?
@@ -65,10 +66,18 @@ export default class RelSelectInput extends InputBase {
                         'focused': (idx === this.state.focusedIndex)
                     });
 
+                    var editLink = null;
+                    if (showEditLink) {
+                        editLink = <a className="relselectinput-editlink"
+                            onMouseDown={ this.onClickEdit.bind(this, obj) }>
+                            Edit</a>;
+                    }
+
                     return (
                         <li key={ value } className={ classes }
                             onMouseDown={ this.onClickOption.bind(this, obj) }>
                             { label }
+                            { editLink }
                         </li>
                     );
                 }, this)}
@@ -141,6 +150,12 @@ export default class RelSelectInput extends InputBase {
         this.selectObject(obj);
     }
 
+    onClickEdit(obj) {
+        if (this.props.onEdit) {
+            this.props.onEdit(obj);
+        }
+    }
+
     onClickCreate() {
         this.createObject();
     }
@@ -178,10 +193,14 @@ RelSelectInput.propTypes = {
     objects: React.PropTypes.array.isRequired,
     valueField: React.PropTypes.string,
     labelField: React.PropTypes.string,
-    onCreate: React.PropTypes.func
+    showEditLink: React.PropTypes.bool,
+    onValueChange: React.PropTypes.func,
+    onCreate: React.PropTypes.func,
+    onEdit: React.PropTypes.func
 };
 
 RelSelectInput.defaultProps = {
+    showEditLink: false,
     valueField: 'id',
     labelField: 'title'
 };

--- a/src/js/components/forms/inputs/RelSelectInput.jsx
+++ b/src/js/components/forms/inputs/RelSelectInput.jsx
@@ -45,10 +45,20 @@ export default class RelSelectInput extends InputBase {
 
         const filteredObjects = this.getFilteredObjects();
 
-        const createOptionClasses = cx({
-            'relselectinput-create': true,
-            'focused': (this.state.focusedIndex == filteredObjects.length)
-        });
+        var createOption = null;
+        if (this.props.showCreateOption) {
+            const createOptionClasses = cx({
+                'relselectinput-create': true,
+                'focused': (this.state.focusedIndex == filteredObjects.length)
+            });
+
+            createOption = (
+                <li key="create" className={ createOptionClasses }
+                    onMouseDown={ this.onClickCreate.bind(this) }>
+                    Create <em>{ this.state.inputValue || 'new' }...</em>
+                </li>
+            );
+        }
 
         return (
             <div className={ classes }>
@@ -81,10 +91,7 @@ export default class RelSelectInput extends InputBase {
                         </li>
                     );
                 }, this)}
-                    <li key="create" className={ createOptionClasses }
-                        onMouseDown={ this.onClickCreate.bind(this) }>
-                        Create <em>{ this.state.inputValue || 'new' }...</em>
-                    </li>
+                    { createOption }
                 </ul>
             </div>
         );
@@ -110,11 +117,13 @@ export default class RelSelectInput extends InputBase {
         const focusedIndex = this.state.focusedIndex;
         const objects = this.getFilteredObjects();
         const objectCount = objects.length;
+        const maxIndex = this.props.showCreateOption?
+            objectCount : objectCount - 1;
 
         if (ev.keyCode == 40) {
             // User pressed down, increment or set to zero if undefined
             this.setState({
-                focusedIndex: Math.min(objectCount,
+                focusedIndex: Math.min(maxIndex,
                     (focusedIndex === undefined)? 0 : focusedIndex + 1)
             });
 
@@ -124,7 +133,7 @@ export default class RelSelectInput extends InputBase {
             // User pressed up, decrement or set to last if undefined
             this.setState({
                 focusedIndex: Math.max(0, (focusedIndex === undefined)?
-                    objectCount : focusedIndex - 1)
+                    maxIndex : focusedIndex - 1)
             });
 
             ev.preventDefault();
@@ -193,6 +202,7 @@ RelSelectInput.propTypes = {
     objects: React.PropTypes.array.isRequired,
     valueField: React.PropTypes.string,
     labelField: React.PropTypes.string,
+    showCreateOption: React.PropTypes.bool,
     showEditLink: React.PropTypes.bool,
     onValueChange: React.PropTypes.func,
     onCreate: React.PropTypes.func,
@@ -200,6 +210,7 @@ RelSelectInput.propTypes = {
 };
 
 RelSelectInput.defaultProps = {
+    showCreateOption: true,
     showEditLink: false,
     valueField: 'id',
     labelField: 'title'

--- a/src/js/components/header/search/ActionDayMatch.jsx
+++ b/src/js/components/header/search/ActionDayMatch.jsx
@@ -4,7 +4,7 @@ import url from 'url';
 import MatchBase from './MatchBase';
 
 
-export default class LocationMatch extends MatchBase {
+export default class ActionDayMatch extends MatchBase {
     getTitle() {
         const count = this.props.data.action_count;
         const date = this.props.data.date;

--- a/src/js/components/header/search/QueryMatch.jsx
+++ b/src/js/components/header/search/QueryMatch.jsx
@@ -1,0 +1,11 @@
+import React from 'react/addons';
+import url from 'url';
+
+import MatchBase from './MatchBase';
+
+
+export default class QueryMatch extends MatchBase {
+    getTitle() {
+        return 'Person query: ' + this.props.data.title;
+    }
+}

--- a/src/js/components/header/search/Search.jsx
+++ b/src/js/components/header/search/Search.jsx
@@ -6,6 +6,7 @@ import ActionDayMatch from './ActionDayMatch';
 import CampaignMatch from './CampaignMatch';
 import LocationMatch from './LocationMatch';
 import PersonMatch from './PersonMatch';
+import QueryMatch from './QueryMatch';
 
 
 export default class Search extends FluxComponent {
@@ -51,6 +52,7 @@ export default class Search extends FluxComponent {
 
                     var Match;
 
+                    // TODO: Move this to separate index.js?
                     switch(match.type) {
                         case 'actionday':
                             Match = ActionDayMatch;
@@ -63,6 +65,9 @@ export default class Search extends FluxComponent {
                             break;
                         case 'person':
                             Match = PersonMatch;
+                            break;
+                        case 'query':
+                            Match = QueryMatch;
                             break;
                     }
 
@@ -119,6 +124,11 @@ export default class Search extends FluxComponent {
             case 'person':
                 defaultBase = '/people/list';
                 paneType = 'person';
+                params = [ match.data.id ];
+                break;
+            case 'query':
+                defaultBase = '/people/list';
+                paneType = 'query';
                 params = [ match.data.id ];
                 break;
             default:

--- a/src/js/components/panes/EditQueryPane.jsx
+++ b/src/js/components/panes/EditQueryPane.jsx
@@ -12,7 +12,7 @@ export default class QueryPane extends PaneBase {
     }
 
     getPaneTitle(data) {
-        return data.title;
+        return 'Edit query: ' + data.title;
     }
 
     componentDidMount() {

--- a/src/js/components/panes/QueryPane.jsx
+++ b/src/js/components/panes/QueryPane.jsx
@@ -35,6 +35,7 @@ export default class QueryPane extends PaneBase {
         }
 
         const filterTypes = {
+            'join_date': 'Join date',
             'person_data': 'Person data'
         };
 

--- a/src/js/components/panes/QueryPane.jsx
+++ b/src/js/components/panes/QueryPane.jsx
@@ -1,0 +1,50 @@
+import React from 'react/addons';
+
+import PaneBase from './PaneBase';
+import PeopleList from '../misc/peoplelist/PeopleList';
+
+
+export default class EditQueryPane extends PaneBase {
+    getRenderData() {
+        const queryStore = this.getStore('query');
+
+        return queryStore.getQuery(this.getParam(0));
+    }
+
+    getPaneTitle(data) {
+        return data.title;
+    }
+
+    getPaneSubTitle(data) {
+        return (
+            <a key="editLink" onClick={ this.onEditClick.bind(this) }>
+                Edit this query</a>
+        );
+    }
+
+    componentDidMount() {
+        this.listenTo('person', this.forceUpdate);
+        this.listenTo('query', this.forceUpdate);
+    }
+
+    renderPaneContent(data) {
+        const personStore = this.getStore('person');
+        const queryStore = this.getStore('query');
+        const people = personStore.getPeople();
+
+        const filteredPeople = queryStore.executeQuery(data.id, people);
+
+        return [
+            <PeopleList key="peopleList" people={ filteredPeople }
+                onSelect={ this.onPersonSelect.bind(this) }/>
+        ];
+    }
+
+    onPersonSelect(person) {
+        this.gotoSubPane('person', person.id);
+    }
+
+    onEditClick(ev) {
+        this.gotoSubPane('editquery', this.getParam(0));
+    }
+}

--- a/src/js/components/panes/QueryPane.jsx
+++ b/src/js/components/panes/QueryPane.jsx
@@ -1,0 +1,43 @@
+import React from 'react/addons';
+
+import PaneBase from './PaneBase';
+import { resolveFilterComponent } from '../filters';
+
+
+export default class QueryPane extends PaneBase {
+    getRenderData() {
+        const queryStore = this.getStore('query');
+
+        return queryStore.getQuery(this.getParam(0));
+    }
+
+    getPaneTitle(data) {
+        return data.title;
+    }
+
+    renderPaneContent(data) {
+        const filters = data.filters;
+        const filterElements = [];
+
+        for (let i = 0; i < filters.length; i++) {
+            let filter = filters[i];
+            let FilterComponent = resolveFilterComponent(filter.type);
+
+            filterElements.push(
+                <FilterComponent config={ filter.config }
+                    onFilterChange={ this.onFilterChange.bind(this, i) }/>
+            );
+        }
+
+        return (
+            <div className="filters">
+                { filterElements }
+            </div>
+        );
+    }
+
+    onFilterChange(filterIndex, config) {
+        const queryId = this.getParam(0);
+        this.getActions('query').updateFilter(queryId, filterIndex, config);
+    }
+}

--- a/src/js/components/panes/QueryPane.jsx
+++ b/src/js/components/panes/QueryPane.jsx
@@ -35,6 +35,7 @@ export default class QueryPane extends PaneBase {
         }
 
         const filterTypes = {
+            'campaign': 'Campaign participation',
             'join_date': 'Join date',
             'person_data': 'Person data'
         };

--- a/src/js/components/panes/QueryPane.jsx
+++ b/src/js/components/panes/QueryPane.jsx
@@ -29,6 +29,7 @@ export default class QueryPane extends PaneBase {
 
             filterElements.push(
                 <FilterComponent key={ i } config={ filter.config }
+                    onFilterRemove={ this.onFilterRemove.bind(this, i) }
                     onFilterChange={ this.onFilterChange.bind(this, i) }/>
             );
         }
@@ -64,5 +65,10 @@ export default class QueryPane extends PaneBase {
     onFilterChange(filterIndex, config) {
         const queryId = this.getParam(0);
         this.getActions('query').updateFilter(queryId, filterIndex, config);
+    }
+
+    onFilterRemove(filterIndex) {
+        const queryId = this.getParam(0);
+        this.getActions('query').removeFilter(queryId, filterIndex);
     }
 }

--- a/src/js/components/panes/QueryPane.jsx
+++ b/src/js/components/panes/QueryPane.jsx
@@ -15,6 +15,10 @@ export default class QueryPane extends PaneBase {
         return data.title;
     }
 
+    componentDidMount() {
+        this.listenTo('query', this.forceUpdate);
+    }
+
     renderPaneContent(data) {
         const filters = data.filters;
         const filterElements = [];
@@ -24,16 +28,37 @@ export default class QueryPane extends PaneBase {
             let FilterComponent = resolveFilterComponent(filter.type);
 
             filterElements.push(
-                <FilterComponent config={ filter.config }
+                <FilterComponent key={ i } config={ filter.config }
                     onFilterChange={ this.onFilterChange.bind(this, i) }/>
             );
         }
 
-        return (
+        const filterTypes = {
+            'person_data': 'Person data'
+        };
+
+        return [
             <div className="filters">
                 { filterElements }
+            </div>,
+            <div className="pseudofilter">
+                <select key="filterTypeSelect" value=""
+                    onChange={ this.onFilterTypeSelect.bind(this) }>
+                    <option value="">Add filter</option>
+                    {Object.keys(filterTypes).map(function(type) {
+                        const label = filterTypes[type];
+                        return <option value={ type }>{ label }</option>;
+                    })}
+                </select>
             </div>
-        );
+        ];
+    }
+
+    onFilterTypeSelect(ev) {
+        const filterType = ev.target.value;
+        const queryId = this.getParam(0);
+
+        this.getActions('query').addFilter(queryId, filterType);
     }
 
     onFilterChange(filterIndex, config) {

--- a/src/js/components/sections/people/PeopleListPane.jsx
+++ b/src/js/components/sections/people/PeopleListPane.jsx
@@ -2,6 +2,7 @@ import React from 'react/addons';
 
 import PaneBase from '../../panes/PaneBase';
 import PeopleList from '../../misc/peoplelist/PeopleList';
+import RelSelectInput from '../../forms/inputs/RelSelectInput';
 
 
 export default class PeopleListPane extends PaneBase {
@@ -38,17 +39,10 @@ export default class PeopleListPane extends PaneBase {
         return [
             <input key="addButton" type="button" value="Add"
                 onClick={ this.onAddClick.bind(this) }/>,
-            <select key="querySelect" value={ queryId }
-                onChange={ this.onQueryChange.bind(this) }>
-                <option value="">----</option>
-                {queries.map(function(query) {
-                    return (
-                        <option key={ query.id } value={ query.id }>
-                            { query.title }
-                        </option>
-                    );
-                })}
-            </select>,
+            <RelSelectInput name="querySelect" value={ queryId }
+                objects={ queries }
+                onValueChange={ this.onQueryChange.bind(this) }
+                onCreate={ this.onQueryCreate.bind(this) }/>,
             <PeopleList key="peopleList" people={ people }
                 onSelect={ this.onSelect.bind(this) }/>
         ];
@@ -62,9 +56,17 @@ export default class PeopleListPane extends PaneBase {
         this.gotoSubPane('addperson');
     }
 
-    onQueryChange(ev) {
+    onQueryChange(name, value) {
         this.setState({
-            selectedQueryId: ev.target.value
+            selectedQueryId: value
         });
+    }
+
+    onQueryCreate(title) {
+        // TODO: Is this the best way?
+        this.getActions('query').createQuery(title);
+
+        const queries = this.getStore('query').getQueries();
+        this.gotoSubPane('query', queries[queries.length-1].id);
     }
 }

--- a/src/js/components/sections/people/PeopleListPane.jsx
+++ b/src/js/components/sections/people/PeopleListPane.jsx
@@ -68,10 +68,10 @@ export default class PeopleListPane extends PaneBase {
         this.getActions('query').createQuery(title);
 
         const queries = this.getStore('query').getQueries();
-        this.gotoSubPane('query', queries[queries.length-1].id);
+        this.gotoSubPane('editquery', queries[queries.length-1].id);
     }
 
     onQueryEdit(query) {
-        this.gotoSubPane('query', query.id);
+        this.gotoSubPane('editquery', query.id);
     }
 }

--- a/src/js/components/sections/people/PeopleListPane.jsx
+++ b/src/js/components/sections/people/PeopleListPane.jsx
@@ -5,11 +5,20 @@ import PeopleList from '../../misc/peoplelist/PeopleList';
 
 
 export default class PeopleListPane extends PaneBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            selectedQueryId: undefined
+        };
+    }
+
     getPaneTitle() {
         return 'People';
     }
 
     componentDidMount() {
+        this.listenTo('query', this.forceUpdate);
         this.listenTo('person', this.forceUpdate);
         this.getActions('person').retrievePeople();
     }
@@ -18,10 +27,29 @@ export default class PeopleListPane extends PaneBase {
         var personStore = this.getStore('person');
         var people = personStore.getPeople();
 
+        const queryId = this.state.selectedQueryId;
+        const queryStore = this.getStore('query');
+        const queries = queryStore.getQueries();
+
+        if (queryId) {
+            people = queryStore.executeQuery(queryId, people);
+        }
+
         return [
-            <input type="button" value="Add"
+            <input key="addButton" type="button" value="Add"
                 onClick={ this.onAddClick.bind(this) }/>,
-            <PeopleList people={ people }
+            <select key="querySelect" value={ queryId }
+                onChange={ this.onQueryChange.bind(this) }>
+                <option value="">----</option>
+                {queries.map(function(query) {
+                    return (
+                        <option key={ query.id } value={ query.id }>
+                            { query.title }
+                        </option>
+                    );
+                })}
+            </select>,
+            <PeopleList key="peopleList" people={ people }
                 onSelect={ this.onSelect.bind(this) }/>
         ];
     }
@@ -32,5 +60,11 @@ export default class PeopleListPane extends PaneBase {
 
     onAddClick(person) {
         this.gotoSubPane('addperson');
+    }
+
+    onQueryChange(ev) {
+        this.setState({
+            selectedQueryId: ev.target.value
+        });
     }
 }

--- a/src/js/components/sections/people/PeopleListPane.jsx
+++ b/src/js/components/sections/people/PeopleListPane.jsx
@@ -40,9 +40,10 @@ export default class PeopleListPane extends PaneBase {
             <input key="addButton" type="button" value="Add"
                 onClick={ this.onAddClick.bind(this) }/>,
             <RelSelectInput name="querySelect" value={ queryId }
-                objects={ queries }
+                objects={ queries } showEditLink={ true }
                 onValueChange={ this.onQueryChange.bind(this) }
-                onCreate={ this.onQueryCreate.bind(this) }/>,
+                onCreate={ this.onQueryCreate.bind(this) }
+                onEdit={ this.onQueryEdit.bind(this) }/>,
             <PeopleList key="peopleList" people={ people }
                 onSelect={ this.onSelect.bind(this) }/>
         ];
@@ -68,5 +69,9 @@ export default class PeopleListPane extends PaneBase {
 
         const queries = this.getStore('query').getQueries();
         this.gotoSubPane('query', queries[queries.length-1].id);
+    }
+
+    onQueryEdit(query) {
+        this.gotoSubPane('query', query.id);
     }
 }

--- a/src/js/flux.js
+++ b/src/js/flux.js
@@ -16,6 +16,7 @@ import ParticipantActions from './actions/participant';
 import ParticipantStore from './stores/participant';
 import PersonActions from './actions/person';
 import PersonStore from './stores/person';
+import QueryActions from './actions/query';
 import QueryStore from './stores/query';
 import SearchActions from './actions/search';
 import SearchStore from './stores/search';
@@ -67,6 +68,7 @@ export default class Flux extends Flummox {
         this.createActions('location', LocationActions, this);
         this.createActions('participant', ParticipantActions, this);
         this.createActions('person', PersonActions, this);
+        this.createActions('query', QueryActions);
         this.createActions('search', SearchActions);
         this.createActions('user', UserActions);
 

--- a/src/js/flux.js
+++ b/src/js/flux.js
@@ -16,6 +16,7 @@ import ParticipantActions from './actions/participant';
 import ParticipantStore from './stores/participant';
 import PersonActions from './actions/person';
 import PersonStore from './stores/person';
+import QueryStore from './stores/query';
 import SearchActions from './actions/search';
 import SearchStore from './stores/search';
 import UserActions from './actions/user';
@@ -77,6 +78,7 @@ export default class Flux extends Flummox {
         this.createStore('org', OrgStore, this);
         this.createStore('participant', ParticipantStore, this);
         this.createStore('person', PersonStore, this);
+        this.createStore('query', QueryStore, this);
         this.createStore('search', SearchStore, this);
         this.createStore('user', UserStore, this);
     }

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -1,0 +1,71 @@
+import { Store } from 'flummox';
+
+
+export default class QueryStore extends Store {
+    constructor(flux) {
+        super();
+
+        this.flux = flux;
+
+        // TODO: Get rid of dummy data
+        this.setState({
+            queries: [
+                {
+                    id: 1,
+                    title: 'My Query',
+                    filters: [{
+                        type: 'person_data',
+                        config: {
+                            text: 'larsson',
+                            fields: null // All fields
+                        }
+                    }]
+                }
+            ]
+        });
+    }
+
+    getQueries() {
+        return this.state.queries;
+    }
+
+    getQuery(id) {
+        return this.state.queries.find(q => q.id == id);
+    }
+
+    executeQuery(queryId, people) {
+        const query = this.state.queries.find(q => q.id == queryId);
+        return people.filter(p => matchesQuery(p, query));
+    }
+}
+
+function matchesQuery(person, query) {
+    for (let i = 0; i < query.filters.length; i++) {
+        let filter = query.filters[i];
+
+        if (filter.type in filterFunctions) {
+            let func = filterFunctions[filter.type];
+            if (func(person, filter.config)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+let filterFunctions = {
+    person_data: function matchPersonData(person, filterConfig) {
+        const field = filterConfig.field;
+        const qs = filterConfig.text.toLowerCase();
+
+        for (let key in person) {
+            if (!field || field == '*' || field == key) {
+                let val = person[key];
+                if (val && val.toString().toLowerCase().indexOf(qs) >= 0) {
+                    return true;
+                }
+            }
+        }
+    }
+};

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -23,6 +23,9 @@ export default class QueryStore extends Store {
                 }
             ]
         });
+
+        const queryActions = flux.getActions('query');
+        this.register(queryActions.updateFilter, this.onUpdateFilter);
     }
 
     getQueries() {
@@ -36,6 +39,19 @@ export default class QueryStore extends Store {
     executeQuery(queryId, people) {
         const query = this.state.queries.find(q => q.id == queryId);
         return people.filter(p => matchesQuery(p, query));
+    }
+
+    onUpdateFilter(payload) {
+        const queryId = payload.queryId;
+        const filterIndex = payload.filterIndex;
+        const filterConfig = payload.filterConfig;
+
+        const query = this.state.queries.find(q => q.id == queryId);
+        query.filters[filterIndex].config = filterConfig;
+
+        this.setState({
+            queries: this.state.queries
+        });
     }
 }
 

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -138,6 +138,11 @@ let filterFunctions = {
     join_date: function matchJoinDate(person, filterConfig) {
         // TODO: Implement once join date is actually on person object
         return true;
+    },
+
+    campaign: function matchCampaign(person, filterConfig) {
+        // TODO: Implement server-side
+        return true;
     }
 };
 
@@ -155,6 +160,13 @@ let defaultConfigs = {
         return {
             operator: 'gt',
             date: jan1.format('{yyyy}-{MM}-{dd}')
+        }
+    },
+
+    campaign: function getCampaignDefault() {
+        return {
+            operator: 'in',
+            campaign: undefined
         }
     }
 };

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -27,6 +27,7 @@ export default class QueryStore extends Store {
         const queryActions = flux.getActions('query');
         this.register(queryActions.addFilter, this.onAddFilter);
         this.register(queryActions.updateFilter, this.onUpdateFilter);
+        this.register(queryActions.removeFilter, this.onRemoveFilter);
     }
 
     getQueries() {
@@ -66,6 +67,18 @@ export default class QueryStore extends Store {
 
         const query = this.state.queries.find(q => q.id == queryId);
         query.filters[filterIndex].config = filterConfig;
+
+        this.setState({
+            queries: this.state.queries
+        });
+    }
+
+    onRemoveFilter(payload) {
+        const queryId = payload.queryId;
+        const filterIndex = payload.filterIndex;
+
+        const query = this.state.queries.find(q => q.id == queryId);
+        query.filters.splice(filterIndex, 1);
 
         this.setState({
             queries: this.state.queries

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -25,6 +25,7 @@ export default class QueryStore extends Store {
         });
 
         const queryActions = flux.getActions('query');
+        this.register(queryActions.addFilter, this.onAddFilter);
         this.register(queryActions.updateFilter, this.onUpdateFilter);
     }
 
@@ -39,6 +40,23 @@ export default class QueryStore extends Store {
     executeQuery(queryId, people) {
         const query = this.state.queries.find(q => q.id == queryId);
         return people.filter(p => matchesQuery(p, query));
+    }
+
+    onAddFilter(payload) {
+        const queryId = payload.queryId;
+        const filterType = payload.filterType;
+
+        const query = this.state.queries.find(q => q.id == queryId);
+        const getDefault = defaultConfigs[filterType];
+
+        query.filters.push({
+            type: filterType,
+            config: getDefault()
+        });
+
+        this.setState({
+            queries: this.state.queries
+        });
     }
 
     onUpdateFilter(payload) {
@@ -82,6 +100,15 @@ let filterFunctions = {
                     return true;
                 }
             }
+        }
+    }
+};
+
+let defaultConfigs = {
+    person_data: function getPersonDataDefault() {
+        return {
+            field: undefined,
+            text: ''
         }
     }
 };

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -79,13 +79,14 @@ function matchesQuery(person, query) {
 
         if (filter.type in filterFunctions) {
             let func = filterFunctions[filter.type];
-            if (func(person, filter.config)) {
-                return true;
+            // TODO: Implement boolean relationships
+            if (!func(person, filter.config)) {
+                return false;
             }
         }
     }
 
-    return false;
+    return true;
 }
 
 let filterFunctions = {
@@ -101,6 +102,8 @@ let filterFunctions = {
                 }
             }
         }
+
+        return false;
     }
 };
 

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -117,6 +117,11 @@ let filterFunctions = {
         }
 
         return false;
+    },
+
+    join_date: function matchJoinDate(person, filterConfig) {
+        // TODO: Implement once join date is actually on person object
+        return true;
     }
 };
 
@@ -125,6 +130,15 @@ let defaultConfigs = {
         return {
             field: undefined,
             text: ''
+        }
+    },
+
+    join_date: function getJoinDateDefault() {
+        const jan1 = new Date((new Date()).getFullYear(), 0, 1);
+
+        return {
+            operator: 'gt',
+            date: jan1.format('{yyyy}-{MM}-{dd}')
         }
     }
 };

--- a/src/js/stores/query.js
+++ b/src/js/stores/query.js
@@ -25,6 +25,7 @@ export default class QueryStore extends Store {
         });
 
         const queryActions = flux.getActions('query');
+        this.register(queryActions.createQuery, this.onCreateQuery);
         this.register(queryActions.addFilter, this.onAddFilter);
         this.register(queryActions.updateFilter, this.onUpdateFilter);
         this.register(queryActions.removeFilter, this.onRemoveFilter);
@@ -41,6 +42,21 @@ export default class QueryStore extends Store {
     executeQuery(queryId, people) {
         const query = this.state.queries.find(q => q.id == queryId);
         return people.filter(p => matchesQuery(p, query));
+    }
+
+    onCreateQuery(title) {
+        const queries = this.state.queries;
+        const id = queries.length?
+            queries[queries.length-1].id + 1 : 1;
+
+        const query = {
+            id, title,
+            filters: []
+        };
+
+        this.setState({
+            queries: queries.concat([ query ])
+        });
     }
 
     onAddFilter(payload) {

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -107,6 +107,16 @@ export default class SearchStore extends Store {
                 results: initialResults
                     .filter(r => searchMatches(query, r.data))
             });
+
+            // TODO: When queries are in the platform, move this server-side
+            // Search for person queries (inconveniantly named "queries" like
+            // the search query string that is the input to this function).
+            const queries = this.flux.getStore('query').getQueries();
+            this.setState({
+                results: this.state.results.concat(queries
+                    .filter(q => searchMatches(query, q))
+                    .map(q => ({ type: 'query', data: q })))
+            });
         }
 
         var sendQuery = function(query) {

--- a/src/js/utils/PaneUtils.js
+++ b/src/js/utils/PaneUtils.js
@@ -12,6 +12,7 @@ import EditCampaignPane from '../components/panes/EditCampaignPane';
 import EditLocationPane from '../components/panes/EditLocationPane';
 import MoveParticipantsPane from '../components/panes/MoveParticipantsPane';
 import PersonPane from '../components/panes/PersonPane';
+import QueryPane from '../components/panes/QueryPane';
 
 var _panes = {
     'actionday': ActionDayPane,
@@ -28,7 +29,8 @@ var _panes = {
     'editlocation': EditLocationPane,
     'location': EditLocationPane,
     'moveparticipants': MoveParticipantsPane,
-    'person': PersonPane
+    'person': PersonPane,
+    'query': QueryPane
 };
 
 function resolve(name) {

--- a/src/js/utils/PaneUtils.js
+++ b/src/js/utils/PaneUtils.js
@@ -13,6 +13,7 @@ import EditLocationPane from '../components/panes/EditLocationPane';
 import EditQueryPane from '../components/panes/EditQueryPane';
 import MoveParticipantsPane from '../components/panes/MoveParticipantsPane';
 import PersonPane from '../components/panes/PersonPane';
+import QueryPane from '../components/panes/QueryPane';
 
 var _panes = {
     'actionday': ActionDayPane,
@@ -30,7 +31,8 @@ var _panes = {
     'editquery': EditQueryPane,
     'location': EditLocationPane,
     'moveparticipants': MoveParticipantsPane,
-    'person': PersonPane
+    'person': PersonPane,
+    'query': QueryPane
 };
 
 function resolve(name) {

--- a/src/js/utils/PaneUtils.js
+++ b/src/js/utils/PaneUtils.js
@@ -10,9 +10,9 @@ import EditActionPane from '../components/panes/EditActionPane';
 import EditActivityPane from '../components/panes/EditActivityPane';
 import EditCampaignPane from '../components/panes/EditCampaignPane';
 import EditLocationPane from '../components/panes/EditLocationPane';
+import EditQueryPane from '../components/panes/EditQueryPane';
 import MoveParticipantsPane from '../components/panes/MoveParticipantsPane';
 import PersonPane from '../components/panes/PersonPane';
-import QueryPane from '../components/panes/QueryPane';
 
 var _panes = {
     'actionday': ActionDayPane,
@@ -27,10 +27,10 @@ var _panes = {
     'editactivity': EditActivityPane,
     'editcampaign': EditCampaignPane,
     'editlocation': EditLocationPane,
+    'editquery': EditQueryPane,
     'location': EditLocationPane,
     'moveparticipants': MoveParticipantsPane,
-    'person': PersonPane,
-    'query': QueryPane
+    'person': PersonPane
 };
 
 function resolve(name) {

--- a/src/scss/filters/_base.scss
+++ b/src/scss/filters/_base.scss
@@ -1,7 +1,21 @@
 .filter {
+    position: relative;
     @include card;
-    padding: 1em;
+    padding: 2em 1em 1em;
     margin: 1em 0;
+
+    .filter-remove {
+        display: block;
+        position: absolute;
+        top: 0.5em;
+        left: 1em;
+        overflow: hidden;
+        text-indent: 1000;
+        background-color: red;
+        width: 1em;
+        height: 1em;
+        cursor: pointer;
+    }
 }
 
 .pseudofilter {

--- a/src/scss/filters/_base.scss
+++ b/src/scss/filters/_base.scss
@@ -1,0 +1,14 @@
+.filter {
+    @include card;
+    padding: 1em;
+    margin: 1em 0;
+}
+
+.pseudofilter {
+    border: 3px dashed #e8e8e8;
+    padding: 2em;
+
+    select {
+        margin: 0;
+    }
+}

--- a/src/scss/inputs/_base.scss
+++ b/src/scss/inputs/_base.scss
@@ -44,6 +44,11 @@
                     background-color: red;
                 }
             }
+
+            .relselectinput-editlink {
+                float: right;
+                text-decoration: underline;
+            }
         }
     }
 

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -3,6 +3,22 @@
     min-width: 400px;
     z-index: 1000;
 
+    header {
+        h2 {
+            margin: 30px 0 30px;
+        }
+
+        small {
+            display: block;
+            margin: -15px 0 30px;
+
+            a {
+                cursor: pointer;
+                text-decoration: underline;
+            }
+        }
+    }
+
     .section-pane-content::after {
         content: "";
         display: block;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -2,6 +2,7 @@
 @import "_mixins";
 @import "_base";
 @import "inputs/_base";
+@import "filters/_base";
 @import "header/_base";
 @import "section/_base";
 @import "dashboard/_base";


### PR DESCRIPTION
This PR creates a framework for setting up complex person queries by chaining different kinds of filters. It creates some basic filters (some of which are noops simply for demo purpose at this point), and an `EditQueryPane` for adding and configuring filters into a query.

![image](https://cloud.githubusercontent.com/assets/550212/9637045/dd2aa1d4-519e-11e5-8e62-2c9d2672d879.png)

The PR also implements searching for stored queries and opening their results in a separate `QueryPane`, so that you can search for example for a cadre shortlist to more easily find people who are easy to engage in one of tomorrow's actions. Although not yet implemented in `PeopleList` (#133), it should be possible to drag people directly from this shortlist onto an action to book them.

![image](https://cloud.githubusercontent.com/assets/550212/9653714/d45a9014-5225-11e5-85ba-0e57c13527d1.png)

Closes #111