### PR TITLE
PeopleList optimization

### DIFF
--- a/src/js/components/misc/peoplelist/PeopleList.jsx
+++ b/src/js/components/misc/peoplelist/PeopleList.jsx
@@ -4,6 +4,10 @@ import PeopleListItem from './PeopleListItem';
 
 
 export default class PeopleList extends React.Component {
+    shouldComponentUpdate(nextProps, nextState) {
+        return (nextProps.people !== this.props.people);
+    }
+
     render() {
         const people = this.props.people;
 

--- a/src/js/components/misc/peoplelist/PeopleListItem.jsx
+++ b/src/js/components/misc/peoplelist/PeopleListItem.jsx
@@ -4,6 +4,11 @@ import DraggableAvatar from '../DraggableAvatar';
 
 
 export default class PeopleListItem extends React.Component {
+    shouldComponentUpdate(nextProps, nextState) {
+        return (nextProps.person !== this.props.person
+            || nextProps.onSelect !== this.props.onSelect);
+    }
+
     render() {
         const person = this.props.person;
 

--- a/src/js/stores/person.js
+++ b/src/js/stores/person.js
@@ -59,14 +59,14 @@ export default class PersonStore extends Store {
         StoreUtils.updateOrAdd(people, person.id, person);
 
         this.setState({
-            people: people
+            people: people.concat()
         });
     }
 
     onCreatePersonComplete(res) {
         this.state.people.push(res.data.data);
         this.setState({
-            people: this.state.people
+            people: this.state.people.concat()
         });
     }
 
@@ -77,14 +77,14 @@ export default class PersonStore extends Store {
         StoreUtils.updateOrAdd(people, person.id, person);
 
         this.setState({
-            people: people
+            people: people.concat()
         });
     }
 
     onDeletePersonBegin(personId) {
         StoreUtils.remove(this.state.people, personId);
         this.setState({
-            people: this.state.people
+            people: this.state.people.concat()
         });
     }
 


### PR DESCRIPTION
This PR makes data in the people store pseudo-immutable, by making sure that whenever the people array changes it gets copied. This means that data can be relied upon to not change unless the entire list is replaced, which is used to deduce whether the `PeopleList` and `PeopleListItem` components need to render, in their respective `shouldComponentUpdate()` methods.

Closes #130.