### PR TITLE
Fixes to misc priority bugs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/common"]
+	path = src/common
+	url = git@github.com:zetkin/zetkin-common

--- a/src/actions/person.js
+++ b/src/actions/person.js
@@ -13,7 +13,7 @@ export function createPerson(data) {
     };
 }
 
-export function retrievePeople(page = 0) {
+export function retrievePeople(page = 0, perPage = 20) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;
         dispatch({
@@ -21,7 +21,7 @@ export function retrievePeople(page = 0) {
             meta: { page },
             payload: {
                 promise: z.resource('orgs', orgId, 'people')
-                    .get(page, 20)
+                    .get(page, perPage)
             }
         });
     };

--- a/src/components/filters/CallHistoryFilter.jsx
+++ b/src/components/filters/CallHistoryFilter.jsx
@@ -25,6 +25,8 @@ export default class CallHistoryFilter extends FilterBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         let assignmentList = this.props.callAssignments.assignmentList;
 
         if (assignmentList.items.length == 0 && !assignmentList.isPending) {

--- a/src/components/filters/CampaignFilter.jsx
+++ b/src/components/filters/CampaignFilter.jsx
@@ -24,6 +24,8 @@ export default class CampaignFilter extends FilterBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         let campaignList = this.props.campaigns.campaignList;
 
         if (campaignList.items.length == 0 && !campaignList.isPending) {

--- a/src/components/filters/FilterBase.jsx
+++ b/src/components/filters/FilterBase.jsx
@@ -25,6 +25,10 @@ export default class FilterBase extends React.Component {
         );
     }
 
+    componentDidMount() {
+        this.onConfigChange();
+    }
+
     renderFilterForm(config) {
         return null;
     }

--- a/src/components/filters/PersonTagsFilter.jsx
+++ b/src/components/filters/PersonTagsFilter.jsx
@@ -32,6 +32,8 @@ export default class PersonTagsFilter extends FilterBase {
     }
 
     componentDidMount() {
+        super.componentDidMount();
+
         let tagList = this.props.personTags.tagList;
 
         if (tagList.items.length == 0 && !tagList.isPending) {

--- a/src/components/filters/PersonTagsFilter.jsx
+++ b/src/components/filters/PersonTagsFilter.jsx
@@ -17,7 +17,7 @@ export default class PersonTagsFilter extends FilterBase {
         super(props);
 
         this.state = {
-            condition: props.config.condition,
+            condition: props.config.condition || 'all',
             tags: props.config.tags || [],
         };
     }

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -241,7 +241,7 @@ export default class RelSelectInput extends InputBase {
             this.setState({
                 inputFocused: false
             });
-        }, 50);
+        }, 250);
     }
 
     createObject() {

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Logo from './Logo';
 import Search from './search/Search';
-import UserMenu from './UserMenu';
+import OrgUserMenu from './OrgUserMenu';
 
 
 export default class Header extends React.Component {
@@ -11,7 +11,7 @@ export default class Header extends React.Component {
             <header className="Header">
                 <Logo />
                 <Search onMatchNavigate={ this.props.onSearchNavigate }/>
-                <UserMenu />
+                <OrgUserMenu />
             </header>
         );
     }

--- a/src/components/header/OrgPicker.jsx
+++ b/src/components/header/OrgPicker.jsx
@@ -12,7 +12,7 @@ export default class OrgPicker extends React.Component {
 
         if(memberships.length > 1){
             return (
-                <div className="OrgPicker UserMenu-activeOrg">
+                <div className="OrgPicker OrgUserMenu-activeOrg">
                     <span className="OrgPicker-label">
                         Switch organization</span>
                     <ul className="OrgPicker-list">

--- a/src/components/header/OrgUserMenu.jsx
+++ b/src/components/header/OrgUserMenu.jsx
@@ -7,7 +7,7 @@ import Avatar from '../misc/Avatar';
 
 
 @connect(state => state)
-export default class UserMenu extends React.Component {
+export default class OrgUserMenu extends React.Component {
     render() {
         let userStore = this.props.user;
 
@@ -19,25 +19,25 @@ export default class UserMenu extends React.Component {
         const memberships = userStore.memberships;
 
         return (
-            <nav className="UserMenu">
+            <nav className="OrgUserMenu">
                 <Avatar person={ profile }/>
-                <div className="UserMenu-info">
-                    <div className="UserMenu-user">
+                <div className="OrgUserMenu-info">
+                    <div className="OrgUserMenu-user">
                         <a href={ accountUrl }>
-                            <span className="UserMenu-name">
+                            <span className="OrgUserMenu-name">
                                 { profile.name }
                             </span>
                         </a>
-                        <span className="UserMenu-org">{ activeOrg.title }</span>
+                        <span className="OrgUserMenu-org">{ activeOrg.title }</span>
                     </div>
                     <ul>
                         <li>
-                            <Link className="UserMenu-logout"
+                            <Link className="OrgUserMenu-logout"
                                 href="/logout"
                                 msgId="header.userMenu.logOutLink"/>
                         </li>
                         <li>
-                            <Link className="UserMenu-account"
+                            <Link className="OrgUserMenu-account"
                                 href={ accountUrl }
                                 msgId="header.userMenu.accountLink"/>
                         </li>

--- a/src/components/header/OrgUserMenu.scss
+++ b/src/components/header/OrgUserMenu.scss
@@ -1,4 +1,4 @@
-.UserMenu {
+.OrgUserMenu {
     display: block;
     position: absolute;
     top: 0.5em;
@@ -6,19 +6,19 @@
     font-size: 1.6em;
 
     &:hover {
-        .usermenu-info{
+        .OrgUserMenu-info{
             display: block;
         }
     }
 }
-.UserMenu .Avatar {
+.OrgUserMenu .Avatar {
     position: absolute;
     top: 0.3em;
     right: 0.3em;
     width: 2.4em;
     height: 2.4em;
 }
-.UserMenu-info{
+.OrgUserMenu-info{
     display: none;
     margin-top: 3em;
     margin-right: -0.6em;
@@ -45,30 +45,30 @@
         }
 
     }
-    .UserMenu-logout:before {
+    .OrgUserMenu-logout:before {
         @include icon($fa-var-power-off);
     }
-    .UserMenu-account:before {
+    .OrgUserMenu-account:before {
         @include icon($fa-var-user);
     }
-    .UserMenu-activeOrg:before {
+    .OrgUserMenu-activeOrg:before {
         @include icon($fa-var-sitemap);
     }
 }
-.UserMenu-name,
-.UserMenu-org{
+.OrgUserMenu-name,
+.OrgUserMenu-org{
     text-align: center;
     display: block;
 }
-.UserMenu-name{
+.OrgUserMenu-name{
 }
-.UserMenu-org{
+.OrgUserMenu-org{
     font-size: 0.7em;
     margin-top: 0.3em;
 }
 
 @include medium-screen {
-    .UserMenu {
+    .OrgUserMenu {
         transition: color 0.1s;
 
         &::before {
@@ -93,17 +93,17 @@
                 visibility: visible;
             }
 
-            .usermenu-info ul {
+            .OrgUserMenu-info ul {
                 display: block;
             }
 
             color: white;
         }
     }
-    .UserMenu .Avatar {
+    .OrgUserMenu .Avatar {
         z-index: 3000;
     }
-    .UserMenu-info {
+    .OrgUserMenu-info {
         position: absolute;
         top: 0;
         right: 0;
@@ -124,12 +124,12 @@
             margin-top: 0.8em;
         }
     }
-    .UserMenu-user{
+    .OrgUserMenu-user{
         width: 14em;
         padding: 0.5em 3.5em 0.45em 0;
     }
-    .UserMenu-name,
-    .UserMenu-org {
+    .OrgUserMenu-name,
+    .OrgUserMenu-org {
         text-align: right;
     }
 }

--- a/src/components/header/search/Search.jsx
+++ b/src/components/header/search/Search.jsx
@@ -226,7 +226,7 @@ export default class Search extends React.Component {
     onBlur(ev) {
         setTimeout(() => {
             this.props.dispatch(clearSearch());
-        }, 50);
+        }, 350);
     }
 }
 

--- a/src/components/lists/PersonList.jsx
+++ b/src/components/lists/PersonList.jsx
@@ -9,6 +9,7 @@ export default class PersonList extends React.Component {
     static propTypes = {
         allowBulkSelection: React.PropTypes.bool,
         bulkSelection: React.PropTypes.object,
+        enablePagination: React.PropTypes.bool,
         onItemSelect: React.PropTypes.func,
         onItemClick: React.PropTypes.func,
         personList: React.PropTypes.shape({
@@ -39,7 +40,7 @@ export default class PersonList extends React.Component {
             <List className="PersonList"
                 headerColumns={ columns } itemComponent={ PersonListItem }
                 list={ this.props.personList }
-                enablePagination={ true }
+                enablePagination={ !!this.props.enablePagination }
                 allowBulkSelection={ this.props.allowBulkSelection }
                 bulkSelection={ this.props.bulkSelection }
                 onItemSelect={ this.props.onItemSelect }

--- a/src/components/lists/items/CallAssignmentListItem.jsx
+++ b/src/components/lists/items/CallAssignmentListItem.jsx
@@ -18,9 +18,25 @@ export default class CallAssignmentListItem extends React.Component {
     };
 
     componentDidMount() {
-        let assignment = this.props.data
-        this.props.dispatch(retrieveCallAssignmentStats(assignment.id));
-        this.props.dispatch(retrieveCallAssignmentCallers(assignment.id));
+        let assignment = this.props.data;
+        if (!assignment.statsItem) {
+            this.props.dispatch(retrieveCallAssignmentStats(assignment.id));
+        }
+
+        if (!assignment.callerList) {
+            this.props.dispatch(retrieveCallAssignmentCallers(assignment.id));
+        }
+    }
+
+    componentWillUpdate(nextProps, nextState) {
+        let assignment = nextProps.data;
+        if (!assignment.statsItem) {
+            this.props.dispatch(retrieveCallAssignmentStats(assignment.id));
+        }
+
+        if (!assignment.callerList) {
+            this.props.dispatch(retrieveCallAssignmentCallers(assignment.id));
+        }
     }
 
     render() {
@@ -29,10 +45,11 @@ export default class CallAssignmentListItem extends React.Component {
         let goalStats = null;
         let participantList = null;
 
-        if (!assignment.statsItem || assignment.statsItem.isPending) {
+        if (assignment.statsItem && assignment.statsItem.isPending) {
             targetStats = <LoadingIndicator/>;
             goalStats = <LoadingIndicator/>;
-        } else {
+        }
+        else if (assignment.statsItem && assignment.statsItem.data) {
             let stats = assignment.statsItem.data;
             targetStats = (
                 <h1 key="targetStatsHeader">
@@ -46,9 +63,10 @@ export default class CallAssignmentListItem extends React.Component {
             );
         }
 
-        if (!assignment.callerList || assignment.callerList.isPending) {
+        if (assignment.callerList && assignment.callerList.isPending) {
             participantList = <LoadingIndicator/>
-        } else {
+        }
+        else if (assignment.callerList) {
             let participants = assignment.callerList.items.map(p => p.data);
             participantList = <ParticipantList
                 maxVisible={ 4 }

--- a/src/components/misc/actioncal/ActionDay.jsx
+++ b/src/components/misc/actioncal/ActionDay.jsx
@@ -66,7 +66,7 @@ export default class ActionDay extends React.Component {
         });
 
         var dropHint = null;
-        if (this.props.isOver) {
+        if (false && this.props.isOver) { // TODO: Add back once cloning works
             dropHint = <span className="cloneHint">
                 Hold <code>shift</code> to copy action.</span>;
         }

--- a/src/components/panes/SelectPeoplePane.jsx
+++ b/src/components/panes/SelectPeoplePane.jsx
@@ -18,7 +18,7 @@ import {
 @injectIntl
 export default class SelectPeoplePane extends PaneBase {
     componentDidMount() {
-        this.props.dispatch(retrievePeople());
+        this.props.dispatch(retrievePeople(null, null));
     }
 
     getRenderData() {

--- a/src/components/sections/people/ImportPane.jsx
+++ b/src/components/sections/people/ImportPane.jsx
@@ -50,7 +50,7 @@ export default class ImportPane extends PaneBase {
                     <li>Tagged: { stats.num_tagged }</li>
                 </ul>,
                 <Button key="importMoreButton"
-                    labelMsg="panes.import.importMore"
+                    labelMsg="panes.import.importMoreButton"
                     onClick={ this.onClickReset.bind(this) }/>
             ];
         }

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -90,6 +90,7 @@ export default class PeopleListPane extends PaneBase {
 
         return (
             <PersonList key="personList" personList={ personList }
+                enablePagination={ true }
                 allowBulkSelection={ true }
                 bulkSelection={ selection }
                 onLoadPage={ this.onLoadPage.bind(this) }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -254,3 +254,29 @@
 @mixin col-offset($col, $sum) {
     margin-left: percentage($col/$sum);
 }
+
+@mixin circle-button($color: lighten($c-ui-bg, 1), $amount:3, $icon:false, $size:3em) {
+    width: $size;
+    height: $size;
+    padding: 0;
+    cursor: pointer;
+    border: 0;
+    border-radius: 50%;
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.15);
+    transition: box-shadow 0.3s;
+    @include button-color($color, $amount);
+    @if $icon {
+        &:before {
+            @include icon($icon);
+            line-height: 0.5em;
+            height: 0;
+        }
+    }
+    &:focus {
+        outline: none;
+    }
+    &:active {
+        box-shadow: 0 0px 1px rgba(0, 0, 0, 0.15);
+    }
+}
+

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -85,6 +85,19 @@ export default function initApp(messages) {
 }
 
 function renderReactPage(Component, req, res) {
+    // Remove all segments of path representing panes that refer to draft data,
+    // which will not be available after a refresh.
+    let pathWithoutDrafts = req.path
+        .split('/')
+        .filter(s => s.indexOf(':$') < 0 && s.indexOf(',$') < 0)
+        .join('/');
+
+    // If there were references to drafts, redirect to path without drafts.
+    if (pathWithoutDrafts !== req.path) {
+        res.redirect(pathWithoutDrafts);
+        return;
+    }
+
     try {
         req.store.dispatch(setPanesFromUrlPath(req.path));
 

--- a/src/store/callAssignments.js
+++ b/src/store/callAssignments.js
@@ -102,6 +102,17 @@ export default function callAssignments(state = null, action) {
                 return state;
             }
 
+        case types.RETRIEVE_CALL_ASSIGNMENT_CALLERS + '_PENDING':
+            assignment = {
+                id: action.meta.id,
+                callerList: createList(null, { isPending: true }),
+            };
+
+            return Object.assign({}, state, {
+                assignmentList: updateOrAddListItem(state.assignmentList,
+                    assignment.id, assignment),
+            });
+
         case types.RETRIEVE_CALL_ASSIGNMENT_CALLERS + '_FULFILLED':
             assignment = {
                 id: action.meta.id,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,8 @@ import { combineReducers, compose, applyMiddleware, createStore } from 'redux';
 import { intlReducer } from 'react-intl-redux';
 import promiseMiddleware from 'redux-promise-middleware';
 
+import loginRedirect from '../common/redux/middleware/loginRedirect';
+
 import actions from './actions';
 import actionResponses from './actionResponses';
 import activities from './activities';
@@ -67,6 +69,7 @@ export const configureStore = (initialState, z) => {
         urlMiddleware,
         promiseMiddleware(),
         thunkWithZ,
+        loginRedirect(process.env.ZETKIN_APP_ID, process.env.ZETKIN_DOMAIN),
     ];
 
     let devTools = f => f;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var webpack = require('webpack');
 
+var appId = process.env.ZETKIN_APP_ID || 'a3';
+
 module.exports = {
     entry: [
         path.join(__dirname, 'dist/organize.zetk.in/client/main.js')
@@ -8,6 +10,7 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': process.env.NODE_ENV,
+            'process.env.ZETKIN_APP_ID': JSON.stringify(appId),
             'process.env.ZETKIN_DOMAIN': '"dev.zetkin.org"',
             'process.env.GA_TRACKING_ID': '"UA-75118791-1"',
         }),


### PR DESCRIPTION
This PR contains fixes for several priority bugs ahead of the January launch.

* Remove draft references from URL when reloading (#246)
* Redirect if logged out (#327)
* Hide action clone hint since cloning doesn't work (#337)
* Fix incorrect message ID in import pane (#351)
* Load call assignment basic data, stats and callers in correct order (#343)
* Re-open search socket after error/close (#266)
* Increase delays on input blur (#304, #353)
* Disable pagination in SelectPeoplePane (#345)
* Emit initial config from filters using `onFilterChange` on `componentDidMount` (#260)
* Default to "all" for `PersonTagsFilter` (#354)