### PR TITLE
Hand Person "name" attribute

### DIFF
--- a/src/js/components/misc/Avatar.jsx
+++ b/src/js/components/misc/Avatar.jsx
@@ -5,7 +5,9 @@ export default class Avatar extends React.Component {
     render() {
         const person = this.props.person;
         const src = '//avatars.zetk.in/avatar/' + person.id;
-        const alt = person.first_name + ' ' + person.last_name;
+        const alt = (person.first_name && person.last_name)?
+            person.first_name + ' ' + person.last_name :
+            person.name? person.name : '';
 
         return (
             <img className="avatar" src={ src } alt={ alt } title={ alt }/>

--- a/src/js/components/misc/elements/Person.jsx
+++ b/src/js/components/misc/elements/Person.jsx
@@ -3,8 +3,10 @@ import React from 'react/addons';
 
 export default class Person extends React.Component {
     render() {
-        var person = this.props.person;
-        var fullName = person.first_name + ' ' + person.last_name;
+        const person = this.props.person;
+        const fullName = (person.first_name && person.last_name)?
+            person.first_name + ' ' + person.last_name :
+            person.name? person.name : '';
 
         return (
             <span className="person" onClick={ this.props.onClick }>


### PR DESCRIPTION
In many cases, a person object will not be a full object but the smaller version available in many relationships. This PR makes sure that `Person` and `Avatar` components handle these cases and still display the correct name, from the `name` attribute instead of the `first_name` and `last_name` attributes.

Fixes #167