### PR TITLE
Action summary pane

### DIFF
--- a/src/components/lists/items/elements/ParticipantItem.jsx
+++ b/src/components/lists/items/elements/ParticipantItem.jsx
@@ -21,12 +21,13 @@ const participantSource = {
         const newAction = dropResult.newAction;
         const targetType = dropResult.targetType;
 
-        if (oldAction.id != newAction.id && dropResult.onMoveParticipant) {
-            dropResult.onMoveParticipant(person, oldAction);
-        }
-
+        // TODO: Use general-purpose onDropPerson
         if (targetType == 'contact' && dropResult.onSetContact) {
             dropResult.onSetContact(person, oldAction);
+        }
+
+        if (oldAction && oldAction.id != newAction.id && dropResult.onMoveParticipant) {
+            dropResult.onMoveParticipant(person, oldAction);
         }
     }
 }

--- a/src/components/lists/items/elements/ParticipantList.jsx
+++ b/src/components/lists/items/elements/ParticipantList.jsx
@@ -44,7 +44,7 @@ export default class ParticipantList extends React.Component {
 }
 
 ParticipantList.propTypes = {
-    maxVisible: React.PropTypes.number.isRequired,
+    maxVisible: React.PropTypes.number,
     onShowAll: React.PropTypes.func,
     action: React.PropTypes.shape({
         id: React.PropTypes.number.isRequired

--- a/src/components/lists/items/elements/ParticipantList.jsx
+++ b/src/components/lists/items/elements/ParticipantList.jsx
@@ -5,7 +5,7 @@ import ParticipantItem from './ParticipantItem';
 
 export default class ParticipantList extends React.Component {
     shouldComponentUpdate(nextProps, nextState) {
-        return (nextProps.participants
+        return (!!nextProps.participants
             && nextProps.participants != this.props.participants);
     }
 
@@ -16,7 +16,7 @@ export default class ParticipantList extends React.Component {
 
         var moreItem = null;
 
-        if (participants.length > maxVisible) {
+        if (maxVisible && participants.length > maxVisible) {
             const numAdditional = participants.length - (maxVisible - 1);
 
             moreItem = (
@@ -54,8 +54,4 @@ ParticipantList.propTypes = {
         first_name: React.PropTypes.string.isRequired,
         last_name: React.PropTypes.string.isRequired
     }))
-};
-
-ParticipantList.defaultProps = {
-    maxVisible: 4
 };

--- a/src/components/panes/ActionPane.jsx
+++ b/src/components/panes/ActionPane.jsx
@@ -165,6 +165,10 @@ export default class ActionPane extends PaneBase {
                 <div key="participants"
                     className="ActionPane-participants">
                     <h3>Participants</h3>
+                    <p>
+                        <a onClick={ this.onClickReminders.bind(this) }>
+                            Send reminders</a>
+                    </p>
                     { participantList }
                 </div>,
 
@@ -182,5 +186,10 @@ export default class ActionPane extends PaneBase {
     onClickEdit(ev) {
         let actionId = this.getParam(0);
         this.openPane('editaction', actionId);
+    }
+
+    onClickReminders(ev) {
+        let actionId = this.getParam(0);
+        this.openPane('actionreminder', actionId);
     }
 }

--- a/src/components/panes/ActionPane.jsx
+++ b/src/components/panes/ActionPane.jsx
@@ -1,17 +1,68 @@
-import React from 'react';
 import { connect } from 'react-redux';
+import { DropTarget } from 'react-dnd';
+import React from 'react';
 
 import LoadingIndicator from '../misc/LoadingIndicator';
 import PaneBase from './PaneBase';
+import ParticipantList from '../lists/items/elements/ParticipantList';
 import { getListItemById } from '../../utils/store';
 import { retrieveAction } from '../../actions/action';
+import {
+    addActionParticipant,
+    retrieveActionParticipants,
+} from '../../actions/participant';
 
 
-@connect(state => ({ actions: state.actions }))
+const actionTarget = {
+    canDrop(props, monitor) {
+        let person = monitor.getItem();
+        let actionId = props.paneData.params[0];
+        let participants = props.participants.byAction[actionId];
+        let duplicate = participants.find(p => (p.id == person.id));
+
+        // Only allow drops if it wouldn't result in duplicate
+        return (duplicate === undefined);
+    },
+
+    drop(props) {
+        let actionId = props.paneData.params[0];
+
+        return {
+            targetType: 'actionParticipant',
+            onDropPerson: person => {
+                props.dispatch(addActionParticipant(
+                    person.id, actionId));
+            },
+        };
+    }
+};
+
+function collectParticipant(connect, monitor) {
+    return {
+        connectParticipantDropTarget: connect.dropTarget(),
+        isParticipantOver: monitor.isOver(),
+        canDropParticipant: monitor.canDrop()
+    };
+}
+
+
+let select = state => ({
+    actions: state.actions,
+    participants: state.participants,
+});
+
+
+@connect(select)
+@DropTarget('person', actionTarget, collectParticipant)
 export default class ActionPane extends PaneBase {
     componentDidMount() {
         let actionId = this.getParam(0);
+
         this.props.dispatch(retrieveAction(actionId));
+
+        if (!this.props.participants.byAction[actionId]) {
+            this.props.dispatch(retrieveActionParticipants(actionId));
+        }
     }
 
     getRenderData() {
@@ -49,12 +100,36 @@ export default class ActionPane extends PaneBase {
 
     renderPaneContent(data) {
         if (data.actionItem) {
-            return (
-                <p>
-                    <a onClick={ this.onClickEdit.bind(this) }>
-                        Edit</a>
-                </p>
+            let action = data.actionItem.data;
+            let participants = this.props.participants.byAction[action.id];
+
+            let participantList = this.props.connectParticipantDropTarget(
+                <div className="ActionPane-participantDropTarget">
+                    <ParticipantList participants={ participants }/>
+                </div>
             );
+
+            return [
+                <div key="summary"
+                    className="ActionPane-summary">
+                    <span className="ActionPane-info">
+                        { action.info_text }
+                    </span>
+                    <a onClick={ this.onClickEdit.bind(this) }>
+                        Edit details</a>
+                </div>,
+
+                <div key="participants"
+                    className="ActionPane-participants">
+                    <h3>Participants</h3>
+                    { participantList }
+                </div>,
+
+                <div key="responses"
+                    className="ActionPane-responses">
+                    <h3>Responses</h3>
+                </div>
+            ];
         }
         else {
             return <LoadingIndicator/>;

--- a/src/components/panes/ActionPane.jsx
+++ b/src/components/panes/ActionPane.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import LoadingIndicator from '../misc/LoadingIndicator';
+import PaneBase from './PaneBase';
+import { getListItemById } from '../../utils/store';
+import { retrieveAction } from '../../actions/action';
+
+
+@connect(state => ({ actions: state.actions }))
+export default class ActionPane extends PaneBase {
+    componentDidMount() {
+        let actionId = this.getParam(0);
+        this.props.dispatch(retrieveAction(actionId));
+    }
+
+    getRenderData() {
+        let actionId = this.getParam(0);
+        let actionList = this.props.actions.actionList;
+
+        return {
+            actionItem: getListItemById(actionList, actionId),
+        }
+    }
+
+    getPaneTitle(data) {
+        if (data.actionItem && data.actionItem.data) {
+            let action = data.actionItem.data;
+            return 'Action: ' + action.activity.title;
+        }
+        else {
+            return 'Action';
+        }
+    }
+
+    getPaneSubTitle(data) {
+        if (data.actionItem && data.actionItem.data) {
+            let action = data.actionItem.data;
+            let startDate = Date.utc.create(action.start_time);
+            let timeLabel = startDate.setUTC(true)
+                .format('{yyyy}-{MM}-{dd}, {HH}:{mm}');
+
+            return action.location.title + ', ' + timeLabel;
+        }
+        else {
+            return null;
+        }
+    }
+
+    renderPaneContent(data) {
+        if (data.actionItem) {
+            return (
+                <p>
+                    <a onClick={ this.onClickEdit.bind(this) }>
+                        Edit</a>
+                </p>
+            );
+        }
+        else {
+            return <LoadingIndicator/>;
+        }
+    }
+
+    onClickEdit(ev) {
+        let actionId = this.getParam(0);
+        this.openPane('editaction', actionId);
+    }
+}

--- a/src/components/panes/ActionPane.scss
+++ b/src/components/panes/ActionPane.scss
@@ -1,4 +1,8 @@
 .ActionPane {
+    .ContactSlot {
+        float: none;
+    }
+
     .ParticipantList {
         float: none;
     }

--- a/src/components/panes/ActionPane.scss
+++ b/src/components/panes/ActionPane.scss
@@ -1,0 +1,5 @@
+.ActionPane {
+    .ParticipantList {
+        float: none;
+    }
+}

--- a/src/components/panes/CallAssignmentPane.jsx
+++ b/src/components/panes/CallAssignmentPane.jsx
@@ -31,7 +31,7 @@ export default class CallAssignmentPane extends PaneBase {
 
         if (assignmentItem && assignmentItem.data
             && !assignmentItem.data.statsItem) {
-            // If there are now stats for this assignment, e.g. because they
+            // If there are no stats for this assignment, e.g. because they
             // were removed by some operation that invalidated them, retrieve
             // call assignment statistics anew.
             this.props.dispatch(retrieveCallAssignmentStats(assignmentId));

--- a/src/components/panes/index.js
+++ b/src/components/panes/index.js
@@ -33,6 +33,7 @@ import SelectPersonTagsPane from './SelectPersonTagsPane';
 var _panes = {
     'action': ActionPane,
     'actionday': ActionDayPane,
+    'actionreminder': ActionReminderPane,
     'addaction': AddActionPane,
     'addactivity': AddActivityPane,
     'addcallassignment': AddCallAssignmentPane,
@@ -60,7 +61,6 @@ var _panes = {
     'moveparticipants': MoveParticipantsPane,
     'person': PersonPane,
     'query': QueryPane,
-    'reminder': ActionReminderPane,
     'selectpeople': SelectPeoplePane,
     'selectpersontags': SelectPersonTagsPane,
 };

--- a/src/components/panes/index.js
+++ b/src/components/panes/index.js
@@ -1,3 +1,4 @@
+import ActionPane from './ActionPane';
 import ActionDayPane from './ActionDayPane';
 import ActionReminderPane from './ActionReminderPane';
 import AddActionPane from './AddActionPane';
@@ -30,6 +31,7 @@ import SelectPeoplePane from './SelectPeoplePane';
 import SelectPersonTagsPane from './SelectPersonTagsPane';
 
 var _panes = {
+    'action': ActionPane,
     'actionday': ActionDayPane,
     'addaction': AddActionPane,
     'addactivity': AddActivityPane,

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -60,7 +60,7 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         }
         else {
             viewComponent = <ActionList actionList={ actionList }
-                onSelect={ this.onSelect.bind(this) }/>
+                onSelect={ item => this.onSelectAction(item.data) }/>
         }
 
         return viewComponent;
@@ -86,9 +86,5 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         this.setState({
             viewMode: state
         });
-    }
-
-    onSelect(item) {
-        this.openPane('editaction', item.data.id);
     }
 }

--- a/src/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -70,7 +70,7 @@ export default class CampaignSectionPaneBase extends PaneBase {
     }
 
     onSelectAction(action) {
-        this.openPane('editaction', action.id);
+        this.openPane('action', action.id);
     }
 
     onEditCampaign(campaign) {

--- a/src/server/datarouter.js
+++ b/src/server/datarouter.js
@@ -78,6 +78,10 @@ function waitForActions(execActions) {
 }
 
 
+router.get(/action:(\d+)$/, waitForActions(req => [
+    retrieveAction(req.params[0])
+]));
+
 router.get([/people$/, /people\/list$/], waitForActions(req => [
     retrievePeople()
 ]));


### PR DESCRIPTION
This PR adds a new `ActionPane` summary pane, to replace `EditActionPane` in most cases (except when user explicitly wants to edit the action). The `ActionPane` contains (or will at some future point contain):

* Action summary (time, location et c)
* Organizer notes for action
* List of action participants
* List of responses to be booked to action