### PR TITLE
Use RelSelectInput for campaign filter

### DIFF
--- a/src/js/components/misc/CampaignSelect.jsx
+++ b/src/js/components/misc/CampaignSelect.jsx
@@ -1,6 +1,7 @@
 import React from 'react/addons';
 
 import FluxComponent from '../FluxComponent';
+import RelSelectInput from '../forms/inputs/RelSelectInput';
 
 
 export default class CampaignSelect extends FluxComponent {
@@ -13,29 +14,21 @@ export default class CampaignSelect extends FluxComponent {
         }
 
         return (
-            <select value={ selected }
-                onChange={ this.onChange.bind(this) }>
-
-                <option key="all" value="all">Any campaign</option>
-
-            {campaigns.map(function(campaign) {
-                return (
-                    <option key={ campaign.id } value={ campaign.id }>
-                        { campaign.title }</option>
-                );
-            })}
-            </select>
+            <RelSelectInput value={ selected } objects={ campaigns }
+                showEditLink={ true } allowNull={ true }
+                nullLabel="Any campaign"
+                onEdit={ this.props.onEdit }
+                onCreate={ this.props.onCreate }
+                onValueChange={ this.onChange.bind(this) }/>
         );
     }
 
-    onChange(ev) {
-        const id = ev.target.value;
-
-        if (id === 'all') {
+    onChange(name, value) {
+        if (!value) {
             this.getActions('campaign').selectCampaign(null);
         }
         else {
-            this.getActions('campaign').selectCampaign(id);
+            this.getActions('campaign').selectCampaign(value);
         }
     }
 }

--- a/src/js/components/sections/campaign/ActionDistributionPane.jsx
+++ b/src/js/components/sections/campaign/ActionDistributionPane.jsx
@@ -34,7 +34,9 @@ export default class ActionDistributionPane extends CampaignSectionPaneBase {
         const actions = actionStore.getActions();
 
         return [
-            <CampaignSelect/>,
+            <CampaignSelect
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>,
             <div className="locations">
                 <h3>Locations</h3>
                 <ActionDistribution actions={ actions }

--- a/src/js/components/sections/campaign/ActionDistributionPane.jsx
+++ b/src/js/components/sections/campaign/ActionDistributionPane.jsx
@@ -1,12 +1,12 @@
 import React from 'react/addons';
 
-import PaneWithCalendar from './PaneWithCalendar';
+import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 import CampaignSelect from '../../misc/CampaignSelect';
 import ActionDistribution from '../../misc/actiondistro/ActionDistribution';
 import ActionMiniCalendar from '../../misc/actioncal/ActionMiniCalendar';
 
 
-export default class ActionDistributionPane extends PaneWithCalendar {
+export default class ActionDistributionPane extends CampaignSectionPaneBase {
     getPaneTitle() {
         return 'Location and activity distribution';
     }

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -1,13 +1,13 @@
 import React from 'react/addons';
 
-import PaneWithCalendar from './PaneWithCalendar';
+import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 import ActionList from '../../misc/actionlist/ActionList';
 import CampaignSelect from '../../misc/CampaignSelect';
 import ActionCalendar from '../../misc/actioncal/ActionCalendar';
 import ViewSwitch from '../../misc/ViewSwitch';
 
 
-export default class AllActionsPane extends PaneWithCalendar {
+export default class AllActionsPane extends CampaignSectionPaneBase {
     constructor(props) {
         super(props);
 

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -64,7 +64,10 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
                 selected={ this.state.viewMode }
                 onSwitch={ this.onViewSwitch.bind(this) }/>,
 
-            <CampaignSelect/>,
+            <CampaignSelect
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>,
+
             viewComponent
         ];
     }

--- a/src/js/components/sections/campaign/CampaignOverviewPane.jsx
+++ b/src/js/components/sections/campaign/CampaignOverviewPane.jsx
@@ -1,11 +1,11 @@
 import React from 'react/addons';
 
-import PaneBase from '../../panes/PaneBase';
+import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 
 import CampaignSelect from '../../misc/CampaignSelect';
 
 
-export default class CampaignOverviewPane extends PaneBase {
+export default class CampaignOverviewPane extends CampaignSectionPaneBase {
     getPaneTitle() {
         return 'Campaign overview';
     }

--- a/src/js/components/sections/campaign/CampaignOverviewPane.jsx
+++ b/src/js/components/sections/campaign/CampaignOverviewPane.jsx
@@ -12,7 +12,9 @@ export default class CampaignOverviewPane extends CampaignSectionPaneBase {
 
     renderPaneContent() {
         return [
-            <CampaignSelect/>
+            <CampaignSelect
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>
         ];
     }
 }

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -1,12 +1,12 @@
 import React from 'react/addons';
 
-import PaneWithCalendar from './PaneWithCalendar';
+import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 import CampaignSelect from '../../misc/CampaignSelect';
 import CampaignPlayer from '../../misc/campaignplayer/CampaignPlayer';
 import ActionMiniCalendar from '../../misc/actioncal/ActionMiniCalendar';
 
 
-export default class CampaignPlaybackPane extends PaneWithCalendar {
+export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
     getPaneTitle() {
         return 'Campaign playback';
     }

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -39,7 +39,9 @@ export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
         const center = locationStore.getAverageCenterOfLocations();
 
         return [
-            <CampaignSelect key="select"/>,
+            <CampaignSelect
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>,
             <CampaignPlayer key="player"
                 actions={ actions } locations={ locations }
                 centerLat={ center.lat } centerLng={ center.lng }

--- a/src/js/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/js/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -72,4 +72,12 @@ export default class CampaignSectionPaneBase extends PaneBase {
     onSelectAction(action) {
         this.openPane('editaction', action.id);
     }
+
+    onEditCampaign(campaign) {
+        this.openPane('editcampaign', campaign.id);
+    }
+
+    onCreateCampaign(title) {
+        this.openPane('addcampaign', title);
+    }
 }

--- a/src/js/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/js/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import PaneBase from '../../panes/PaneBase';
 
 
-export default class PaneWithCalendar extends PaneBase {
+export default class CampaignSectionPaneBase extends PaneBase {
     onCalendarAddAction(date) {
         const campaignStore = this.getStore('campaign');
         const selectedCampaign = campaignStore.getSelectedCampaign();


### PR DESCRIPTION
This PR uses the `RelSelectInput` component in `CampaignSelect` to allow for adding and editing campaigns from that box. It also adds the possibility for null options to `RelSelectInput`.

Closes #146.