### PR TITLE
Better header look in ActionDay

### DIFF
--- a/src/js/components/misc/actioncal/ActionDay.jsx
+++ b/src/js/components/misc/actioncal/ActionDay.jsx
@@ -68,10 +68,10 @@ export default class ActionDay extends React.Component {
 
         return this.props.connectDropTarget(
             <div className={ classes }>
-                <h3 onClick={ this.onDayClick.bind(this) }>
+                <h4 onClick={ this.onDayClick.bind(this) }>
                     <span className="date">{ dateLabel }</span>
                     <span className="weekday">{ dayLabel }</span>
-                </h3>
+                </h4>
                 <CSSTransitionGroup transitionName="actionitem" component="ul">
                 { actions.map(function(action) {
                     return <ActionItem key={ action.id } action={ action }

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -49,19 +49,21 @@
         background-color: #eee;
     }
 
-    &.today h3 {
+    &.today h4 {
         border: 1px solid #aaa;
     }
 
-    h3 {
+    h4 {
+        font-size: 11px;
         margin: 0 0 0.1em;
         padding: 0.5em 1em;
         background-color: white;
+        color: #666;
         box-shadow: 0 0 0.1em rgba(0,0,0,0.1);
         cursor: pointer;
 
         .date {
-            font-size: 1.3em;
+            font-size: 1.1em;
             font-weight: bold;
             padding-right: 0.5em;
         }
@@ -104,7 +106,8 @@
         }
     }
 
-    h3 {
+    h4 {
+        font-size: 11px;
         cursor: pointer;
         margin: 0.5em 0;
         color: #999;


### PR DESCRIPTION
Makes the headers smaller and lighter to make them stand out less.

![image](https://cloud.githubusercontent.com/assets/550212/9698879/5264992c-53cb-11e5-9e25-f891ea93ba84.png)
