### PR TITLE
OpenWeaterMap API key

### DIFF
--- a/src/js/server/widgets.js
+++ b/src/js/server/widgets.js
@@ -22,6 +22,7 @@ widgets.get('/today', function(req, res) {
         const url = 'http://api.openweathermap.org/data/2.5/forecast/daily'
             .concat('?lat=' + lat)
             .concat('&lon=' + lng)
+            .concat('&APPID=' + process.env.OPENWEATHERMAP_APIKEY)
             .concat('&cnt=1&units=metric');
 
         http.get(url, function(res) {


### PR DESCRIPTION
A recent change to the OpenWeatherMap API introduces API keys as a requirement. This PR adds the ability to configure the API key using an environment variable.