### PR TITLE
Draggable avatar

### DIFF
--- a/src/js/components/misc/DraggableAvatar.jsx
+++ b/src/js/components/misc/DraggableAvatar.jsx
@@ -1,0 +1,47 @@
+import React from 'react/addons';
+import { DragSource } from 'react-dnd';
+
+import Avatar from './Avatar';
+
+
+const personSource = {
+    beginDrag(props) {
+        return props.person;
+    },
+
+    endDrag(props, monitor, component) {
+        const dropResult = monitor.getDropResult();
+        if (!dropResult) {
+            // This was not a successful drag
+            return;
+        }
+
+        const person = monitor.getItem();
+        const newAction = dropResult.newAction;
+        const targetType = dropResult.targetType;
+
+        if (dropResult.onAddParticipant) {
+            dropResult.onAddParticipant(person);
+        }
+
+        if (targetType == 'contact' && dropResult.onSetContact) {
+            dropResult.onSetContact(person);
+        }
+    }
+}
+
+function collect(connect, monitor) {
+    return {
+        connectDragSource: connect.dragSource(),
+        isDragging: monitor.isDragging()
+    }
+}
+
+
+@DragSource('person', personSource, collect)
+export default class DraggableAvatar extends Avatar {
+    render() {
+        return this.props.connectDragSource(super.render());
+    }
+}
+

--- a/src/js/components/misc/peoplelist/PeopleListItem.jsx
+++ b/src/js/components/misc/peoplelist/PeopleListItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react/addons';
 
-import Avatar from '../Avatar';
+import DraggableAvatar from '../DraggableAvatar';
 
 
 export default class PeopleListItem extends React.Component {
@@ -17,7 +17,7 @@ export default class PeopleListItem extends React.Component {
             <li key={ person.id } className="peoplelistitem"
                 onClick={ this.props.onSelect }>
 
-                <Avatar person={ person }/>
+                <DraggableAvatar person={ person }/>
                 <span className="first_name">{ person.first_name }</span>
                 <span className="last_name">{ person.last_name }</span>
                 <span className="email">{ mailLink }</span>

--- a/src/js/components/panes/PersonPane.jsx
+++ b/src/js/components/panes/PersonPane.jsx
@@ -1,51 +1,8 @@
 import React from 'react/addons';
-import { DragSource } from 'react-dnd';
 
 import PaneBase from './PaneBase';
 import PersonForm from '../forms/PersonForm';
-import Avatar from '../misc/Avatar';
-
-const personSource = {
-    beginDrag(props) {
-        return props.person;
-    },
-
-    endDrag(props, monitor, component) {
-        const dropResult = monitor.getDropResult();
-        if (!dropResult) {
-            // This was not a successful drag
-            return;
-        }
-
-        const person = monitor.getItem();
-        const newAction = dropResult.newAction;
-        const targetType = dropResult.targetType;
-
-        if (dropResult.onAddParticipant) {
-            dropResult.onAddParticipant(person);
-        }
-
-        if (targetType == 'contact' && dropResult.onSetContact) {
-            dropResult.onSetContact(person);
-        }
-    }
-}
-
-function collect(connect, monitor) {
-    return {
-        connectDragSource: connect.dragSource(),
-        isDragging: monitor.isDragging()
-    }
-}
-
-// Create a draggable version of the Avatar component as
-// a simple decorated sub-class of Avatar.
-@DragSource('person', personSource, collect)
-class DraggableAvatar extends Avatar {
-    render() {
-        return this.props.connectDragSource(super.render());
-    }
-}
+import DraggableAvatar from '../misc/DraggableAvatar';
 
 
 export default class PersonPane extends PaneBase {


### PR DESCRIPTION
This create a separate `DraggableAvatar` component which takes care of the `DragSource` setup itself, so that it doesn't have to be implemented separately in every use case. This new component is now used in the `PeopleList` so that avatars can be dragged straight from the list without opening a `PersonPane`.

![image](https://cloud.githubusercontent.com/assets/550212/9654307/37f3d758-522a-11e5-81a4-dca3c2584330.png)
