### PR TITLE
Pane header revamp (WIP)

### DIFF
--- a/src/js/components/misc/ViewSwitch.jsx
+++ b/src/js/components/misc/ViewSwitch.jsx
@@ -1,16 +1,23 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 
 export default class ViewSwitch extends React.Component {
     render() {
-        var stateNames = Object.keys(this.props.states);
+        const states = this.props.states;
+        const stateNames = Object.keys(this.props.states);
 
         return (
             <div className="viewswitch">
             {stateNames.map(function(state) {
-                var label = this.props.states[state];
-                var className = label.toLowerCase();
-                return <button key={ state } className={className} onClick={ this.onLabelClick.bind(this, state) }>{ label }</button>;
+                const label = states[state];
+                const classes = cx('viewswitch-state-' + state, {
+                    'selected': (state == this.props.selected)
+                });
+
+                return <button key={ state } className={ classes }
+                    onClick={ this.onLabelClick.bind(this, state) }>
+                        { label }</button>
             }, this)}
             </div>
         );

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -1,28 +1,41 @@
 import React from 'react/addons';
+import cx from 'classnames';
 
 import FluxComponent from '../FluxComponent';
 
 
-class EmptyIndex extends React.Component {
-    render() {
-        return null;
-    }
-}
-
-class EmptyNotFound extends React.Component {
-    render() {
-        return null;
-    }
-}
-
 export default class PaneBase extends FluxComponent {
-    render() {
-        var data = this.getRenderData();
-        var classNames = ['section-pane'];
+    constructor(props) {
+        super(props);
 
-        if (this.props.paneType) {
-            classNames.push('section-pane-' + this.props.paneType);
-        }
+        this.state = {
+            scrolled: false
+        };
+    }
+
+    componentDidMount() {
+        const paneDOMNode = React.findDOMNode(this.refs.pane);
+
+        paneDOMNode.onPaneScroll = (function onPaneScroll(scrollTop) {
+            this.setState({
+                scrolled: (scrollTop != 0)
+            });
+        }).bind(this);
+    }
+
+    componentWillUnmount() {
+        const paneDOMNode = React.findDOMNode(this.refs.pane);
+        paneDOMNode.onPaneScroll = null;
+    }
+
+    render() {
+        const data = this.getRenderData();
+        const paneType = this.props.paneType;
+
+        const classes = cx('section-pane-' + paneType, {
+            'section-pane': true,
+            'scrolled': this.state.scrolled
+        });
 
         var toolbar = this.getPaneTools();
         if (toolbar) {
@@ -47,7 +60,7 @@ export default class PaneBase extends FluxComponent {
         }
 
         return (
-            <div className={ classNames.join(' ') }>
+            <div ref="pane" className={ classes }>
                 <header>
                     <div className="pane-top">
                     { this.renderPaneTop(data) }

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -24,18 +24,35 @@ export default class PaneBase extends FluxComponent {
             classNames.push('section-pane-' + this.props.paneType);
         }
 
+        var toolbar = this.getPaneTools();
+        if (toolbar) {
+            toolbar = (
+                <div className="section-pane-toolbar">
+                    { toolbar }
+                </div>
+            );
+        }
+
+        var closeButton = null;
+        if (!this.props.isBase) {
+            closeButton = (
+                <a className="section-pane-closelink"
+                    onClick={ this.onCloseClick.bind(this) }/>
+            );
+        }
+
         return (
             <div className={ classNames.join(' ') }>
                 <header>
                     <div className="pane-top">
                     { this.renderPaneTop(data) }
                     </div>
-                    <a className="section-pane-closelink"
-                        onClick={ this.onCloseClick.bind(this) }/>
-                    <h2>{ this.getPaneTitle(data) }</h2>
-                    <small>{ this.getPaneSubTitle(data) }</small>
+                    { closeButton }
+                    { toolbar }
                 </header>
                 <div className="section-pane-content">
+                    <h2>{ this.getPaneTitle(data) }</h2>
+                    <small>{ this.getPaneSubTitle(data) }</small>
                     { this.renderPaneContent(data) }
                 </div>
             </div>
@@ -43,6 +60,10 @@ export default class PaneBase extends FluxComponent {
     }
 
     renderPaneTop(data) {
+        return null;
+    }
+
+    getPaneTools(data) {
         return null;
     }
 
@@ -104,10 +125,15 @@ export default class PaneBase extends FluxComponent {
 }
 
 PaneBase.propTypes = {
+    isBase: React.PropTypes.bool,
     onClose: React.PropTypes.func,
     onReplace: React.PropTypes.func,
     onOpenPane: React.PropTypes.func,
     onPushPane: React.PropTypes.func
+};
+
+PaneBase.defaultProps = {
+    isBase: false
 };
 
 function panePathSegment(paneType, params) {

--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -33,12 +33,17 @@ export default class PaneBase extends FluxComponent {
             );
         }
 
+        var title = null;
+        var subTitle = null;
         var closeButton = null;
         if (!this.props.isBase) {
             closeButton = (
                 <a className="section-pane-closelink"
                     onClick={ this.onCloseClick.bind(this) }/>
             );
+
+            title = <h2>{ this.getPaneTitle(data) }</h2>;
+            subTitle = <small>{ this.getPaneSubTitle(data) }</small>;
         }
 
         return (
@@ -51,8 +56,8 @@ export default class PaneBase extends FluxComponent {
                     { toolbar }
                 </header>
                 <div className="section-pane-content">
-                    <h2>{ this.getPaneTitle(data) }</h2>
-                    <small>{ this.getPaneSubTitle(data) }</small>
+                    { title }
+                    { subTitle }
                     { this.renderPaneContent(data) }
                 </div>
             </div>

--- a/src/js/components/sections/SectionBase.jsx
+++ b/src/js/components/sections/SectionBase.jsx
@@ -50,7 +50,7 @@ export default class SectionBase extends FluxComponent {
             Pane = subSections[0].startPane;
             panePath = basePath + '/' + subSections[0].path;
             panes.push(
-                <Pane ref="pane0" key={ subSections[0].path }
+                <Pane ref="pane0" key={ subSections[0].path } isBase={ true }
                     onOpenPane={ this.onOpenPane.bind(this, 0) }
                     onPushPane={ this.onPushPane.bind(this) }
                     paneType={ subSections[0].path } panePath={ panePath }/>);
@@ -67,7 +67,7 @@ export default class SectionBase extends FluxComponent {
                     Pane = section.startPane;
                     panePath = basePath + '/' + section.path;
                     panes.push(
-                        <Pane ref="pane0" key={ section.path }
+                        <Pane ref="pane0" key={ section.path } isBase={ true }
                             onOpenPane={ this.onOpenPane.bind(this, 0) }
                             onPushPane={ this.onPushPane.bind(this) }
                             paneType={ section.path } panePath={ panePath }/>);
@@ -88,7 +88,7 @@ export default class SectionBase extends FluxComponent {
                 Pane = section.startPane;
                 panePath = basePath + '/' + section.path;
                 panes.push(
-                    <Pane ref="pane0" key={ section.path }
+                    <Pane ref="pane0" key={ section.path } isBase={ true }
                         onOpenPane={ this.onOpenPane.bind(this, 0) }
                         onPushPane={ this.onPushPane.bind(this) }
                         paneType={ section.path } panePath={ panePath }/>);

--- a/src/js/components/sections/campaign/ActionDistributionPane.jsx
+++ b/src/js/components/sections/campaign/ActionDistributionPane.jsx
@@ -12,6 +12,8 @@ export default class ActionDistributionPane extends CampaignSectionPaneBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         this.listenTo('action', this.forceUpdate);
         this.listenTo('campaign', this.forceUpdate);
         this.getActions('action').retrieveAllActions();
@@ -34,9 +36,6 @@ export default class ActionDistributionPane extends CampaignSectionPaneBase {
         const actions = actionStore.getActions();
 
         return [
-            <CampaignSelect
-                onCreate={ this.onCreateCampaign.bind(this) }
-                onEdit={ this.onEditCampaign.bind(this) }/>,
             <div className="locations">
                 <h3>Locations</h3>
                 <ActionDistribution actions={ actions }
@@ -54,6 +53,14 @@ export default class ActionDistributionPane extends CampaignSectionPaneBase {
                     onMouseOut={ this.onMouseOut.bind(this) }/>
             </div>
         ];
+    }
+
+    getPaneTools(data) {
+        return (
+            <CampaignSelect
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>
+        );
     }
 
     onLocMouseOver(loc) {

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -58,21 +58,22 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
                 onActionOperation={ this.onActionOperation.bind(this) }/>;
         }
 
+        return viewComponent;
+    }
+
+    getPaneTools(data) {
         const viewStates = {
             'cal': 'Calendar',
             'list': 'List'
         };
 
         return [
-            <ViewSwitch states={ viewStates }
-                selected={ this.state.viewMode }
-                onSwitch={ this.onViewSwitch.bind(this) }/>,
-
             <CampaignSelect
                 onCreate={ this.onCreateCampaign.bind(this) }
                 onEdit={ this.onEditCampaign.bind(this) }/>,
-
-            viewComponent
+            <ViewSwitch states={ viewStates }
+                selected={ this.state.viewMode }
+                onSwitch={ this.onViewSwitch.bind(this) }/>
         ];
     }
 

--- a/src/js/components/sections/campaign/AllActionsPane.jsx
+++ b/src/js/components/sections/campaign/AllActionsPane.jsx
@@ -21,6 +21,8 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         this.listenTo('action', this.forceUpdate);
         this.listenTo('campaign', this.forceUpdate);
         this.getActions('action').retrieveAllActions();

--- a/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/js/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -12,6 +12,8 @@ export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         this.listenTo('action', this.forceUpdate);
         this.listenTo('campaign', this.forceUpdate);
         this.listenTo('location', this.forceUpdate);
@@ -38,13 +40,18 @@ export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
 
         const center = locationStore.getAverageCenterOfLocations();
 
-        return [
-            <CampaignSelect
-                onCreate={ this.onCreateCampaign.bind(this) }
-                onEdit={ this.onEditCampaign.bind(this) }/>,
+        return (
             <CampaignPlayer key="player"
                 actions={ actions } locations={ locations }
                 centerLat={ center.lat } centerLng={ center.lng }/>
-        ];
+        );
+    }
+
+    getPaneTools() {
+        return (
+            <CampaignSelect
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>
+        );
     }
 }

--- a/src/js/components/sections/maps/LocationsPane.jsx
+++ b/src/js/components/sections/maps/LocationsPane.jsx
@@ -30,11 +30,6 @@ export default class LocationsPane extends PaneBase {
         // add pending to location list
         var pendingLocation = locationStore.getPendingLocation();
 
-        var switchStates = {
-            'map': 'Map',
-            'list': 'List'
-        };
-
         if (this.state.viewMode == 'map') {
             var style = {
                 position: 'absolute',
@@ -45,10 +40,6 @@ export default class LocationsPane extends PaneBase {
             };
 
             content = (
-                <div>
-                <button type="button"
-                    className={ 'locations-map-button add-map-marker' }
-                    onClick={ this.onAddClick.bind(this) } >Add</button>
                 <LocationMap style={ style } 
                     locations={ locations }
                     locationsForBounds={ locations }
@@ -56,15 +47,11 @@ export default class LocationsPane extends PaneBase {
                     ref="locationMap"
                     onLocationChange={ this.onLocationChange.bind(this) }
                     onLocationSelect={ this.onLocationSelect.bind(this) }/>
-                </div>
             );
         }
         else if (this.state.viewMode == 'list') {
             content = (
                 <div>
-                    <button type="button"
-                    className={ 'add-map-marker' }
-                    onClick={ this.onAddClick.bind(this) } >Add</button>
                     <ul>
                     {locations.map(function(loc) {
                         return (
@@ -80,14 +67,27 @@ export default class LocationsPane extends PaneBase {
 
         return (
             <div>
-                <ViewSwitch states={ switchStates }
-                    selected={ this.state.viewMode }
-                    onSwitch={ this.onViewSwitch.bind(this) }/>
-
                 { content }
             </div>
         );
     }
+
+    getPaneTools(data) {
+        const switchStates = {
+            'map': 'Map',
+            'list': 'List'
+        };
+
+        return [
+            <ViewSwitch states={ switchStates }
+                selected={ this.state.viewMode }
+                onSwitch={ this.onViewSwitch.bind(this) }/>,
+            <button type="button"
+                className={ 'add-map-marker' }
+                onClick={ this.onAddClick.bind(this) } >Add</button>
+        ];
+    }
+
     onAddClick() {
         // TODO: when in list mode what to use as center?
         var loc = {

--- a/src/js/components/sections/people/PeopleListPane.jsx
+++ b/src/js/components/sections/people/PeopleListPane.jsx
@@ -19,6 +19,8 @@ export default class PeopleListPane extends PaneBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         this.listenTo('query', this.forceUpdate);
         this.listenTo('person', this.forceUpdate);
         this.getActions('person').retrievePeople();
@@ -30,23 +32,31 @@ export default class PeopleListPane extends PaneBase {
 
         const queryId = this.state.selectedQueryId;
         const queryStore = this.getStore('query');
-        const queries = queryStore.getQueries();
 
         if (queryId) {
             people = queryStore.executeQuery(queryId, people);
         }
 
+        return (
+            <PeopleList key="peopleList" people={ people }
+                onSelect={ this.onSelect.bind(this) }/>
+        );
+    }
+
+    getPaneTools(data) {
+        const queryId = this.state.selectedQueryId;
+        const queryStore = this.getStore('query');
+        const queries = queryStore.getQueries();
+
         return [
-            <button key="addButton" className="add-person"
-            onClick={ this.onAddClick.bind(this) }>Add</button>,
             <RelSelectInput name="querySelect" value={ queryId }
                 objects={ queries } showEditLink={ true }
                 allowNull={ true } nullLabel="(Show all people)"
                 onValueChange={ this.onQueryChange.bind(this) }
                 onCreate={ this.onQueryCreate.bind(this) }
                 onEdit={ this.onQueryEdit.bind(this) }/>,
-            <PeopleList key="peopleList" people={ people }
-                onSelect={ this.onSelect.bind(this) }/>
+            <button key="addButton" className="add-person"
+                onClick={ this.onAddClick.bind(this) }>Add</button>
         ];
     }
 

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -237,6 +237,10 @@ function Pane(domElement, isBase) {
         scroll = val;
         this.contentElement.style.transform = 'translate3d(0,'+scroll+'px,0)';
         this.contentElement.style.webkitTransform = 'translate3d(0,'+scroll+'px,0)';
+
+        if (this.domElement.onPaneScroll) {
+            this.domElement.onPaneScroll(scroll);
+        }
     }
 
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -38,10 +38,11 @@ a {
 ul {
     @include list-unstyled;
 }
+
 button{
     border: 1px solid $c-ui-dark;
     background-color: $c-ui-bg;
-    padding: .25em .5em;
+    padding: 5px;
     cursor: pointer;
     &.add{
         @include icon-button($fa-var-plus);
@@ -52,19 +53,35 @@ button{
     &.add-map-marker{
         @include icon-button-add($fa-var-map-marker)
     }
-    &.calendar{
-        @include icon-button($fa-var-calendar);
-    }
-    &.list{
-        @include icon-button($fa-var-list-alt);
-    }
-    &.map{
-        @include icon-button($fa-var-map-o);
-    }
 }
 
-.viewswitch{
-    button:first-of-type{
-        border-right-width: 0;
+.viewswitch {
+    button {
+        height: 25px;
+        padding: 5px;
+
+        &:focus {
+            outline: 0;
+        }
+
+        &:first-child {
+            border-right-width: 0;
+        }
+
+        &.selected {
+            background-color: #eee;
+        }
+    }
+
+    &.viewswitch-state-calendar{
+        @include icon-button($fa-var-calendar);
+    }
+
+    &.viewswitch-state-list{
+        @include icon-button($fa-var-list-alt);
+    }
+
+    &.viewswitch-state-map{
+        @include icon-button($fa-var-map-o);
     }
 }

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -48,9 +48,11 @@ button{
         @include icon-button($fa-var-plus);
     }
     &.add-person{
+        position: relative;
         @include icon-button($fa-var-user-plus);
     }
     &.add-map-marker{
+        position: relative;
         @include icon-button-add($fa-var-map-marker)
     }
 }

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -1,8 +1,8 @@
 .actionminicalendar {
-    background-color: rgba(0,0,0,0.05);
+    background-color: #eee;
     height: 13em;
 
-    margin: 0 -2em 2em;
+    margin: 0 -2em;
     overflow-x: scroll;
     overflow-y: hidden;
     white-space: nowrap;

--- a/src/scss/inputs/_base.scss
+++ b/src/scss/inputs/_base.scss
@@ -1,9 +1,20 @@
 .relselectinput {
     position: relative;
 
+    input[type=text] {
+        height: 25px;
+        margin: 0;
+        border: 1px solid #eee;
+        background-color: white;
+
+        &:focus {
+            border: 1px solid #ddd;
+        }
+    }
+
     ul {
         position: absolute;
-        top: 2em;
+        top: 25px;
         left: 0;
         right: 0;
         z-index: 2000;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -154,6 +154,13 @@
     min-width: 400px;
 }
 
+// Person list (will get better name after SCSS refactor)
+.section-pane-list {
+    .relselectinput {
+        width: 300px;
+    }
+}
+
 .section-pane-location {
     min-width: 400px;
 }

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -166,6 +166,10 @@
 }
 
 .section-pane-locations {
+    .section-pane-toolbar {
+        position: relative;
+        z-index: 2000;
+    }
 }
 
 .section-pane-moveparticipants {

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -21,7 +21,7 @@
 
     .pane-top {
         position: relative;
-        z-index: 3000;
+        z-index: 2000;
     }
 
     .section-pane-toolbar {
@@ -43,7 +43,7 @@
             top: 0;
             left: 0;
             right: 0;
-            z-index: 3000;
+            z-index: 2000;
 
             padding: 5px 20px;
             height: 35px;
@@ -234,7 +234,7 @@
         top: 130px;
         left: 0;
         right: 0;
-        z-index: 3000;
+        z-index: 2000;
         margin: 0;
 
         padding: 5px 20px;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -19,6 +19,11 @@
         }
     }
 
+    .pane-top {
+        position: relative;
+        z-index: 3000;
+    }
+
     .section-pane-toolbar {
         padding: 20px 0;
         margin: 0 0 30px;
@@ -89,6 +94,16 @@
 }
 
 .section-pane-distribution {
+    .campaignselect {
+        width: 300px;
+    }
+
+    &.scrolled {
+        .section-pane-toolbar {
+            top: 130px;
+        }
+    }
+
     .section-pane-content {
         h3 {
             font-size: 1.5em;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -19,6 +19,16 @@
         }
     }
 
+    .section-pane-toolbar {
+        padding: 20px 0;
+        margin-bottom: 20px;
+
+        & > * {
+            display: inline-block;
+            margin-right: 20px;
+        }
+    }
+
     h3 {
         font-size: 1.5em;
     }

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -42,6 +42,10 @@
 
 .section-pane-actions {
     background-color: #fafafa;
+
+    .campaignselect {
+        width: 300px;
+    }
 }
 
 .section-pane-person {

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -222,14 +222,22 @@
 }
 
 .section-pane-playback {
-    header {
-        position: relative;
-        z-index: 2;
+    .section-pane-toolbar {
+        position: absolute;
+        top: 130px;
+        left: 0;
+        right: 0;
+        z-index: 3000;
+        margin: 0;
+
+        padding: 5px 20px;
+        height: 35px;
+        background-color: white;
+        border-bottom: 1px solid #ddd;
     }
 
     .campaignselect {
-        position: relative;
-        z-index: 2;
+        width: 300px;
     }
 
     .campaignplayer {

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -21,11 +21,33 @@
 
     .section-pane-toolbar {
         padding: 20px 0;
-        margin-bottom: 20px;
+        margin: 0 0 30px;
+        height: 50px;
+
+        transition: height 0.2s, padding-top 0.2s, background-color 0.1s;
 
         & > * {
             display: inline-block;
             margin-right: 20px;
+        }
+    }
+
+    &.scrolled {
+        .section-pane-toolbar {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 3000;
+
+            padding: 5px 20px;
+            height: 35px;
+            background-color: white;
+            border-bottom: 1px solid #ddd;
+        }
+
+        .section-pane-content {
+            padding-top: 80px;
         }
     }
 

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -108,12 +108,6 @@
 }
 
 .section-pane-locations {
-    .viewswitch {
-        position: absolute;
-        z-index: 2000;
-        bottom: 20px;
-        left: 20px;
-    }
 }
 
 .section-pane-moveparticipants {

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -143,6 +143,7 @@
         .section-pane-shader {
             display: block;
             position: absolute;
+            z-index: 2000;
             top: 0;
             left: 0;
             right: 0;

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -160,10 +160,6 @@
         header {
             margin-top: 0;
         }
-
-        .section-pane-closelink {
-            display: none;
-        }
     }
 
     section:last-child {


### PR DESCRIPTION
This PR contains a complete technical and conceptual revamp of the pane headers. It moves tools like view switches, filter selects and add buttons to the new "toolbar", and removes title text from base panes. The header/toolbar looks like regular content, but sticks to the top when scrolling a pane.

![scrollingpaneheader](https://cloud.githubusercontent.com/assets/550212/9705983/8d4b848a-54d7-11e5-85dd-5ec5e518b366.gif)

Closes #115