### PR TITLE
Better campaign player

### DIFF
--- a/src/js/components/forms/inputs/InputBase.jsx
+++ b/src/js/components/forms/inputs/InputBase.jsx
@@ -8,7 +8,7 @@ export default class InputBase extends React.Component {
 
     render() {
         return (
-            <div>
+            <div className={ this.props.className }>
                 <label>{ this.props.label }</label>
                 { this.renderInput() }
             </div>
@@ -23,5 +23,6 @@ export default class InputBase extends React.Component {
 InputBase.propTypes = {
     name: React.PropTypes.string.isRequired,
     label: React.PropTypes.string.isRequired,
-    initialValue: React.PropTypes.string
+    initialValue: React.PropTypes.string,
+    className: React.PropTypes.string
 }

--- a/src/js/components/misc/CampaignSelect.jsx
+++ b/src/js/components/misc/CampaignSelect.jsx
@@ -15,6 +15,7 @@ export default class CampaignSelect extends FluxComponent {
 
         return (
             <RelSelectInput value={ selected } objects={ campaigns }
+                className='campaignselect'
                 showEditLink={ true } allowNull={ true }
                 nullLabel="Any campaign"
                 onEdit={ this.props.onEdit }

--- a/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/js/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -51,7 +51,12 @@ export default class CampaignPlayer extends React.Component {
         const ctrDOMNode = React.findDOMNode(this.refs.mapContainer);
         const mapOptions = {
             center: { lat: centerLat, lng: centerLng },
-            zoom: 11
+            zoom: 11,
+            disableDefaultUI: true,
+            zoomControl: true,
+            zoomControlOptions: {
+                position: google.maps.ControlPosition.LEFT_CENTER
+            }
         };
 
         this.map = new google.maps.Map(ctrDOMNode, mapOptions);

--- a/src/js/components/misc/campaignplayer/Transport.jsx
+++ b/src/js/components/misc/campaignplayer/Transport.jsx
@@ -12,12 +12,17 @@ export default class Transport extends React.Component {
             'stop-btn': this.props.playing
         });
 
+        const d = Date.utc.create(this.props.time);
+        const timeLabel = d.setUTC(true).format('{yyyy}-{MM}-{dd} {HH}:{mm}');
+
         return (
             <div className="transport">
                 <button className={ btnClass }
                     onClick={ this.onPlayStopClick.bind(this) }/>
+                <span className="transport-time">{ timeLabel }</span>
                 <Scrubber time={ this.props.time }
-                    startTime={ this.props.startTime } endTime={ this.props.endTime }
+                    startTime={ this.props.startTime }
+                    endTime={ this.props.endTime }
                     onScrubBegin={ this.props.onScrubBegin }
                     onScrubEnd={ this.props.onScrubEnd }
                     onScrub={ this.props.onScrub }/>

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -44,16 +44,7 @@ export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
                 onEdit={ this.onEditCampaign.bind(this) }/>,
             <CampaignPlayer key="player"
                 actions={ actions } locations={ locations }
-                centerLat={ center.lat } centerLng={ center.lng }
-                onActionsChange={ this.onActionsChange.bind(this) }/>
+                centerLat={ center.lat } centerLng={ center.lng }/>
         ];
-    }
-
-    onActionsChange(actions) {
-        const actionActions = this.getActions('action');
-        const actionIds = actions.map(a => a.id);
-
-        actionActions.clearActionHighlights();
-        actionActions.highlightActions(actionIds);
     }
 }

--- a/src/scss/campaignplayer/_base.scss
+++ b/src/scss/campaignplayer/_base.scss
@@ -14,6 +14,14 @@
 
         box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
 
+        .transport-time {
+            position: absolute;
+            left: 77px;
+            top: 14px;
+            font-size: 1.2em;
+            color: #aaa;
+        }
+
         .btn {
             width: 5em;
             height: 5em;
@@ -41,7 +49,7 @@
     .scrubber {
         position: absolute;
         top: 1.25em;
-        left: 8em;
+        left: 180px;
         right: 1em;
 
         &::before {

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -172,6 +172,39 @@
     }
 }
 
+.section-pane-playback {
+    header {
+        position: relative;
+        z-index: 2;
+    }
+
+    .campaignselect {
+        position: relative;
+        z-index: 2;
+    }
+
+    .campaignplayer {
+        .heatmap {
+            position: absolute;
+            z-index: 1;
+            top: 130px;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            height: auto;
+        }
+
+        .transport {
+            position: absolute;
+            z-index: 2;
+            bottom: 20px;
+            left: 40px;
+            right: 40px;
+            width: auto;
+        }
+    }
+}
+
 .section-pane-editcampaign {
     min-width: 400px;
 }


### PR DESCRIPTION
This PR enhances the campaign player in several ways. It improves the performance by disabling the heavy mini-calendar highlights. It might be possible to add this back once stores are immutable.

The PR also adds a time label to the player transport, and re-styles the entire `CampaignPlaybackPane` with a full-screen map and the transport at the bottom.

![image](https://cloud.githubusercontent.com/assets/550212/9683911/74804630-5314-11e5-975c-6e852288c504.png)

This pane will still need to be revisited, and especially the campaign select box, once a new solution for headers has been developed, as discussed in #115.

Closes #125.