### PR TITLE
Better MoveParticipantsPane

### DIFF
--- a/src/js/actions/participant.js
+++ b/src/js/actions/participant.js
@@ -41,7 +41,8 @@ export default class ParticipantActions extends Actions {
         for (i = 0; i < moves.length; i++) {
             var move = moves[i];
             apiCalls.push(Z.resource('orgs', orgId, 'actions',
-                move.from, 'participants', move.person).del());
+                move.from, 'participants', move.person)
+                .meta('move', move).del());
             apiCalls.push(Z.resource('orgs', orgId, 'actions',
                 move.to, 'participants', move.person).put());
         }

--- a/src/js/components/misc/actionlist/ActionList.jsx
+++ b/src/js/components/misc/actionlist/ActionList.jsx
@@ -68,12 +68,14 @@ export default class ActionList extends FluxComponent {
     }
 
     onMoveParticipant(action, person, oldAction) {
-        this.getActions('participant').moveParticipant(
-            person.id, oldAction.id, action.id);
+        if (this.props.onMoveParticipant) {
+            this.props.onMoveParticipant(action, person, oldAction);
+        }
     }
 }
 
 ActionList.propTypes = {
     actions: React.PropTypes.array.isRequired,
+    onMoveParticipant: React.PropTypes.func,
     onActionOperation: React.PropTypes.func
 };

--- a/src/js/components/misc/elements/Action.jsx
+++ b/src/js/components/misc/elements/Action.jsx
@@ -3,13 +3,16 @@ import React from 'react/addons';
 
 export default class Action extends React.Component {
     render() {
-        var a = this.props.action;
+        const action = this.props.action;
+        const startDate = Date.utc.create(action.start_time);
+        const timeLabel = startDate.setUTC(true)
+            .format('{yyyy}-{MM}-{dd}, {HH}:{mm}');
 
         return (
             <span className="action">
-                <span className="date">{ a.start_time }</span>
-                <span className="activity">{ a.activity.title }</span>
-                <span className="location">{ a.location.title }</span>
+                <span className="date">{ timeLabel }</span>
+                <span className="activity">{ action.activity.title }</span>
+                <span className="location">{ action.location.title }</span>
             </span>
         );
     }

--- a/src/js/components/misc/elements/Person.jsx
+++ b/src/js/components/misc/elements/Person.jsx
@@ -7,7 +7,7 @@ export default class Person extends React.Component {
         var fullName = person.first_name + ' ' + person.last_name;
 
         return (
-            <span className="person">
+            <span className="person" onClick={ this.props.onClick }>
                 { fullName }
             </span>
         );
@@ -15,5 +15,6 @@ export default class Person extends React.Component {
 }
 
 Person.propTypes = {
+    onClick: React.PropTypes.func,
     person: React.PropTypes.object.isRequired
 };

--- a/src/js/components/panes/ActionDayPane.jsx
+++ b/src/js/components/panes/ActionDayPane.jsx
@@ -28,6 +28,7 @@ export default class EditActionPane extends PaneBase {
             <input key="nextBtn" type="button" value=">"
                 onClick={ this.onClickNext.bind(this) }/>,
             <ActionList key="actionList" actions={ actions }
+                onMoveParticipant={ this.onMoveParticipant.bind(this) }
                 onActionOperation={ this.onActionOperation.bind(this) }/>
         ];
     }
@@ -46,6 +47,18 @@ export default class EditActionPane extends PaneBase {
         const dateStr = newDate.format('{yyyy}-{MM}-{dd}');
 
         this.gotoPane('actionday', dateStr);
+    }
+
+    onMoveParticipant(action, person, oldAction) {
+        this.getActions('participant').moveParticipant(
+            person.id, oldAction.id, action.id);
+
+        const participantStore = this.getStore('participant');
+        const moves = participantStore.getMoves();
+
+        if (moves.length) {
+            this.pushPane('moveparticipants');
+        }
     }
 
     onActionOperation(action, operation) {

--- a/src/js/components/panes/ActionDayPane.jsx
+++ b/src/js/components/panes/ActionDayPane.jsx
@@ -8,6 +8,11 @@ import ActionList from '../misc/actionlist/ActionList';
 export default class EditActionPane extends PaneBase {
     componentDidMount() {
         this.listenTo('action', this.forceUpdate);
+
+        const actions = this.getStore('action').getActions();
+        if (actions.length == 0) {
+            this.getActions('action').retrieveAllActions();
+        }
     }
 
     getPaneTitle(data) {

--- a/src/js/components/panes/MoveParticipantsPane.jsx
+++ b/src/js/components/panes/MoveParticipantsPane.jsx
@@ -37,7 +37,8 @@ export default class MoveParticipantsPane extends PaneBase {
 
                 return (
                     <li key={ key }>
-                        <Person person={ person }/>
+                        <Person person={ person }
+                            onClick={ this.onPersonClick.bind(this, person) }/>
                         <Action action={ fromAction }/>
                         <Action action={ toAction }/>
                     </li>
@@ -49,6 +50,10 @@ export default class MoveParticipantsPane extends PaneBase {
             <input type="button" value="Reset and cancel"
                 onClick={ this.onResetClick.bind(this) }/>
         ];
+    }
+
+    onPersonClick(person) {
+        this.openPane('person', person.id);
     }
 
     onExecuteClick(ev) {

--- a/src/js/components/panes/MoveParticipantsPane.jsx
+++ b/src/js/components/panes/MoveParticipantsPane.jsx
@@ -28,6 +28,10 @@ export default class MoveParticipantsPane extends PaneBase {
         const peopleStore = this.getStore('person');
 
         return [
+            <input type="button" value="Execute all"
+                onClick={ this.onExecuteClick.bind(this) }/>,
+            <input type="button" value="Reset all and cancel"
+                onClick={ this.onResetClick.bind(this) }/>,
             <ul className="movelist">
             {data.moves.map(function(move) {
                 const key = [move.person, move.from, move.to].join(',');
@@ -49,11 +53,7 @@ export default class MoveParticipantsPane extends PaneBase {
                     </li>
                 );
             }, this)}
-            </ul>,
-            <input type="button" value="Execute"
-                onClick={ this.onExecuteClick.bind(this) }/>,
-            <input type="button" value="Reset and cancel"
-                onClick={ this.onResetClick.bind(this) }/>
+            </ul>
         ];
     }
 

--- a/src/js/components/panes/MoveParticipantsPane.jsx
+++ b/src/js/components/panes/MoveParticipantsPane.jsx
@@ -56,11 +56,7 @@ export default class MoveParticipantsPane extends PaneBase {
         const participantStore = this.getStore('participant');
         const moves = participantStore.getMoves();
 
-        participantActions.executeMoves(moves)
-            .then(function() {
-                participantActions.clearMoves();
-                this.closePane();
-            }.bind(this));
+        participantActions.executeMoves(moves);
     }
 
     onResetClick(ev) {
@@ -69,7 +65,6 @@ export default class MoveParticipantsPane extends PaneBase {
         const moves = participantStore.getMoves();
 
         participantActions.undoMoves(moves);
-        participantActions.clearMoves();
 
         this.closePane();
     }

--- a/src/js/components/panes/MoveParticipantsPane.jsx
+++ b/src/js/components/panes/MoveParticipantsPane.jsx
@@ -30,10 +30,10 @@ export default class MoveParticipantsPane extends PaneBase {
         return [
             <ul className="movelist">
             {data.moves.map(function(move) {
-                var key = [move.person, move.from, move.to].join(',');
-                var person = peopleStore.getPerson(move.person);
-                var fromAction = actionStore.getAction(move.from);
-                var toAction = actionStore.getAction(move.to);
+                const key = [move.person, move.from, move.to].join(',');
+                const person = peopleStore.getPerson(move.person);
+                const fromAction = actionStore.getAction(move.from);
+                const toAction = actionStore.getAction(move.to);
 
                 return (
                     <li key={ key }>
@@ -41,6 +41,11 @@ export default class MoveParticipantsPane extends PaneBase {
                             onClick={ this.onPersonClick.bind(this, person) }/>
                         <Action action={ fromAction }/>
                         <Action action={ toAction }/>
+
+                        <input type="button" value="Execute"
+                            onClick={ this.onMoveExecute.bind(this, move) }/>
+                        <input type="button" value="Cancel"
+                            onClick={ this.onMoveCancel.bind(this, move) }/>
                     </li>
                 );
             }, this)}
@@ -54,6 +59,18 @@ export default class MoveParticipantsPane extends PaneBase {
 
     onPersonClick(person) {
         this.openPane('person', person.id);
+    }
+
+    onMoveExecute(move) {
+        const participantActions = this.getActions('participant');
+
+        participantActions.executeMoves([ move ]);
+    }
+
+    onMoveCancel(move) {
+        const participantActions = this.getActions('participant');
+
+        participantActions.undoMoves([ move ]);
     }
 
     onExecuteClick(ev) {

--- a/src/js/components/sections/SectionBase.jsx
+++ b/src/js/components/sections/SectionBase.jsx
@@ -230,9 +230,14 @@ export default class SectionBase extends FluxComponent {
         const router = this.context.router;
         const basePath = router.getMatch().matchedPath;
         const subPath = router.getMatch().unmatchedPath || '';
+        const subPathSegments = subPath? subPath.split('/') : [];
+
+        // Make sure that newSegment is unique
+        const subPathFiltered = subPathSegments.filter(s => s != newSegment);
 
         // Add segment at the end
-        const path = basePath + '/' + subPath + '/' + newSegment;
+        subPathFiltered.push(newSegment);
+        const path = [ basePath ].concat(subPathFiltered).join('/');
 
         router.navigate(path);
     }

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -23,11 +23,8 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
     componentDidMount() {
         this.listenTo('action', this.forceUpdate);
         this.listenTo('campaign', this.forceUpdate);
-        this.listenTo('participant', this.onParticipantStoreUpdate);
         this.getActions('action').retrieveAllActions();
         this.getActions('campaign').retrieveCampaigns();
-
-        this.openMovePane();
     }
 
     renderPaneContent() {
@@ -46,7 +43,8 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
             }
             else {
                 viewComponent = <ActionList actions={ actions }
-                        onActionOperation={ this.onActionOperation.bind(this) }/>;
+                    onMoveParticipant={ this.onMoveParticipant.bind(this) }
+                    onActionOperation={ this.onActionOperation.bind(this) }/>;
             }
         }
         else {
@@ -84,16 +82,15 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         }
     }
 
-    onParticipantStoreUpdate() {
-        this.openMovePane();
-    }
+    onMoveParticipant(action, person, oldAction) {
+        this.getActions('participant').moveParticipant(
+            person.id, oldAction.id, action.id);
 
-    openMovePane() {
         const participantStore = this.getStore('participant');
         const moves = participantStore.getMoves();
 
         if (moves.length) {
-            this.openPane('moveparticipants');
+            this.pushPane('moveparticipants');
         }
     }
 }

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -121,10 +121,18 @@
     }
 
     li {
+        @include card;
+
         list-style-type: none;
-        padding-left: 0;
+        padding: 1em;
         margin: 1em 0;
         font-size: 1.1em;
+
+        input[type=button] {
+            width: 48%;
+            float: left;
+            margin: 1em 1% 0.5em;
+        }
 
         &::after {
             content: "";
@@ -145,7 +153,6 @@
 
             padding: 0.5em;
             padding: 0.5em;
-            background-color: #eee;
 
             .date, .activity, .location {
                 display: block;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -135,6 +135,7 @@
         .person {
             display: block;
             font-weight: bold;
+            cursor: pointer;
         }
 
         .action {


### PR DESCRIPTION
This PR contains several improvements to the `MoveParticipantsPane` and code related to moving participants.

* Always open `MoveParticipantsPane` on top and never allow more than one open
* Add individual execute/undo buttons to moves
* Remove undone/executed moves from store, ridding the nead for `clearMoves()`
* Improve styling of `MoveParticipantsPane`

![image](https://cloud.githubusercontent.com/assets/550212/9682929/7c0c952e-530b-11e5-8066-b2ba0acb7876.png)


The PR also adds logic to load actions from `ActionDayPane` if the store is empty.

Closes #138.