### PR TITLE
Fix search issue with old results lingering

### DIFF
--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -103,17 +103,15 @@ export default class SearchStore extends Store {
         }
         else {
             // Remove results that no longer match
-            this.setState({
-                results: initialResults
-                    .filter(r => searchMatches(query, r.data))
-            });
+            var results = initialResults
+                .filter(r => searchMatches(query, r.data));
 
             // TODO: When queries are in the platform, move this server-side
             // Search for person queries (inconveniantly named "queries" like
             // the search query string that is the input to this function).
             const queries = this.flux.getStore('query').getQueries();
             this.setState({
-                results: this.state.results.concat(queries
+                results: results.concat(queries
                     .filter(q => searchMatches(query, q))
                     .map(q => ({ type: 'query', data: q })))
             });


### PR DESCRIPTION
When stored query searching was implemented this introduced an issue with old
search matches not being properly cleaned out as the search string changed.