### PR TITLE
Hook up person queries to API

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -73,6 +73,7 @@ export const CLEAR_SEARCH = 'CLEAR_SEARCH';
 
 // Flux actions related to queries
 export const RETRIEVE_QUERIES = 'RETRIEVE_QUERIES';
+export const RETRIEVE_QUERY = 'RETRIEVE_QUERY';
 export const RETRIEVE_QUERY_MATCHES = 'RETRIEVE_QUERY_MATCHES';
 export const CREATE_QUERY = 'CREATE_QUERY';
 export const UPDATE_QUERY_FILTER = 'UPDATE_FILTER';

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -45,8 +45,21 @@ export function retrieveQueryMatches(id) {
 }
 
 export function createQuery(title) {
-    return {
-        type: types.CREATE_QUERY,
+    return function(dispatch, getState) {
+        let orgId = getState().org.activeId;
+        let data = {
+            title: title,
+            filter_spec: [],
+        };
+
+        dispatch({
+            type: types.CREATE_QUERY,
+            meta: { title },
+            payload: {
+                promise: Z.resource('orgs', orgId,
+                    'people', 'queries').post(data),
+            },
+        });
     };
 }
 

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -86,11 +86,28 @@ export function addQueryFilter(id, filterType) {
     }
 }
 
-export function updateQueryFilter(queryId, filterIndex, filterConfig) {
-    return {
-        type: types.UPDATE_QUERY_FILTER,
-        payload: { queryId, filterIndex, filterConfig },
-    };
+export function updateQueryFilter(id, filterIndex, filterConfig) {
+    return function(dispatch, getState) {
+        let orgId = getState().org.activeId;
+        let queryList = getState().queries.queryList;
+        let queryItem = getListItemById(queryList, id);
+        let filterSpec = queryItem.data.filter_spec.concat();
+
+        filterSpec[filterIndex] = Object.assign({},
+            filterSpec[filterIndex], filterConfig);
+
+        let data = {
+            filter_spec: filterSpec,
+        };
+
+        dispatch({
+            type: types.UPDATE_QUERY_FILTER,
+            payload: {
+                promise: Z.resource('orgs', orgId,
+                    'people', 'queries', id).patch(data)
+            },
+        });
+    }
 }
 
 export function removeQueryFilter(queryId, filterIndex) {

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -110,9 +110,25 @@ export function updateQueryFilter(id, filterIndex, filterConfig) {
     }
 }
 
-export function removeQueryFilter(queryId, filterIndex) {
-    return {
-        type: types.REMOVE_QUERY_FILTER,
-        payload: { queryId, filterIndex }
-    };
+export function removeQueryFilter(id, filterIndex) {
+    return function(dispatch, getState) {
+        let orgId = getState().org.activeId;
+        let queryList = getState().queries.queryList;
+        let queryItem = getListItemById(queryList, id);
+        let filterSpec = queryItem.data.filter_spec.concat();
+
+        filterSpec.splice(filterIndex, 1);
+
+        let data = {
+            filter_spec: filterSpec,
+        };
+
+        dispatch({
+            type: types.REMOVE_QUERY_FILTER,
+            payload: {
+                promise: Z.resource('orgs', orgId,
+                    'people', 'queries', id).patch(data)
+            },
+        });
+    }
 }

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -3,11 +3,30 @@ import Z from 'zetkin';
 import * as types from '.';
 
 
-// TODO: Implement API calls for all of these
-
 export function retrieveQueries() {
-    return {
-        type: types.RETRIEVE_QUERIES,
+    return function(dispatch, getState) {
+        let orgId = getState().org.activeId;
+
+        dispatch({
+            type: types.RETRIEVE_QUERIES,
+            payload: {
+                promise: Z.resource('orgs', orgId, 'people', 'queries').get(),
+            }
+        });
+    }
+}
+
+export function retrieveQuery(id) {
+    return function(dispatch, getState) {
+        let orgId = getState().org.activeId;
+        dispatch({
+            type: types.RETRIEVE_QUERY,
+            meta: { id },
+            payload: {
+                promise: Z.resource('orgs', orgId, 'people', 'queries',
+                    id).get()
+            },
+        });
     };
 }
 

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -1,6 +1,7 @@
 import Z from 'zetkin';
 
 import * as types from '.';
+import { getListItemById } from '../utils/store';
 
 
 export function retrieveQueries() {
@@ -63,11 +64,26 @@ export function createQuery(title) {
     };
 }
 
-export function addQueryFilter(queryId, filterType) {
-    return {
-        type: types.ADD_QUERY_FILTER,
-        payload: { filterType },
-    };
+export function addQueryFilter(id, filterType) {
+    return function(dispatch, getState) {
+        let orgId = getState().org.activeId;
+        let queryList = getState().queries.queryList;
+        let queryItem = getListItemById(queryList, id);
+
+        let data = {
+            filter_spec: queryItem.data.filter_spec.concat([{
+                type: filterType,
+            }])
+        };
+
+        dispatch({
+            type: types.ADD_QUERY_FILTER,
+            payload: {
+                promise: Z.resource('orgs', orgId,
+                    'people', 'queries', id).patch(data)
+            },
+        });
+    }
 }
 
 export function updateQueryFilter(queryId, filterIndex, filterConfig) {

--- a/src/components/panes/EditQueryPane.jsx
+++ b/src/components/panes/EditQueryPane.jsx
@@ -31,9 +31,10 @@ export default class QueryPane extends PaneBase {
         for (let i = 0; i < filters.length; i++) {
             let filter = filters[i];
             let FilterComponent = resolveFilterComponent(filter.type);
+            let key = i.toString() + '-' + JSON.stringify(filter);
 
             filterElements.push(
-                <FilterComponent key={ i } config={ filter }
+                <FilterComponent key={ key } config={ filter }
                     onFilterRemove={ this.onFilterRemove.bind(this, i) }
                     onFilterChange={ this.onFilterChange.bind(this, i) }/>
             );

--- a/src/components/panes/QueryPane.jsx
+++ b/src/components/panes/QueryPane.jsx
@@ -1,13 +1,23 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import PaneBase from './PaneBase';
 import PeopleList from '../misc/peoplelist/PeopleList';
+import { getListItemById } from '../../utils/store';
+import { retrieveQuery, retrieveQueryMatches } from '../../actions/query';
 
 
+@connect(state => ({ queries: state.queries }))
 export default class QueryPane extends PaneBase {
-    getRenderData() {
-        let queryList = this.props.queries.queryList;
+    componentDidMount() {
         let queryId = this.getParam(0);
+        this.props.dispatch(retrieveQuery(queryId));
+        this.props.dispatch(retrieveQueryMatches(queryId));
+    }
+
+    getRenderData() {
+        let queryId = this.getParam(0);
+        let queryList = this.props.queries.queryList;
 
         return {
             queryItem: getListItemById(queryList, queryId)
@@ -26,17 +36,15 @@ export default class QueryPane extends PaneBase {
     }
 
     renderPaneContent(data) {
-        if (!data.queryItem) {
-            return null;
+        let item = data.queryItem;
+        if (item && item.data && item.data.matchList) {
+            let people = item.data.matchList.items;
+
+            return [
+                <PeopleList key="peopleList" people={ people }
+                    onSelect={ this.onPersonSelect.bind(this) }/>
+            ];
         }
-
-        // TODO: Use result of server-side query
-        const filteredPeople = [];
-
-        return [
-            <PeopleList key="peopleList" people={ filteredPeople }
-                onSelect={ this.onPersonSelect.bind(this) }/>
-        ];
     }
 
     onPersonSelect(person) {

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -1,16 +1,19 @@
 import { connect } from 'react-redux';
 import React from 'react';
 
-import { retrievePeople } from '../../../actions/person';
-import { retrieveQueries, createQuery } from '../../../actions/query';
-import { getListItemById } from '../../../utils/store';
-
 import PaneBase from '../../panes/PaneBase';
 import PeopleList from '../../misc/peoplelist/PeopleList';
 import RelSelectInput from '../../forms/inputs/RelSelectInput';
+import { retrievePeople } from '../../../actions/person';
+import { getListItemById } from '../../../utils/store';
+import {
+    createQuery,
+    retrieveQueries,
+    retrieveQueryMatches,
+} from '../../../actions/query';
 
 
-@connect(state => state)
+@connect(state => ({ people: state.people, queries: state.queries }))
 export default class PeopleListPane extends PaneBase {
     constructor(props) {
         super(props);
@@ -33,8 +36,17 @@ export default class PeopleListPane extends PaneBase {
     }
 
     renderPaneContent() {
-        // TODO: Handle queries correctly
         let people = this.props.people.personList.items;
+
+        if (this.state.selectedQueryId) {
+            let queryId = this.state.selectedQueryId;
+            let queryList = this.props.queries.queryList;
+            let query = getListItemById(queryList, queryId);
+
+            if (query && query.data && query.data.matchList) {
+                people = query.data.matchList.items;
+            }
+        }
 
         return (
             <PeopleList key="personList" people={ people }
@@ -73,6 +85,10 @@ export default class PeopleListPane extends PaneBase {
     }
 
     onQueryChange(name, value) {
+        if (value) {
+            this.props.dispatch(retrieveQueryMatches(value));
+        }
+
         this.setState({
             selectedQueryId: value
         });

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -46,7 +46,11 @@ export default class PeopleListPane extends PaneBase {
         let queryId = this.state.selectedQueryId;
         let queryList = this.props.queries.queryList;
         let query = getListItemById(queryList, queryId);
-        let queries = queryList.items.map(i => i.data);
+
+        // Only include queries that have a title
+        // TODO: Find some better way to filter out call assignment queries,
+        //       e.g. a proper type attribute on the query
+        let queries = queryList.items.map(i => i.data).filter(q => q.title);
 
         return [
             <RelSelectInput key="querySelect" name="querySelect"

--- a/src/server/search.js
+++ b/src/server/search.js
@@ -28,6 +28,7 @@ function search(ws, req) {
 
         if (!msg.scope || msg.scope == 'people') {
             searchFuncs.push(searchPeople);
+            searchFuncs.push(searchPersonQueries);
         }
 
         if (!msg.scope || msg.scope == 'maps') {
@@ -135,6 +136,19 @@ function searchPeople(orgId, q, writeMatch) {
                 }
             }
         })
+}
+
+function searchPersonQueries(orgId, q, writeMatch) {
+    return Z.resource('orgs', orgId, 'people', 'queries').get()
+        .then(function(result) {
+            let queries = result.data.data;
+
+            for (let i = 0; i < queries.length; i++) {
+                if (searchMatches(q, queries[i])) {
+                    writeMatch(q, 'query', queries[i]);
+                }
+            }
+        });
 }
 
 function searchLocations(orgId, q, writeMatch) {

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -29,6 +29,7 @@ export default function queries(state = null, action) {
                     query.id, query, { isPending: true }),
             });
 
+        case types.CREATE_QUERY + '_FULFILLED':
         case types.RETRIEVE_QUERY + '_FULFILLED':
             query = action.payload.data.data;
             return Object.assign({}, state, {

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -31,6 +31,7 @@ export default function queries(state = null, action) {
 
         case types.CREATE_QUERY + '_FULFILLED':
         case types.ADD_QUERY_FILTER + '_FULFILLED':
+        case types.UPDATE_QUERY_FILTER + '_FULFILLED':
         case types.RETRIEVE_QUERY + '_FULFILLED':
             query = action.payload.data.data;
             return Object.assign({}, state, {

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -36,6 +36,17 @@ export default function queries(state = null, action) {
                     query.id, query, { isPending: false, error: null }),
             });
 
+        case types.RETRIEVE_QUERY_MATCHES + '_PENDING':
+            query = {
+                id: action.meta.id,
+                matchList: createList(null, { isPending: true }),
+            };
+
+            return Object.assign({}, state, {
+                queryList: updateOrAddListItem(state.queryList,
+                    query.id, query)
+            });
+
         case types.RETRIEVE_QUERY_MATCHES + '_FULFILLED':
             query = {
                 id: action.meta.id,

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -30,6 +30,7 @@ export default function queries(state = null, action) {
             });
 
         case types.CREATE_QUERY + '_FULFILLED':
+        case types.ADD_QUERY_FILTER + '_FULFILLED':
         case types.RETRIEVE_QUERY + '_FULFILLED':
             query = action.payload.data.data;
             return Object.assign({}, state, {

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -7,10 +7,37 @@ import {
 
 
 export default function queries(state = null, action) {
-    // TODO: Implement full API communications
+    let query;
     switch (action.type) {
+        case types.RETRIEVE_QUERIES + '_PENDING':
+            return Object.assign({}, state, {
+                queryList: Object.assign({}, state.queryList, {
+                    isPending: true,
+                }),
+            });
+
+        case types.RETRIEVE_QUERIES + '_FULFILLED':
+            return Object.assign({}, state, {
+                queryList: createList(action.payload.data.data,
+                    { isPending: false, error: null })
+            });
+
+        case types.RETRIEVE_QUERY + '_PENDING':
+            query = { id: action.meta.id };
+            return Object.assign({}, state, {
+                queryList: updateOrAddListItem(state.queryList,
+                    query.id, query, { isPending: true }),
+            });
+
+        case types.RETRIEVE_QUERY + '_FULFILLED':
+            query = action.payload.data.data;
+            return Object.assign({}, state, {
+                queryList: updateOrAddListItem(state.queryList,
+                    query.id, query, { isPending: false, error: null }),
+            });
+
         case types.RETRIEVE_QUERY_MATCHES + '_FULFILLED':
-            let query = {
+            query = {
                 id: action.meta.id,
                 matchList: createList(action.payload.data.data)
             };

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -32,6 +32,7 @@ export default function queries(state = null, action) {
         case types.CREATE_QUERY + '_FULFILLED':
         case types.ADD_QUERY_FILTER + '_FULFILLED':
         case types.UPDATE_QUERY_FILTER + '_FULFILLED':
+        case types.REMOVE_QUERY_FILTER + '_FULFILLED':
         case types.RETRIEVE_QUERY + '_FULFILLED':
             query = action.payload.data.data;
             return Object.assign({}, state, {


### PR DESCRIPTION
This PR properly hooks up the person query feature to the relevent APIs. Person queries were previously implemented as a placeholder/dummy feature using LocalStorage, but was replaced with no-op actions as part of the #237 Redux refactor.