### PR TITLE
Fix issue with actioncalendar not rendering properly

### DIFF
--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -20,7 +20,8 @@ export default class ActionCalendar extends React.Component {
         }
 
         // Always start on previous Monday
-        startDate.setDate(startDate.getDate() - startDate.getDay() + 1);
+        const startDay = startDate.getDay();
+        startDate.setDate(startDate.getDate() + 1 - (startDay? startDay : 7));
 
         // Always end on next Sunday
         endDate.setDate(endDate.getDate() + (7 - endDate.getDay()));


### PR DESCRIPTION
When a campaign started on a Sunday, the calendar would render from the following Monday (instead of the previous) resulting in no actions being rendered because it never found the correct date for the first one in the loop.