### PR TITLE
Time inputs

### DIFF
--- a/src/js/components/forms/ActionForm.jsx
+++ b/src/js/components/forms/ActionForm.jsx
@@ -42,7 +42,7 @@ export default class ActionForm extends FluxComponent {
             endDate.setUTC(true).format('{HH}:{mm}') : undefined;
 
         return (
-            <Form ref="form" {...this.props }>
+            <Form className="actionform" ref="form" {...this.props }>
                 <RelSelectInput label="Campaign" name="campaign_id"
                     objects={ campaigns } showEditLink={ true }
                     onCreate={ this.props.onCreateCampaign }

--- a/src/js/components/forms/Form.jsx
+++ b/src/js/components/forms/Form.jsx
@@ -1,4 +1,5 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 
 export default class Form extends React.Component {
@@ -19,10 +20,16 @@ export default class Form extends React.Component {
         }
 
         return (
-            <form onSubmit={ this.onSubmit.bind(this) }>
+            <form className={ this.props.className }
+                onSubmit={ this.onSubmit.bind(this) }>
                 <ul>
                 {inputs.map(function(input, index) {
-                    var props = input.props;
+                    const props = input.props;
+
+                    const classes = cx(
+                        props.className,
+                        'forminput-' + props.name
+                    );
 
                     if (props.name !== undefined
                         && !this.state.values.hasOwnProperty(props.name)) {
@@ -32,11 +39,16 @@ export default class Form extends React.Component {
 
                     props.value = this.state.values[props.name]
                     props.onValueChange = this.onValueChange.bind(this);
+
                     delete props.initialValue;
+                    delete props.className;
 
                     var elem = React.cloneElement(input, props);
 
-                    return <li key={ index }>{ elem }</li>;
+                    return (
+                        <li className={ classes } key={ index }>
+                            { elem }</li>
+                    );
                 }, this)}
                 </ul>
             </form>
@@ -87,5 +99,6 @@ export default class Form extends React.Component {
 }
 
 Form.propTypes = {
+    className: React.PropTypes.string,
     onSubmit: React.PropTypes.func
 };

--- a/src/js/components/forms/inputs/TimeInput.jsx
+++ b/src/js/components/forms/inputs/TimeInput.jsx
@@ -4,12 +4,159 @@ import InputBase from './InputBase';
 
 
 export default class TimeInput extends InputBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            hourFocused: false,
+            minuteFocused: false
+        };
+    }
+
     renderInput() {
-        const value = this.props.value;
+        const valueFields = this.props.value.split(':');
+        var hour = parseInt(valueFields[0]);
+        var minute = parseInt(valueFields[1]);
+
+        if (!this.state.hourFocused) hour = zeroPad(hour);
+        if (!this.state.minuteFocused) minute = zeroPad(minute);
 
         return (
-            <input type="time" value={ value }
-                onChange={ this.onChange.bind(this) }/>
+            <div className="timeinput">
+                <input type="text" pattern="[0-9]{1,2}"
+                    ref="hourInput" value={ hour }
+                    onFocus={ this.onHourFocus.bind(this) }
+                    onBlur={ this.onHourBlur.bind(this) }
+                    onKeyDown={ this.onHourKeyDown.bind(this) }
+                    onChange={ this.onChangeHour.bind(this) }/>
+                :
+                <input type="text" pattern="[0-9]{1,2}"
+                    ref="minuteInput" value={ minute }
+                    onFocus={ this.onMinuteFocus.bind(this) }
+                    onBlur={ this.onMinuteBlur.bind(this) }
+                    onKeyDown={ this.onMinuteKeyDown.bind(this) }
+                    onChange={ this.onChangeMinute.bind(this) }/>
+            </div>
         );
     }
+
+    onHourFocus(ev) {
+        console.log('focus hour!');
+        const hourDOMNode = React.findDOMNode(this.refs.hourInput);
+        hourDOMNode.select();
+    }
+
+    onHourBlur(ev) {
+        this.setState({
+            hourFocused: false
+        });
+    }
+
+    onMinuteFocus(ev) {
+        const minuteDOMNode = React.findDOMNode(this.refs.minuteInput);
+        minuteDOMNode.select();
+    }
+
+    onMinuteBlur(ev) {
+        this.setState({
+            minuteFocused: false
+        });
+    }
+
+    onChangeHour(ev) {
+        const value = parseInt(ev.target.value);
+        this.setHour(value);
+
+        if (ev.target.value.toString().length > 1) {
+            const minDOMNode = React.findDOMNode(this.refs.minuteInput);
+            minDOMNode.focus();
+        }
+        else {
+            this.setState({
+                hourFocused: true
+            });
+        }
+    }
+
+    onChangeMinute(ev) {
+        const value = parseInt(ev.target.value);
+
+        this.setState({
+            minuteFocused: true
+        });
+
+        this.setMinute(value);
+    }
+
+    onHourKeyDown(ev) {
+        const value = parseInt(ev.target.value);
+
+        if (ev.keyCode == 38) {
+            this.setHour(value + 1);
+            ev.preventDefault();
+        }
+        else if (ev.keyCode == 40) {
+            this.setHour(value - 1);
+            ev.preventDefault();
+        }
+        else {
+        }
+    }
+
+    onMinuteKeyDown(ev) {
+        const value = ev.target.value;
+
+        switch (ev.keyCode) {
+            case 38:
+                this.setMinute(value + 1);
+                ev.preventDefault();
+                break;
+            case 40:
+                this.setMinute(value - 1);
+                ev.preventDefault();
+                break;
+        }
+    }
+
+    setHour(hour) {
+        const valueFields = this.props.value.split(':')
+
+        if (isNaN(hour)) {
+            hour = 0;
+        }
+        else if (hour < 0) {
+            hour = 23;
+        }
+        else if (hour > 23) {
+            hour = 0;
+        }
+
+        valueFields[0] = zeroPad(hour);
+
+        const value = valueFields.join(':');
+        this.props.onValueChange(this.props.name, value);
+    }
+
+    setMinute(minute) {
+        const valueFields = this.props.value.split(':')
+
+        if (isNaN(minute)) {
+            minute = 0;
+        }
+        else if (minute < 0) {
+            minute = 59;
+        }
+        else if (minute > 59) {
+            minute = 0;
+        }
+
+        valueFields[1] = zeroPad(minute);
+
+        const value = valueFields.join(':');
+        this.props.onValueChange(this.props.name, value);
+    }
+}
+
+function zeroPad(n) {
+    return (n<10)? '0' + n : n.toString();
 }

--- a/src/scss/forms/_base.scss
+++ b/src/scss/forms/_base.scss
@@ -24,3 +24,19 @@ select{
         padding: calc(0.25em - 1px);
     }
 }
+
+.actionform {
+    .forminput-start_time {
+        width: 30%;
+        float: left;
+    }
+
+    .forminput-end_time {
+        width: 30%;
+        float: left;
+    }
+
+    .forminput-num_participants_required {
+        clear: left;
+    }
+}

--- a/src/scss/inputs/_base.scss
+++ b/src/scss/inputs/_base.scss
@@ -64,3 +64,17 @@
         }
     }
 }
+
+.timeinput {
+    input[type=text] {
+        display: inline-block;
+        width: 3em;
+        text-align: center;
+    }
+
+    &::after {
+        content: "";
+        display: block;
+        clear: both;
+    }
+}


### PR DESCRIPTION
This revamps the `TimeInput` component with custom logic instead of the browser's wonked `<input type="time">`, as discussed in #55. No good date picker was found, so the native will have to do for now.

This PR also lays out the start and end time inputs in the `ActionForm` next to eachother.

![image](https://cloud.githubusercontent.com/assets/550212/9705381/0988fc2c-54c3-11e5-8a9d-06237995cae2.png)
