### PR TITLE
Use new URL scheme for avatars

### DIFF
--- a/src/components/misc/Avatar.jsx
+++ b/src/components/misc/Avatar.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 
+const mapStateToProps = state => ({
+    orgId: state.org.activeId,
+});
+
+
+@connect(mapStateToProps)
 export default class Avatar extends React.Component {
     render() {
         const person = this.props.person;
-        const avatarDomain = '//avatars.' + process.env.ZETKIN_DOMAIN;
-        const src = avatarDomain + '/avatar/' + person.id;
+        const avatarDomain = '//api.' + process.env.ZETKIN_DOMAIN;
+        const src = avatarDomain + '/v1/orgs/'
+            + this.props.orgId + '/people/' + person.id + '/avatar';
+
         const alt = (person.first_name && person.last_name)?
             person.first_name + ' ' + person.last_name :
             person.name? person.name : '';


### PR DESCRIPTION
The avatars feature has been completely revamped in the Zetkin Platform. Avatars are no longer requested from a separate application, but instead using the `/avatar` suffix on the person API endpoint, which will redirect to the location of the static avatar file.

This PR updates the `Avatar` component to use this new scheme.