### PR TITLE
Fix styling issues

### DIFF
--- a/src/js/components/panes/PaneBase.jsx
+++ b/src/js/components/panes/PaneBase.jsx
@@ -15,9 +15,13 @@ export default class PaneBase extends FluxComponent {
 
     componentDidMount() {
         this.onPaneScroll = (function onPaneScroll(ev) {
-            this.setState({
-                scrolled: (ev.target.scrollTop > 2)
-            });
+            const scrolled = (ev.target.scrollTop > 2);
+
+            if (scrolled != this.state.scrolled) {
+                this.setState({
+                    scrolled: scrolled
+                });
+            }
         }).bind(this);
 
         const contentDOMNode = React.findDOMNode(this.refs.content);

--- a/src/scss/actioncal/_medium.scss
+++ b/src/scss/actioncal/_medium.scss
@@ -2,7 +2,7 @@
     background-color: #eee;
     height: 13em;
 
-    margin: 0 -2em;
+    margin: 0;
     overflow-x: scroll;
     overflow-y: hidden;
     white-space: nowrap;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -69,6 +69,10 @@
     }
 }
 
+.section-pane-actionday {
+    min-width: 680px;
+}
+
 .section-pane-actions {
     background-color: #fafafa;
 

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -95,6 +95,7 @@
     min-width: 400px;
 }
 
+.section-content
 .section-pane-distribution {
     .campaignselect {
         width: 300px;
@@ -107,6 +108,8 @@
     }
 
     .section-pane-content {
+        top: 130px;
+
         h3 {
             font-size: 1.5em;
             color: #888;

--- a/src/scss/panes/_medium.scss
+++ b/src/scss/panes/_medium.scss
@@ -4,19 +4,17 @@
     z-index: 1000;
     padding: 0;
 
-    header {
-        h2 {
-            margin: 30px 0 30px;
-        }
+    h2 {
+        margin: 30px 0 30px;
+    }
 
-        small {
-            display: block;
-            margin: -15px 0 30px;
+    small {
+        display: block;
+        margin: -25px 0 30px;
 
-            a {
-                cursor: pointer;
-                text-decoration: underline;
-            }
+        a {
+            cursor: pointer;
+            text-decoration: underline;
         }
     }
 
@@ -299,7 +297,7 @@
 }
 
 .section-pane-reminder {
-    header small {
+    small {
         span {
             margin-right: 0.5em;
         }


### PR DESCRIPTION
Fix several styling related issues that have arisen due to recent updates.

* Optimize pane transition into and out of `scrolled` state.
* Fix incorrect offsets in min-calendar, causing it to "bleed" left and right.
* Offset content of `ActionDistributionPane`, which was being obscured by mini-calendar.
* Re-tweak styling of subtitles, which was disabled due to selects no longer being valid.