### PR TITLE
Better user menu

### DIFF
--- a/src/js/components/header/UserMenu.jsx
+++ b/src/js/components/header/UserMenu.jsx
@@ -2,6 +2,7 @@ import React from 'react/addons';
 
 import FluxComponent from '../FluxComponent';
 import OrgPicker from './OrgPicker';
+import Avatar from '../misc/Avatar';
 
 
 export default class UserMenu extends FluxComponent {
@@ -21,7 +22,7 @@ export default class UserMenu extends FluxComponent {
 
         return (
             <nav className="usermenu">
-                <div className="usermenu-avatar"></div>
+                <Avatar person={ profile }/>
                 <div className="usermenu-info">
                     <div className="usermenu-user">
                         <a href={ accountUrl }>

--- a/src/js/components/header/UserMenu.jsx
+++ b/src/js/components/header/UserMenu.jsx
@@ -14,16 +14,21 @@ export default class UserMenu extends FluxComponent {
 
         var accountUrl = '//' + userStore.getAccountsHost();
 
-        var userName = userStore.getUserInfo().email;
-        var activeOrg = userStore.getActiveMembership().organization;
-        var memberships = userStore.getMemberships();
+        const membership = userStore.getActiveMembership();
+        const activeOrg = membership.organization;
+        const profile = membership.profile;
+        const memberships = userStore.getMemberships();
 
         return (
             <nav className="usermenu">
                 <div className="usermenu-avatar"></div>
                 <div className="usermenu-info">
                     <div className="usermenu-user">
-                        <a href={ accountUrl }><span className="usermenu-info-name">{ userName }</span></a>
+                        <a href={ accountUrl }>
+                            <span className="usermenu-info-name">
+                                { profile.name }
+                            </span>
+                        </a>
                         <span className="usermenu-info-org">{ activeOrg.title }</span>
                     </div>
                     <ul>

--- a/src/scss/header/_base.scss
+++ b/src/scss/header/_base.scss
@@ -201,22 +201,12 @@
         right: 0;
         font-size: 1.6em;
 
-        .usermenu-avatar {
+        .avatar {
             position: absolute;
-            top: 0;
-            right: 0;
-            width: 3em;
-            height: 3em;
-            // Avatar placeholder
-            &::after {
-                content: "";
-                display: block;
-                height: 80%;
-                width: 80%;
-                margin: 10%;
-                background-color: #EEE;
-                border-radius: 50%;
-            }
+            top: 0.3em;
+            right: 0.3em;
+            width: 2.4em;
+            height: 2.4em;
         }
         &:hover {
             .usermenu-info{

--- a/src/scss/header/_medium.scss
+++ b/src/scss/header/_medium.scss
@@ -16,13 +16,51 @@
     }
 
     .usermenu {
+        transition: color 0.1s;
+
+        &::before {
+            z-index: 1000;
+            content: "";
+            display: block;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: black;
+            visibility: hidden;
+            opacity: 0;
+            transition: opacity 0.3s;
+            pointer-events: none;
+        }
+
         &:hover {
+            &::before {
+                opacity: 0.5;
+                visibility: visible;
+            }
+
             .usermenu-info ul {
                 display: block;
             }
+
+            color: white;
+        }
+
+        .usermenu-avatar {
+            position: absolute;
+            right: 0;
+            top: 0;
+            z-index: 3000;
         }
 
         .usermenu-info{
+            background-color: red;
+            position: absolute;
+            top: 0;
+            right: 0;
+            z-index: 3000;
+
             display: block;
             margin-top: 0;
             padding: 0;

--- a/src/scss/header/_medium.scss
+++ b/src/scss/header/_medium.scss
@@ -47,10 +47,7 @@
             color: white;
         }
 
-        .usermenu-avatar {
-            position: absolute;
-            right: 0;
-            top: 0;
+        .avatar {
             z-index: 3000;
         }
 
@@ -67,7 +64,8 @@
             background-color: transparent;
 
             .usermenu-user{
-                padding: 0.5em 3em 0.45em 0;
+                width: 14em;
+                padding: 0.5em 3.5em 0.45em 0;
             }
 
             ul {


### PR DESCRIPTION
This PR tweaks the styling and content of the user menu.

* Show name instead of e-mail address of user
* Show real avatar using the `Avatar` component
* Fade down background when hovering menu to make it pop

![usermenu](https://cloud.githubusercontent.com/assets/550212/9657784/56ecda8c-5244-11e5-815d-e1b9cb8b4dde.gif)

Closes #117.