### PR TITLE
Native, smoother scrolling

### DIFF
--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -14,18 +14,26 @@ export default class PaneBase extends FluxComponent {
     }
 
     componentDidMount() {
-        const paneDOMNode = React.findDOMNode(this.refs.pane);
-
-        paneDOMNode.onPaneScroll = (function onPaneScroll(scrollTop) {
+        this.onPaneScroll = (function onPaneScroll(ev) {
             this.setState({
-                scrolled: (scrollTop != 0)
+                scrolled: (ev.target.scrollTop > 2)
             });
         }).bind(this);
+
+        const contentDOMNode = React.findDOMNode(this.refs.content);
+        contentDOMNode.addEventListener('scroll', this.onPaneScroll);
+
+        const scrolled = (contentDOMNode.scrollTop > 2);
+        if (scrolled != this.state.scrolled) {
+            this.setState({
+                scrolled: scrolled
+            });
+        }
     }
 
     componentWillUnmount() {
-        const paneDOMNode = React.findDOMNode(this.refs.pane);
-        paneDOMNode.onPaneScroll = null;
+        const contentDOMNode = React.findDOMNode(this.refs.content);
+        contentDOMNode.removeEventListener('scroll', this.onPaneScroll);
     }
 
     render() {
@@ -68,7 +76,7 @@ export default class PaneBase extends FluxComponent {
                     { closeButton }
                     { toolbar }
                 </header>
-                <div className="section-pane-content">
+                <div ref="content" className="section-pane-content">
                     { title }
                     { subTitle }
                     { this.renderPaneContent(data) }

--- a/src/js/utils/PaneManager.js
+++ b/src/js/utils/PaneManager.js
@@ -186,12 +186,10 @@ function Pane(domElement, isBase) {
     this.dragging = false;
     this.isBase = isBase;
 
-    var startX, startY,
-        originalX, originalY,
+    var startX, originalX,
         dragging = false,
         section = this,
         prevX, speedX,
-        prevY, speedY,
         axis;
 
     var x = 0;
@@ -227,45 +225,17 @@ function Pane(domElement, isBase) {
         return w;
     }
 
-    var scroll = 0;
-    this.getScroll = function() {
-        return scroll;
-    }
-    this.setScroll = function(val) {
-        val = Math.min(0, Math.max(val,
-                this.domElement.offsetHeight - this.contentElement.offsetHeight - 200));
-        scroll = val;
-        this.contentElement.style.transform = 'translate3d(0,'+scroll+'px,0)';
-        this.contentElement.style.webkitTransform = 'translate3d(0,'+scroll+'px,0)';
-
-        if (this.domElement.onPaneScroll) {
-            this.domElement.onPaneScroll(scroll);
-        }
-    }
-
-
     function startDragging(data) {
         axis = null;
         dragging = true;
         startX = data.pageX;
-        startY = data.pageY;
         prevX = startX;
-        prevY = startY;
         speedX = 0;
-        speedY = 0;
         originalX = section.getX();
-        originalY = section.getScroll();
     }
 
     function stopDragging() {
         dragging = false;
-    }
-
-    this.domElement.addEventListener('mousewheel', onDomElementMouseWheel);
-    function onDomElementMouseWheel(ev) {
-        if (_layout == HORIZONTAL) {
-            section.setScroll(section.getScroll() + ev.wheelDeltaY/2);
-        }
     }
 
     this.domElement.addEventListener('touchstart', onDomElementTouchStart);
@@ -298,22 +268,9 @@ function Pane(domElement, isBase) {
     function onDomElementTouchMove(ev) {
         if (dragging) {
             var touch = ev.changedTouches[0],
-                dx = touch.pageX - startX,
-                dy = touch.pageY - startY,
-                tmpAxis = null;
+                dx = touch.pageX - startX;
 
-            tmpAxis = axis || ((dx*dx > dy*dy)? 'x' : 'y');
-
-            if (!axis && (dx*dx+dy*dy) > 400) {
-                axis = tmpAxis;
-            }
-
-            if (tmpAxis=='x') {
-                speedX = (originalX + dx) - section.getX();
-            }
-            else if (tmpAxis=='y') {
-                speedY = (originalY + dy) - section.getScroll();
-            }
+            speedX = (originalX + dx) - section.getX();
         }
     }
 
@@ -329,10 +286,6 @@ function Pane(domElement, isBase) {
     }
 
     this.update = function() {
-        if (speedY*speedY > 0.01) {
-            section.setScroll(section.getScroll() + speedY);
-            speedY *= 0.95;
-        }
         if (speedX*speedX > 0.01) {
             section.setX(section.getX() + speedX);
             speedX *= 0.8;
@@ -345,7 +298,6 @@ function Pane(domElement, isBase) {
         this.domElement.removeEventListener('mousemove', onDomElementMouseMove);
         this.domElement.removeEventListener('mousedown', onDomElementMouseDown);
         this.domElement.removeEventListener('touchstart', onDomElementTouchStart);
-        this.domElement.removeEventListener('mousewheel', onDomElementMouseWheel);
 
         document.removeEventListener('touchend', stopDragging);
         document.removeEventListener('mouseup', stopDragging);

--- a/src/scss/dashboard/_medium.scss
+++ b/src/scss/dashboard/_medium.scss
@@ -1,12 +1,19 @@
 .dashboard {
-    max-width: 120em;
-    margin-left: auto;
-    margin-right: auto;
+    position: absolute;
+    left: 0;
+    right: -20px;
+    bottom: 0;
+    top: 0;
+    overflow-y: scroll;
+    padding: 0 1%;
 }
 
 .dashboard-favorites,
 .dashboard-shortcuts {
     font-size: 1.6em;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .dashboard-favorites{
@@ -22,17 +29,19 @@
     }
 }
 .dashboard-shortcuts {
-    margin: 0 2em;
-
     li{
         margin-left: 1em;
     }
 }
 .dashboard-widgets{
-    margin: 0.833em 3.2em;
     -webkit-column-count: 2;
     -moz-column-count: 2;
     column-count: 2;
+
+    max-width: 1200px;
+    margin-top: 0.833em;
+    margin-left: auto;
+    margin-right: auto;
 
     &>.dashboard-widgetcontainer {
         display: inline-block;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -2,6 +2,7 @@
     background-color: #f8f8f8;
     min-width: 400px;
     z-index: 1000;
+    padding: 0;
 
     header {
         h2 {
@@ -26,7 +27,7 @@
 
     .section-pane-toolbar {
         padding: 20px 0;
-        margin: 0 0 30px;
+        margin: 0 20px 30px;
         height: 50px;
 
         transition: height 0.2s, padding-top 0.2s, background-color 0.1s;
@@ -45,6 +46,7 @@
             right: 0;
             z-index: 2000;
 
+            margin: 0;
             padding: 5px 20px;
             height: 35px;
             background-color: white;

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -142,7 +142,7 @@
 
         .section-pane-content {
             display: block;
-            padding: 70px 20px;
+            padding: 70px 30px;
             position: absolute;
             top: 0;
             left: 0;
@@ -168,6 +168,15 @@
             background-color: rgba(0,0,0,0);
             pointer-events: none;
         }
+
+        // Use smaller padding on base pane, which does not have a close
+        // button that needs to be avoided
+        &:first-child {
+            .section-pane-content {
+                padding-left: 20px;
+            }
+        }
+
     }
 
     // TODO: Should 

--- a/src/scss/section/_medium.scss
+++ b/src/scss/section/_medium.scss
@@ -123,12 +123,16 @@
         }
 
         header {
-            margin: 50px 0px 0;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1200;
         }
 
         .section-pane-closelink {
-            top: 1em;
-            left: 1em;
+            top: 10px;
+            left: 10px;
             right: auto;
             &::before{
                 color: inherit;
@@ -138,6 +142,19 @@
 
         .section-pane-content {
             display: block;
+            padding: 70px 20px;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: -20px;
+            bottom: 0;
+            z-index: 1100;
+            overflow-y: scroll;
+            overflow-x: hidden;
+
+            h2 {
+                margin-top: 0;
+            }
         }
 
         .section-pane-shader {


### PR DESCRIPTION
This PR implements native scrolling for dashboard and all panes, instead of the custom-built scrolling that was implemented in `PaneManager`. It hides the scroll bar though, so that you don't get scrollbars visible on every pane all the time.

This fixes several registered issues. See commit messages for details.