### PR TITLE
Person tags filter

### DIFF
--- a/src/components/filters/FilterList.jsx
+++ b/src/components/filters/FilterList.jsx
@@ -70,6 +70,7 @@ export default class FilterList extends React.Component {
 
             items.push(
                 <FilterListItem key={ filter.id } filter={ filter }
+                    openPane={ this.props.openPane } // TODO: Remove eventually
                     showOpSwitch={ i > 0 && !this.props.isDraggingOver }
                     onChangeConfig={ this.onChangeConfig.bind(this, i) }
                     onChangeOp={ this.onChangeOp.bind(this, i) }

--- a/src/components/filters/FilterListItem.jsx
+++ b/src/components/filters/FilterListItem.jsx
@@ -43,6 +43,7 @@ export default class FilterListItem extends React.Component {
         let filter = this.props.connectDragSource(
             <div className="FilterListItem-filter">
                 <FilterComponent config={ filterData.config }
+                    openPane={ this.props.openPane } // TODO: Remove eventually
                     onFilterRemove={ this.onRemove.bind(this) }
                     onConfigChange={ this.onChangeConfig.bind(this) }/>
             </div>

--- a/src/components/filters/PersonTagsFilter.jsx
+++ b/src/components/filters/PersonTagsFilter.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import FilterBase from './FilterBase';
+import SelectInput from '../forms/inputs/SelectInput';
+import TagCloud from '../misc/tagcloud/TagCloud';
+import { retrievePersonTags } from '../../actions/personTag';
+import { createSelection } from '../../actions/selection';
+import { getListItemById } from '../../utils/store';
+
+
+const CONDITION_OPTIONS = {
+    'all': 'All of the following tags',
+    'any': 'Any of the following tags',
+    'none': 'None of the following tags',
+};
+
+@connect(state => ({ personTags: state.personTags }))
+export default class PersonTagsFilter extends FilterBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            condition: props.config.condition,
+            tags: props.config.tags || [],
+        };
+    }
+
+    componentReceivedProps(nextProps) {
+        if (nextProps.config !== this.props.config) {
+            this.setState({
+                condition: nextProps.config.condition,
+                tags: nextProps.config.tags,
+            });
+        }
+    }
+
+    componentDidMount() {
+        let tagList = this.props.personTags.tagList;
+
+        if (tagList.items.length == 0 && !tagList.isPending) {
+            this.props.dispatch(retrievePersonTags());
+        }
+    }
+
+    renderFilterForm(config) {
+        let tagList = this.props.personTags.tagList;
+        let tags = this.state.tags
+            .map(tagId => getListItemById(tagList, tagId))
+            .filter(tagItem => tagItem)
+            .map(tagItem => tagItem.data);
+
+        return [
+            <SelectInput key="condition" name="condition"
+                label="Match people with"
+                options={ CONDITION_OPTIONS } value={ this.state.condition }
+                onValueChange={ this.onSelectCondition.bind(this) }/>,
+            <TagCloud key="tags" tags={ tags }
+                showAddButton={ true } showRemoveButtons={ true }
+                onAdd={ this.onAddTag.bind(this) }
+                onRemove={ this.onRemoveTag.bind(this) }/>
+        ];
+    }
+
+    getConfig() {
+        return {
+            condition: this.state.condition,
+            tags: this.state.tags,
+        };
+    }
+
+    onAddTag() {
+        let action = createSelection('persontag', null, null, ids => {
+            // Add new ids, making sure there are no duplicates
+            let newTags = ids.filter(id => this.state.tags.indexOf(id) < 0);
+            let tags = this.state.tags.concat(newTags);
+
+            this.setState({ tags }, () =>
+                this.onConfigChange());
+        });
+
+        this.props.dispatch(action);
+
+        // TODO: Use action in the future instead,
+        //       once panes have been refactored as a redux store
+        this.props.openPane('selectpersontags', action.payload.id);
+    }
+
+    onRemoveTag(tag) {
+        let tags = this.state.tags.filter(tagId => tagId !== tag.id);
+        this.setState({ tags }, () =>
+            this.onConfigChange());
+    }
+
+    onSelectCondition(name, value) {
+        this.setState({ condition: value }, () =>
+            this.onConfigChange());
+    }
+}

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -2,12 +2,14 @@ import CallHistoryFilter from './CallHistoryFilter';
 import CampaignFilter from './CampaignFilter';
 import JoinDateFilter from './JoinDateFilter';
 import PersonDataFilter from './PersonDataFilter';
+import PersonTagsFilter from './PersonTagsFilter';
 
 const filterComponents = {
     'call_history': CallHistoryFilter,
     'campaign_participation': CampaignFilter,
     'join_date': JoinDateFilter,
-    'person_data': PersonDataFilter
+    'person_data': PersonDataFilter,
+    'person_tags': PersonTagsFilter,
 };
 
 export function resolveFilterComponent(type) {

--- a/src/components/panes/EditQueryPane.jsx
+++ b/src/components/panes/EditQueryPane.jsx
@@ -44,7 +44,8 @@ export default class EditQueryPane extends PaneBase {
                 <QueryForm key="form" ref="form" query={ query }
                     onSubmit={ this.onSubmit.bind(this) }/>,
                 <h3 key="filterHeader">Filters</h3>,
-                <FilterList ref="filters" key="filters" filters={ filters }/>
+                <FilterList ref="filters" key="filters" filters={ filters }
+                    openPane={ this.openPane.bind(this) }/>, // TODO: Remove eventually
             ];
         }
         else {

--- a/src/components/panes/EditQueryPane.jsx
+++ b/src/components/panes/EditQueryPane.jsx
@@ -14,7 +14,7 @@ import {
 } from '../../actions/query';
 
 
-@connect(state => state)
+@connect(state => ({ queries: state.queries }))
 export default class EditQueryPane extends PaneBase {
     componentDidMount() {
         let queryId = this.getParam(0);


### PR DESCRIPTION
This PR adds a `PersonTagsFilter` component to render and edit the `person_tags` query filter type. It depends on a rather ugly hack of passing in `openPane()` into all filters (bd33565) that should be removed once pane logic has been moved to redux and panes can be opened using actions, as discussed in #245.