### PR TITLE
Filter drawer

### DIFF
--- a/locale/panes/allActions/sv.yaml
+++ b/locale/panes/allActions/sv.yaml
@@ -1,3 +1,7 @@
 viewModes:
     calendar: "Kalender"
     list: "Lista"
+
+filters:
+    afterDate: "Från datum"
+    beforeDate: "Till datum"

--- a/locale/panes/sv.yaml
+++ b/locale/panes/sv.yaml
@@ -1,0 +1,1 @@
+filterButton: "Visa/dölj filter"

--- a/src/actions/action.js
+++ b/src/actions/action.js
@@ -1,13 +1,29 @@
 import * as types from '.';
 
 
-export function retrieveActions() {
+export function retrieveActions(afterDate, beforeDate) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;
+
+        let filters = [];
+
+        afterDate = afterDate || getState().actions.filters.afterDate;
+        beforeDate = beforeDate || getState().actions.filters.beforeDate;
+
+        if (afterDate) {
+            filters.push(['start_time', '>', afterDate]);
+        }
+
+        if (beforeDate) {
+            filters.push(['start_time', '<', beforeDate]);
+        }
+
         dispatch({
             type: types.RETRIEVE_ACTIONS,
+            meta: { afterDate, beforeDate },
             payload: {
-                promise: z.resource('orgs', orgId, 'actions').get()
+                promise: z.resource('orgs', orgId, 'actions').get(
+                    null, null, filters),
             }
         });
     };

--- a/src/actions/action.js
+++ b/src/actions/action.js
@@ -15,7 +15,14 @@ export function retrieveActions(afterDate, beforeDate) {
         }
 
         if (beforeDate) {
-            filters.push(['start_time', '<', beforeDate]);
+            // Add one day to beforeDate, to include all actions
+            // on that day
+            let beforeDateNext = Date
+                .create(beforeDate)
+                .addDays(1)
+                .format('{yyyy}-{MM}-{dd}');
+
+            filters.push(['start_time', '<', beforeDateNext]);
         }
 
         dispatch({

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -10,10 +10,10 @@ import ReactDOM from 'react-dom';
 import svLocaleData from 'react-intl/locale-data/sv';
 import Z from 'zetkin';
 
+import polyfills from '../utils/polyfills';
 import App from '../components/App';
 import { configureStore } from '../store';
 import IntlReduxProvider from '../components/IntlReduxProvider';
-import polyfills from '../utils/polyfills';
 import { subscribeToUrlChanges } from '../store/middleware/url';
 
 

--- a/src/components/forms/inputs/DateInput.jsx
+++ b/src/components/forms/inputs/DateInput.jsx
@@ -5,7 +5,7 @@ import InputBase from './InputBase';
 
 export default class DateInput extends InputBase {
     renderInput() {
-        const value = this.props.value;
+        const value = this.props.value || '';
 
         return (
             <div className="DateInput">

--- a/src/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/components/misc/actioncal/ActionCalendar.jsx
@@ -26,8 +26,11 @@ export default class ActionCalendar extends React.Component {
         const startDay = startDate.getDay();
         startDate.setDate(startDate.getDate() + 1 - (startDay? startDay : 7));
 
-        // Always end on next Sunday
-        endDate.setDate(endDate.getDate() + (7 - endDate.getDay()));
+        // Always end on a Sunday
+        if (endDate.getDay() != 0) {
+            // End date is not a Sunday, so use next Sunday
+            endDate.setDate(endDate.getDate() + (7 - endDate.getDay()));
+        }
 
         // Always show at least one month
         const duration = endDate.getTime() - startDate.getTime();

--- a/src/components/panes/PaneBase.jsx
+++ b/src/components/panes/PaneBase.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import cx from 'classnames';
 
+import Button from '../misc/Button';
 import { componentClassNames } from '..';
 
 
@@ -10,7 +11,8 @@ export default class PaneBase extends React.Component {
         super(props);
 
         this.state = {
-            scrolled: false
+            scrolled: false,
+            showFilters: false,
         };
     }
 
@@ -45,14 +47,38 @@ export default class PaneBase extends React.Component {
         const data = this.getRenderData();
 
         const classes = cx(componentClassNames(this), {
-            'PaneBase-scrolled': this.state.scrolled
+            'PaneBase-scrolled': this.state.scrolled,
+            'PaneBase-filtersVisible': this.state.showFilters,
         });
 
+        let filterDrawer = null;
+        let filters = this.getPaneFilters(data);
         var toolbar = this.getPaneTools(data);
-        if (toolbar) {
+
+        if (filters || toolbar) {
+            let filterButton = null;
+
+            if (filters) {
+                if (this.state.showFilters) {
+                    filterDrawer = (
+                        <div className="PaneBase-filterDrawer">
+                            { filters }
+                        </div>
+                    );
+                }
+
+                filterButton = (
+                    <Button key="filterButton"
+                        className="PaneBase-filterButton"
+                        labelMsg="panes.filterButton"
+                        onClick={ this.onFilterButtonClick.bind(this) }/>
+                );
+            }
+
             toolbar = (
                 <div className="PaneBase-toolbar">
                     { toolbar }
+                    { filterButton }
                 </div>
             );
         }
@@ -88,6 +114,7 @@ export default class PaneBase extends React.Component {
                     </div>
                     { closeButton }
                     { toolbar }
+                    { filterDrawer }
                 </header>
                 <div ref="content" className="PaneBase-content">
                     { title }
@@ -108,6 +135,10 @@ export default class PaneBase extends React.Component {
     }
 
     getPaneTools(data) {
+        return null;
+    }
+
+    getPaneFilters(data) {
         return null;
     }
 
@@ -158,6 +189,12 @@ export default class PaneBase extends React.Component {
         if (this.props.onClose) {
             this.props.onClose();
         }
+    }
+
+    onFilterButtonClick() {
+        this.setState({
+            showFilters: !this.state.showFilters,
+        });
     }
 
     onCloseClick(ev) {

--- a/src/components/panes/PaneBase.jsx
+++ b/src/components/panes/PaneBase.jsx
@@ -59,13 +59,11 @@ export default class PaneBase extends React.Component {
             let filterButton = null;
 
             if (filters) {
-                if (this.state.showFilters) {
-                    filterDrawer = (
-                        <div className="PaneBase-filterDrawer">
-                            { filters }
-                        </div>
-                    );
-                }
+                filterDrawer = (
+                    <div className="PaneBase-filterDrawer">
+                        { filters }
+                    </div>
+                );
 
                 filterButton = (
                     <Button key="filterButton"

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -120,10 +120,15 @@
             left: 0;
             right: 0;
             z-index: 1;
-            max-height: 50px;
-            overflow: hidden;
             background-color: $c-ui-bg;
             transition: background-color .2s .2s, max-height .3s;
+        }
+
+        &:first-child {
+            .PaneBase-header {
+                max-height: 50px;
+                overflow: hidden;
+            }
         }
 
         .PaneBase-filterDrawer {

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -12,8 +12,7 @@
         &:first-child {
             .PaneBase-header {
                 z-index: 5;
-                background-color: rgba(lighten($c-ui-bg, 20),1);
-                height: 55px;
+                background-color: white;
                 box-shadow: 0 0 0.2em rgba(0,0,0,0.1);
             }
         }
@@ -120,10 +119,23 @@
             top: 0;
             left: 0;
             right: 0;
-            height: 60px;
             z-index: 1;
+            max-height: 50px;
+            overflow: hidden;
             background-color: $c-ui-bg;
-            transition: background-color .3s, height .3s;
+            transition: background-color .2s .2s, max-height .3s;
+        }
+
+        .PaneBase-filterDrawer {
+            padding: 1em;
+        }
+
+        &.PaneBase-filtersVisible {
+            .PaneBase-header {
+                background-color: white;
+                max-height: 400px;
+                transition: background-color .3s, max-height .5s;
+            }
         }
 
         .PaneBase-closeLink {

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -7,17 +7,6 @@
     color: lighten($c-text, .3);
     z-index: 1;
 
-    &.PaneBase-scrolled {
-
-        &:first-child {
-            .PaneBase-header {
-                z-index: 5;
-                background-color: white;
-                box-shadow: 0 0 0.2em rgba(0,0,0,0.1);
-            }
-        }
-    }
-
     .PaneBase-content {
         padding: 0 2em 2em;
 
@@ -35,12 +24,6 @@
         bottom: 0;
         pointer-events: none;
         z-index: 10;
-    }
-
-    &:first-child {
-        .PaneBase-closeLink {
-            display: none;
-        }
     }
 
     &:not(:last-child) .PaneBase-content {
@@ -124,13 +107,6 @@
             transition: background-color .2s .2s, max-height .3s;
         }
 
-        &:first-child {
-            .PaneBase-header {
-                max-height: 50px;
-                overflow: hidden;
-            }
-        }
-
         .PaneBase-filterDrawer {
             padding: 1em;
             opacity: 0;
@@ -195,23 +171,6 @@
 
         .PaneBase-shader {
             display: block;
-        }
-
-        // Use smaller padding on base pane, which does not have a close
-        // button that needs to be avoided
-        &:first-child {
-            // Base pane, always full-width and not interactive
-            left: 0;
-            right: 0;
-
-            .PaneBase-content {
-                padding-left: 20px;
-                margin-top: 1em;
-            }
-
-            header {
-                margin-top: 0;
-            }
         }
 
         &:last-child {

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -128,13 +128,20 @@
 
         .PaneBase-filterDrawer {
             padding: 1em;
+            opacity: 0;
+            transition: opacity 0.2s 0.2s;
         }
 
         &.PaneBase-filtersVisible {
             .PaneBase-header {
                 background-color: white;
                 max-height: 400px;
+                overflow: visible;
                 transition: background-color .3s, max-height .5s;
+            }
+
+            .PaneBase-filterDrawer {
+                opacity: 1;
             }
         }
 

--- a/src/components/sections/RootPaneBase.jsx
+++ b/src/components/sections/RootPaneBase.jsx
@@ -6,12 +6,13 @@ import Button from '../misc/Button';
 import { componentClassNames } from '..';
 
 
-export default class PaneBase extends React.Component {
+export default class RootPaneBase extends React.Component {
     constructor(props) {
         super(props);
 
         this.state = {
             scrolled: false,
+            showFilters: false,
         };
     }
 
@@ -46,27 +47,45 @@ export default class PaneBase extends React.Component {
         const data = this.getRenderData();
 
         const classes = cx(componentClassNames(this), {
-            'PaneBase-scrolled': this.state.scrolled,
+            'RootPaneBase-scrolled': this.state.scrolled,
+            'RootPaneBase-filtersVisible': this.state.showFilters,
         });
 
-        var title = null;
-        var subTitle = null;
-        var closeButton = null;
-        if (!this.props.isBase) {
-            closeButton = (
-                <a className="PaneBase-closelink"
-                    onClick={ this.onCloseClick.bind(this) }/>
-            );
+        let filterDrawer = null;
+        let filters = this.getPaneFilters(data);
+        var toolbar = this.getPaneTools(data);
 
-            title = <h2>{ this.getPaneTitle(data) }</h2>;
-            subTitle = <small>{ this.getPaneSubTitle(data) }</small>;
+        if (filters || toolbar) {
+            let filterButton = null;
+
+            if (filters) {
+                filterDrawer = (
+                    <div className="RootPaneBase-filterDrawer">
+                        { filters }
+                    </div>
+                );
+
+                filterButton = (
+                    <Button key="filterButton"
+                        className="RootPaneBase-filterButton"
+                        labelMsg="panes.filterButton"
+                        onClick={ this.onFilterButtonClick.bind(this) }/>
+                );
+            }
+
+            toolbar = (
+                <div className="RootPaneBase-toolbar">
+                    { toolbar }
+                    { filterButton }
+                </div>
+            );
         }
 
         let footer = null;
         let footerContent = this.renderPaneFooter(data);
         if (footerContent) {
             footer = (
-                <footer className="PaneBase-footer">
+                <footer className="RootPaneBase-footer">
                     { footerContent }
                 </footer>
             );
@@ -74,15 +93,14 @@ export default class PaneBase extends React.Component {
 
         return (
             <div ref="pane" className={ classes }>
-                <header className="PaneBase-header">
-                    <div className="PaneBase-top">
+                <header className="RootPaneBase-header">
+                    <div className="RootPaneBase-top">
                     { this.renderPaneTop(data) }
                     </div>
-                    { closeButton }
+                    { toolbar }
+                    { filterDrawer }
                 </header>
-                <div ref="content" className="PaneBase-content">
-                    { title }
-                    { subTitle }
+                <div ref="content" className="RootPaneBase-content">
                     { this.renderPaneContent(data) }
                 </div>
                 { footer }
@@ -98,11 +116,11 @@ export default class PaneBase extends React.Component {
         return null;
     }
 
-    getPaneTitle(data) {
-        throw "Must implement getPaneTitle()";
+    getPaneTools(data) {
+        return null;
     }
 
-    getPaneSubTitle(data) {
+    getPaneFilters(data) {
         return null;
     }
 
@@ -147,19 +165,20 @@ export default class PaneBase extends React.Component {
         }
     }
 
+    onFilterButtonClick() {
+        this.setState({
+            showFilters: !this.state.showFilters,
+        });
+    }
+
     onCloseClick(ev) {
         this.closePane();
     }
 }
 
-PaneBase.propTypes = {
-    isBase: React.PropTypes.bool,
+RootPaneBase.propTypes = {
     onClose: React.PropTypes.func,
     onReplace: React.PropTypes.func,
     onOpenPane: React.PropTypes.func,
     onPushPane: React.PropTypes.func
-};
-
-PaneBase.defaultProps = {
-    isBase: false
 };

--- a/src/components/sections/RootPaneBase.scss
+++ b/src/components/sections/RootPaneBase.scss
@@ -1,0 +1,138 @@
+.RootPaneBase {
+    position: absolute;
+    left: 0;
+    right: 0;
+    min-width: 400px;
+    background-color: $c-ui-bg;
+    color: lighten($c-text, .3);
+    z-index: 1;
+
+    .RootPaneBase-filterDrawer {
+        padding: 1em;
+        opacity: 0;
+        transition: opacity 0.2s 0.2s;
+    }
+
+    &.RootPaneBase-scrolled {
+        .RootPaneBase-header {
+            z-index: 5;
+            background-color: white;
+            box-shadow: 0 0 0.2em rgba(0,0,0,0.1);
+        }
+    }
+
+    .RootPaneBase-header {
+        .RootPaneBase-toolbar {
+            padding: 1em;
+            color: #666666;
+            > * { // All direct children
+                display: inline-block;
+                margin-right: 0.5em;
+                margin-bottom: 0;
+            }
+        }
+    }
+
+    .RootPaneBase-content {
+        display: block;
+        padding: 50px 30px 80px;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        overflow-y: scroll;
+        overflow-x: hidden;
+
+        &::-webkit-scrollbar { // hides scrollbar in webkit browsers.
+            width: 0px;
+            background: transparent;
+        }
+
+        h2 {
+            margin-top: 0;
+            font-size: 2.0em;
+        }
+        h3 {
+            font-size: 1.7em;
+        }
+        p {
+            font-size: 1.4em;
+            line-height: 1.8em
+        }
+        small {
+            font-size: 1.1em;
+        }
+    }
+
+    .RootPaneBase-shader {
+        display: none;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        pointer-events: none;
+        z-index: 10;
+    }
+
+    @include medium-screen {
+        top: 0;
+        bottom: 0;
+        display: block;
+
+        .RootPaneBase-header {
+            max-height: 50px;
+            overflow: hidden;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1;
+            background-color: $c-ui-bg;
+            transition: background-color .2s .2s, max-height .3s;
+        }
+
+        &.RootPaneBase-filtersVisible {
+            .RootPaneBase-header {
+                background-color: white;
+                max-height: 400px;
+                overflow: visible;
+                transition: background-color .3s, max-height .5s;
+            }
+
+            .RootPaneBase-filterDrawer {
+                opacity: 1;
+            }
+        }
+
+        // Use smaller padding on base pane, which does not have a close
+        // button that needs to be avoided
+        // Base pane, always full-width and not interactive
+        left: 0;
+        right: 0;
+
+        .RootPaneBase-content {
+            padding-left: 20px;
+            margin-top: 1em;
+        }
+
+        header {
+            margin-top: 0;
+        }
+
+        .RootPaneBase-shader {
+            display: block;
+        }
+
+        &:last-child {
+            position: absolute;
+            top: 0;
+
+            .RootPaneBase-shader {
+                display: none;
+            }
+        }
+
+    }
+}

--- a/src/components/sections/RootPaneBase.scss
+++ b/src/components/sections/RootPaneBase.scss
@@ -8,7 +8,7 @@
     z-index: 1;
 
     .RootPaneBase-filterDrawer {
-        padding: 1em;
+        padding: 0 1em;
         opacity: 0;
         transition: opacity 0.2s 0.2s;
     }
@@ -82,15 +82,19 @@
         display: block;
 
         .RootPaneBase-header {
-            max-height: 50px;
-            overflow: hidden;
             position: absolute;
             top: 0;
             left: 0;
             right: 0;
-            z-index: 1;
+            z-index: 3;
             background-color: $c-ui-bg;
-            transition: background-color .2s .2s, max-height .3s;
+            transition: background-color .2s .2s;
+        }
+
+        .RootPaneBase-filterDrawer {
+            max-height: 0;
+            transition: max-height .3s, padding 0.3s;
+            overflow: hidden;
         }
 
         &.RootPaneBase-filtersVisible {
@@ -98,11 +102,15 @@
                 background-color: white;
                 max-height: 400px;
                 overflow: visible;
-                transition: background-color .3s, max-height .5s;
+                transition: background-color .3s;
+                box-shadow: 0 0 0.2em rgba(0,0,0,0.1);
             }
 
             .RootPaneBase-filterDrawer {
                 opacity: 1;
+                padding: 1em 1em;
+                max-height: 200px;
+                transition: max-height .5s;
             }
         }
 

--- a/src/components/sections/Section.jsx
+++ b/src/components/sections/Section.jsx
@@ -59,7 +59,7 @@ export default class Section extends React.Component {
             curSubSectionIndex = 0;
             let Pane = subSections[0].startPane;
             panes.push(
-                <Pane ref="pane0" key={ subSections[0].path } isBase={ true }
+                <Pane ref="pane0" key={ subSections[0].path }
                     onOpenPane={ this.onOpenPane.bind(this, 0) }
                     onPushPane={ this.onPushPane.bind(this) }/>
             );
@@ -75,7 +75,7 @@ export default class Section extends React.Component {
 
                     let Pane = sub.startPane;
                     panes.push(
-                        <Pane ref="pane0" key={ sub.path } isBase={ true }
+                        <Pane ref="pane0" key={ sub.path }
                             onOpenPane={ this.onOpenPane.bind(this, 0) }
                             onPushPane={ this.onPushPane.bind(this) }/>
                     );
@@ -95,7 +95,7 @@ export default class Section extends React.Component {
                 let sub = subSections[0];
                 let Pane = sub.startPane;
                 panes.push(
-                    <Pane ref="pane0" key={ sub.path } isBase={ true }
+                    <Pane ref="pane0" key={ sub.path }
                         onOpenPane={ this.onOpenPane.bind(this, 0) }
                         onPushPane={ this.onPushPane.bind(this) }/>
                 );

--- a/src/components/sections/campaign/ActionDistributionPane.jsx
+++ b/src/components/sections/campaign/ActionDistributionPane.jsx
@@ -70,14 +70,6 @@ export default class ActionDistributionPane extends CampaignSectionPaneBase {
         ];
     }
 
-    getPaneTools(data) {
-        return (
-            <CampaignSelect
-                onCreate={ this.onCreateCampaign.bind(this) }
-                onEdit={ this.onEditCampaign.bind(this) }/>
-        );
-    }
-
     onLocMouseOver(loc) {
         this.props.dispatch(highlightActionLocation(loc.id));
     }

--- a/src/components/sections/campaign/ActionDistributionPane.scss
+++ b/src/components/sections/campaign/ActionDistributionPane.scss
@@ -41,7 +41,7 @@
 
     @include medium-screen {
 
-        &.PaneBase:first-child .PaneBase-content {
+        .RootPaneBase-content {
             margin-top: 13em;
         }
 

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 import ActionList from '../../lists/ActionList';
 import CampaignSelect from '../../misc/CampaignSelect';
+import DateInput from '../../forms/inputs/DateInput';
 import ActionCalendar from '../../misc/actioncal/ActionCalendar';
 import ViewSwitch from '../../misc/ViewSwitch';
 import { retrieveCampaigns } from '../../../actions/campaign';
@@ -38,17 +39,8 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         let actionList = this.props.filteredActionList;
         let viewComponent;
 
-        let startDate, endDate;
-
-        if (actionList.items.length == 0) {
-            // Use this week and the next month by default
-            const now = new Date();
-            const year = now.getFullYear();
-            const month = now.getMonth();
-            const date = now.getDate();
-            startDate = new Date(year, month, date - 5);
-            endDate = new Date(year, month, date + 30);
-        }
+        let startDate = Date.create(this.props.actions.filters.afterDate);
+        let endDate = Date.create(this.props.actions.filters.beforeDate);
 
         if (this.state.viewMode == 'cal') {
             let actions = actionList.items.map(i => i.data);
@@ -87,6 +79,18 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
             <CampaignSelect key="campaignSelect"
                 onCreate={ this.onCreateCampaign.bind(this) }
                 onEdit={ this.onEditCampaign.bind(this) }/>,
+            <div key="dateFilter" className="AllActionsPane-dateFilter">
+                <DateInput name="afterDate"
+                    value={ this.props.actions.filters.afterDate }
+                    labelMsg="panes.allActions.filters.afterDate"
+                    onValueChange={ this.onFilterAfterDateChange.bind(this) }
+                    />
+                <DateInput name="beforeDate"
+                    value={ this.props.actions.filters.beforeDate }
+                    labelMsg="panes.allActions.filters.beforeDate"
+                    onValueChange={ this.onFilterBeforeDateChange.bind(this) }
+                    />
+            </div>
         ];
     }
 
@@ -94,5 +98,15 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         this.setState({
             viewMode: state
         });
+    }
+
+    onFilterAfterDateChange(name, value) {
+        let beforeDate = this.props.actions.filters.beforeDate;
+        this.props.dispatch(retrieveActions(value, beforeDate));
+    }
+
+    onFilterBeforeDateChange(name, value) {
+        let afterDate = this.props.actions.filters.afterDate;
+        this.props.dispatch(retrieveActions(afterDate, value));
     }
 }

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -23,7 +23,7 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         super(props);
 
         this.state = {
-            viewMode: 'cal'
+            viewMode: 'cal',
         };
     }
 
@@ -76,12 +76,17 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         };
 
         return [
+            <ViewSwitch key="viewSwitch" states={ viewStates }
+                selected={ this.state.viewMode }
+                onSwitch={ this.onViewSwitch.bind(this) }/>,
+        ];
+    }
+
+    getPaneFilters(data) {
+        return [
             <CampaignSelect key="campaignSelect"
                 onCreate={ this.onCreateCampaign.bind(this) }
                 onEdit={ this.onEditCampaign.bind(this) }/>,
-            <ViewSwitch key="viewSwitch" states={ viewStates }
-                selected={ this.state.viewMode }
-                onSwitch={ this.onViewSwitch.bind(this) }/>
         ];
     }
 

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -39,8 +39,20 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         let actionList = this.props.filteredActionList;
         let viewComponent;
 
-        let startDate = Date.create(this.props.actions.filters.afterDate);
-        let endDate = Date.create(this.props.actions.filters.beforeDate);
+        // Use afterDate filter as startDate, or today if it's null
+        let startDate = this.props.actions.filters.afterDate?
+            Date.create(this.props.actions.filters.afterDate) : new Date();
+
+        // Default to no end date (which displays all actions) or, if there
+        // are no actions, use 8 weeks in future. If there is a filter, use
+        // that date.
+        let endDate = null;
+        if (this.props.actions.filters.beforeDate) {
+            endDate = Date.create(this.props.actions.filters.beforeDate);
+        }
+        else if (actionList.items.length == 0) {
+            endDate = startDate.clone().addDays(8 * 7);
+        }
 
         if (this.state.viewMode == 'cal') {
             let actions = actionList.items.map(i => i.data);

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -3,8 +3,6 @@ import { connect } from 'react-redux';
 
 import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 import ActionList from '../../lists/ActionList';
-import CampaignSelect from '../../misc/CampaignSelect';
-import DateInput from '../../forms/inputs/DateInput';
 import ActionCalendar from '../../misc/actioncal/ActionCalendar';
 import ViewSwitch from '../../misc/ViewSwitch';
 import { retrieveCampaigns } from '../../../actions/campaign';
@@ -86,39 +84,9 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         ];
     }
 
-    getPaneFilters(data) {
-        return [
-            <CampaignSelect key="campaignSelect"
-                onCreate={ this.onCreateCampaign.bind(this) }
-                onEdit={ this.onEditCampaign.bind(this) }/>,
-            <div key="dateFilter" className="AllActionsPane-dateFilter">
-                <DateInput name="afterDate"
-                    value={ this.props.actions.filters.afterDate }
-                    labelMsg="panes.allActions.filters.afterDate"
-                    onValueChange={ this.onFilterAfterDateChange.bind(this) }
-                    />
-                <DateInput name="beforeDate"
-                    value={ this.props.actions.filters.beforeDate }
-                    labelMsg="panes.allActions.filters.beforeDate"
-                    onValueChange={ this.onFilterBeforeDateChange.bind(this) }
-                    />
-            </div>
-        ];
-    }
-
     onViewSwitch(state) {
         this.setState({
             viewMode: state
         });
-    }
-
-    onFilterAfterDateChange(name, value) {
-        let beforeDate = this.props.actions.filters.beforeDate;
-        this.props.dispatch(retrieveActions(value, beforeDate));
-    }
-
-    onFilterBeforeDateChange(name, value) {
-        let afterDate = this.props.actions.filters.afterDate;
-        this.props.dispatch(retrieveActions(afterDate, value));
     }
 }

--- a/src/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -12,6 +12,7 @@ import { filteredActionList } from '../../../store/actions';
 
 
 const mapStateToProps = state => ({
+    actions: state.actions,
     locations: state.locations,
     campaigns: state.campaigns,
     filteredActionList: filteredActionList(state)
@@ -49,14 +50,6 @@ export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
             <CampaignPlayer key="player"
                 actions={ actions } locations={ locations }
                 centerLat={ center.lat } centerLng={ center.lng }/>
-        );
-    }
-
-    getPaneTools() {
-        return (
-            <CampaignSelect
-                onCreate={ this.onCreateCampaign.bind(this) }
-                onEdit={ this.onEditCampaign.bind(this) }/>
         );
     }
 }

--- a/src/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -1,11 +1,37 @@
 import moment from 'moment';
 import React from 'react';
 
+import CampaignSelect from '../../misc/CampaignSelect';
+import DateInput from '../../forms/inputs/DateInput';
 import RootPaneBase from '../RootPaneBase';
-import { createAction, updateAction } from '../../../actions/action';
+import {
+    createAction,
+    retrieveActions,
+    updateAction
+} from '../../../actions/action';
 
 
 export default class CampaignSectionPaneBase extends RootPaneBase {
+    getPaneFilters(data) {
+        return [
+            <CampaignSelect key="campaignSelect"
+                onCreate={ this.onCreateCampaign.bind(this) }
+                onEdit={ this.onEditCampaign.bind(this) }/>,
+            <div key="dateFilter" className="AllActionsPane-dateFilter">
+                <DateInput name="afterDate"
+                    value={ this.props.actions.filters.afterDate }
+                    labelMsg="panes.allActions.filters.afterDate"
+                    onValueChange={ this.onFilterAfterDateChange.bind(this) }
+                    />
+                <DateInput name="beforeDate"
+                    value={ this.props.actions.filters.beforeDate }
+                    labelMsg="panes.allActions.filters.beforeDate"
+                    onValueChange={ this.onFilterBeforeDateChange.bind(this) }
+                    />
+            </div>
+        ];
+    }
+
     onCalendarAddAction(date) {
         const selectedId = this.props.campaigns.selectedCampaign;
         const campParam = selectedId || 0;
@@ -79,5 +105,15 @@ export default class CampaignSectionPaneBase extends RootPaneBase {
 
     onCreateCampaign(title) {
         this.openPane('addcampaign', title);
+    }
+
+    onFilterAfterDateChange(name, value) {
+        let beforeDate = this.props.actions.filters.beforeDate;
+        this.props.dispatch(retrieveActions(value, beforeDate));
+    }
+
+    onFilterBeforeDateChange(name, value) {
+        let afterDate = this.props.actions.filters.afterDate;
+        this.props.dispatch(retrieveActions(afterDate, value));
     }
 }

--- a/src/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -1,11 +1,11 @@
 import moment from 'moment';
 import React from 'react';
 
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import { createAction, updateAction } from '../../../actions/action';
 
 
-export default class CampaignSectionPaneBase extends PaneBase {
+export default class CampaignSectionPaneBase extends RootPaneBase {
     onCalendarAddAction(date) {
         const selectedId = this.props.campaigns.selectedCampaign;
         const campParam = selectedId || 0;

--- a/src/components/sections/dialog/AllCallAssignmentsPane.jsx
+++ b/src/components/sections/dialog/AllCallAssignmentsPane.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import { retrieveCallAssignments } from '../../../actions/callAssignment';
 
 import CallAssignmentList from '../../lists/CallAssignmentList'
 
 
 @connect(state => state)
-export default class AllCallAssignmentsPane extends PaneBase {
+export default class AllCallAssignmentsPane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveCallAssignments());
     }

--- a/src/components/sections/dialog/CallAssignmentTemplatePane.jsx
+++ b/src/components/sections/dialog/CallAssignmentTemplatePane.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { FormattedMessage as Msg } from 'react-intl';
 
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import StayInTouchTemplate from './templates/StayInTouchTemplate';
 import InformTemplate from './templates/InformTemplate';
 import MobilizeTemplate from './templates/MobilizeTemplate';
@@ -12,7 +12,7 @@ import { createCallAssignmentDraft } from '../../../actions/callAssignment';
 
 
 @connect(state => state)
-export default class CallAssignmentTemplatePane extends PaneBase {
+export default class CallAssignmentTemplatePane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveCampaigns());
     }

--- a/src/components/sections/dialog/CallLogPane.jsx
+++ b/src/components/sections/dialog/CallLogPane.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import CallList from '../../lists/CallList';
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import { retrieveCalls } from '../../../actions/call';
 
 
 @connect(state => state)
-export default class CallLogPane extends PaneBase {
+export default class CallLogPane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveCalls());
     }

--- a/src/components/sections/maps/LocationsPane.jsx
+++ b/src/components/sections/maps/LocationsPane.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import Button from '../../misc/Button';
 import LocationMap from '../../misc/LocationMap';
 import ViewSwitch from '../../misc/ViewSwitch';
@@ -11,7 +11,7 @@ import { retrieveLocations, setPendingLocation }
 
 
 @connect(state => state)
-export default class LocationsPane extends PaneBase {
+export default class LocationsPane extends RootPaneBase {
     constructor(props) {
         super(props)
 

--- a/src/components/sections/people/ImportPane.jsx
+++ b/src/components/sections/people/ImportPane.jsx
@@ -4,14 +4,14 @@ import DropZone from 'react-dropzone';
 import { connect } from 'react-redux';
 
 import Button from '../../misc/Button';
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import ImporterTableSet from '../../misc/importer/ImporterTableSet';
 import LoadingIndicator from '../../misc/LoadingIndicator';
 import { parseImportFile, resetImport } from '../../../actions/importer';
 
 
 @connect(state => ({ importer: state.importer }))
-export default class ImportPane extends PaneBase {
+export default class ImportPane extends RootPaneBase {
     constructor(props) {
         super(props);
 

--- a/src/components/sections/people/InvitePane.jsx
+++ b/src/components/sections/people/InvitePane.jsx
@@ -4,12 +4,12 @@ import { connect } from 'react-redux';
 
 import InviteBox from '../../misc/InviteBox';
 import LoadingIndicator from '../../misc/LoadingIndicator';
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import { retrieveInvites } from '../../../actions/invite';
 
 
 @connect(state => ({ invites: state.invites }))
-export default class InvitePane extends PaneBase {
+export default class InvitePane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveInvites());
     }

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import React from 'react';
 
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import BulkOpSelect from '../../bulk/BulkOpSelect';
 import Button from '../../misc/Button';
 import PersonList from '../../lists/PersonList';
@@ -30,7 +30,7 @@ const mapStateToProps = state => ({
 
 @connect(mapStateToProps)
 @injectIntl
-export default class PeopleListPane extends PaneBase {
+export default class PeopleListPane extends RootPaneBase {
     constructor(props) {
         super(props);
 

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -99,27 +99,7 @@ export default class PeopleListPane extends PaneBase {
     }
 
     getPaneTools(data) {
-        const formatMessage = this.props.intl.formatMessage;
-
-        let queryId = this.state.selectedQueryId;
-        let queryList = this.props.queries.queryList;
-        let query = getListItemById(queryList, queryId);
-
-        // Only include queries that have a title
-        // TODO: Find some better way to filter out call assignment queries,
-        //       e.g. a proper type attribute on the query
-        let queries = queryList.items.map(i => i.data).filter(q => q.title);
-
-        let querySelectNullLabel = formatMessage(
-            { id: 'panes.peopleList.querySelect.nullLabel' });
-
         let tools = [
-            <RelSelectInput key="querySelect" name="querySelect"
-                value={ queryId } objects={ queries } showEditLink={ true }
-                allowNull={ true } nullLabel={ querySelectNullLabel }
-                onValueChange={ this.onQueryChange.bind(this) }
-                onCreate={ this.onQueryCreate.bind(this) }
-                onEdit={ this.onQueryEdit.bind(this) }/>,
             <Button key="addButton"
                 className="PeopleListPane-addButton"
                 labelMsg="panes.peopleList.addButton"
@@ -139,6 +119,31 @@ export default class PeopleListPane extends PaneBase {
         }
 
         return tools;
+    }
+
+    getPaneFilters(data) {
+        const formatMessage = this.props.intl.formatMessage;
+
+        let queryId = this.state.selectedQueryId;
+        let queryList = this.props.queries.queryList;
+        let query = getListItemById(queryList, queryId);
+
+        // Only include queries that have a title
+        // TODO: Find some better way to filter out call assignment queries,
+        //       e.g. a proper type attribute on the query
+        let queries = queryList.items.map(i => i.data).filter(q => q.title);
+
+        let querySelectNullLabel = formatMessage(
+            { id: 'panes.peopleList.querySelect.nullLabel' });
+
+        return [
+            <RelSelectInput key="querySelect" name="querySelect"
+                value={ queryId } objects={ queries } showEditLink={ true }
+                allowNull={ true } nullLabel={ querySelectNullLabel }
+                onValueChange={ this.onQueryChange.bind(this) }
+                onCreate={ this.onQueryCreate.bind(this) }
+                onEdit={ this.onQueryEdit.bind(this) }/>,
+        ];
     }
 
     onItemClick(item) {

--- a/src/components/sections/settings/OfficialsPane.jsx
+++ b/src/components/sections/settings/OfficialsPane.jsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { FormattedMessage as Msg } from 'react-intl';
 import React from 'react';
 
-import PaneBase from '../../panes/PaneBase';
+import RootPaneBase from '../RootPaneBase';
 import OfficialList from '../../misc/officiallist/OfficialList';
 import { createSelection } from '../../../actions/selection';
 import {
@@ -14,7 +14,7 @@ import {
 
 
 @connect(state => ({ officials: state.officials }))
-export default class OfficialsPane extends PaneBase {
+export default class OfficialsPane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveOfficials());
     }

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -1,8 +1,8 @@
 import Z from 'zetkin';
 import path from 'path';
 
-import initApp from './app';
 import polyfills from '../utils/polyfills';
+import initApp from './app';
 import { loadMessages } from './locale';
 
 var port = process.env.ZETKIN_FRONTEND_PORT || 8000;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -105,11 +105,10 @@ export default function actions(state = null, action) {
         default:
             // By default, filter from last week and eight weeks forward
             let startDate = Date.create('last monday');
-            let endDate = startDate.clone().addDays(8 * 7);
             return state || {
                 filters: {
                     afterDate: startDate.format('{yyyy}-{MM}-{dd}'),
-                    beforeDate: endDate.format('{yyyy}-{MM}-{dd}'),
+                    beforeDate: null,
                 },
                 actionList: createList(),
             };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -26,6 +26,10 @@ export default function actions(state = null, action) {
     switch (action.type) {
         case types.RETRIEVE_ACTIONS + '_PENDING':
             return Object.assign({}, state, {
+                filters: {
+                    afterDate: action.meta.afterDate,
+                    beforeDate: action.meta.beforeDate,
+                },
                 actionList: Object.assign({}, state.actionList, {
                     isPending: true,
                     error:null,
@@ -91,7 +95,14 @@ export default function actions(state = null, action) {
             return toggleActionHighlights(state, action, (a, p) => false);
 
         default:
+            // By default, filter from last week and eight weeks forward
+            let startDate = Date.create('last monday');
+            let endDate = startDate.clone().addDays(8 * 7);
             return state || {
+                filters: {
+                    afterDate: startDate.format('{yyyy}-{MM}-{dd}'),
+                    beforeDate: endDate.format('{yyyy}-{MM}-{dd}'),
+                },
                 actionList: createList(),
             };
     }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -94,6 +94,14 @@ export default function actions(state = null, action) {
         case types.CLEAR_ACTION_HIGHLIGHTS:
             return toggleActionHighlights(state, action, (a, p) => false);
 
+        case types.SELECT_CAMPAIGN:
+            return Object.assign({}, state, {
+                filters: {
+                    afterDate: null,
+                    beforeDate: null,
+                },
+            });
+
         default:
             // By default, filter from last week and eight weeks forward
             let startDate = Date.create('last monday');

--- a/src/utils/PaneManager.js
+++ b/src/utils/PaneManager.js
@@ -181,7 +181,7 @@ function Pane(domElement, isBase) {
     this.domElement = domElement;
     this.contentElement = domElement.getElementsByClassName('PaneBase-content')[0];
     this.shaderElement = document.createElement('div');
-    this.shaderElement.className = 'PaneBase-shader';
+    this.shaderElement.className = isBase? 'RootPaneBase-shader' : 'PaneBase-shader';
     this.domElement.appendChild(this.shaderElement);
     this.dragging = false;
     this.isBase = isBase;


### PR DESCRIPTION
This PR moves filter-type controls from the regular section toolbar to a new filter drawer, which opens and closes at the click of a button in the regular toolbar.

It also implements filtering of actions by date, and refactors the pane class hierarchy so that section root panes and "regular" floating panes inherit separate base classes (`RootPaneBase` and `PaneBase` respectively), as outlined in #319.

This PR does not however implement any nice styling of the added drawers (tracked for future reference by #373).

![filterdrawer](https://cloud.githubusercontent.com/assets/550212/21842337/99da1b9c-d7e6-11e6-998f-9829dc5a76eb.gif)

Fixes #366