### PR TITLE
Never empty ActionCalendar

### DIFF
--- a/src/js/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/js/components/misc/actioncal/ActionCalendar.jsx
@@ -26,6 +26,12 @@ export default class ActionCalendar extends React.Component {
         // Always end on next Sunday
         endDate.setDate(endDate.getDate() + (7 - endDate.getDay()));
 
+        // Always show at least one month
+        const duration = endDate.getTime() - startDate.getTime();
+        if (duration < (31 * 24 * 60 * 60 * 1000)) {
+            endDate.setMonth(endDate.getMonth() + 1);
+        }
+
         var d = new Date(startDate.toDateString());
         var weeks = [];
         var days = [];

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -32,24 +32,30 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         var actions = actionStore.getActions();
         var viewComponent;
 
-        if (actions.length) {
-            if (this.state.viewMode == 'cal') {
-                viewComponent = <ActionCalendar actions={ actions }
-                        onSelectDay={ this.onSelectDay.bind(this) }
-                        onAddAction={ this.onCalendarAddAction.bind(this) }
-                        onMoveAction={ this.onCalendarMoveAction.bind(this) }
-                        onCopyAction={ this.onCalendarCopyAction.bind(this) }
-                        onSelectAction={ this.onSelectAction.bind(this) }/>
-            }
-            else {
-                viewComponent = <ActionList actions={ actions }
-                    onMoveParticipant={ this.onMoveParticipant.bind(this) }
-                    onActionOperation={ this.onActionOperation.bind(this) }/>;
-            }
+        var startDate, endDate;
+        if (actions.length == 0) {
+            // Use this week and the next month by default
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = now.getMonth();
+            const date = now.getDate();
+            startDate = new Date(year, month, date - 5);
+            endDate = new Date(year, month, date + 30);
+        }
+
+        if (this.state.viewMode == 'cal') {
+            viewComponent = <ActionCalendar actions={ actions }
+                    startDate={ startDate } endDate={ endDate }
+                    onSelectDay={ this.onSelectDay.bind(this) }
+                    onAddAction={ this.onCalendarAddAction.bind(this) }
+                    onMoveAction={ this.onCalendarMoveAction.bind(this) }
+                    onCopyAction={ this.onCalendarCopyAction.bind(this) }
+                    onSelectAction={ this.onSelectAction.bind(this) }/>
         }
         else {
-            // TODO: Show loading indicator
-            viewComponent = null;
+            viewComponent = <ActionList actions={ actions }
+                onMoveParticipant={ this.onMoveParticipant.bind(this) }
+                onActionOperation={ this.onActionOperation.bind(this) }/>;
         }
 
         const viewStates = {


### PR DESCRIPTION
This PR makes sure that if there are no actions to be shown in `AllActionsPane`, the `ActionCalendar` will be rendered with a default start and end date 31 days apart around today. It also makes sure that even if there are only a few actions, there will still never be less than one month visible.