### PR TITLE
Alt-clicking for quick edit

### DIFF
--- a/src/components/lists/items/ActionListItem.jsx
+++ b/src/components/lists/items/ActionListItem.jsx
@@ -282,7 +282,7 @@ export default class ActionListItem extends React.Component {
     }
 
     onClick(ev) {
-        this.props.onItemClick();
+        this.props.onItemClick(ev);
     }
 
     onShowAllParticipants(ev) {

--- a/src/components/lists/items/CallAssignmentListItem.jsx
+++ b/src/components/lists/items/CallAssignmentListItem.jsx
@@ -130,7 +130,7 @@ export default class CallAssignmentListItem extends React.Component {
 
         return (
             <div className={ classNames }
-                onClick={ () => {this.props.onItemClick(assignment)} }>
+                onClick={ this.props.onItemClick }>
                     { assignmentDateSpan }
                 <div className="CallAssignmentListItem-info">
                     <h3 className="CallAssignmentListItem-infoTitle">

--- a/src/components/lists/items/ListItem.jsx
+++ b/src/components/lists/items/ListItem.jsx
@@ -46,10 +46,10 @@ export default class ListItem extends React.Component {
         );
     }
 
-    onItemClick() {
+    onItemClick(ev) {
         if (this.props.onItemClick) {
             let item = this.props.item;
-            this.props.onItemClick(item);
+            this.props.onItemClick(item, ev);
         }
     }
 

--- a/src/components/misc/actioncal/ActionCalendar.jsx
+++ b/src/components/misc/actioncal/ActionCalendar.jsx
@@ -93,9 +93,9 @@ export default class ActionCalendar extends React.Component {
         );
     }
 
-    onSelectAction(action) {
+    onSelectAction(action, ev) {
         if (this.props.onSelectAction) {
-            this.props.onSelectAction(action);
+            this.props.onSelectAction(action, ev);
         }
     }
 

--- a/src/components/misc/actioncal/ActionDay.jsx
+++ b/src/components/misc/actioncal/ActionDay.jsx
@@ -83,7 +83,7 @@ export default class ActionDay extends React.Component {
                     transitionName="actionitem" component="ul">
                 { actions.map(function(action) {
                     return <ActionItem key={ action.id } action={ action }
-                            onClick={ this.onActionClick.bind(this, action) }/>
+                            onClick={ this.onActionClick.bind(this) }/>
                 }, this) }
                     { overflow }
                     <li className="ActionDay-pseudoItem">
@@ -102,9 +102,9 @@ export default class ActionDay extends React.Component {
         }
     }
 
-    onActionClick(action) {
+    onActionClick(action, ev) {
         if (this.props.onSelectAction) {
-            this.props.onSelectAction(action);
+            this.props.onSelectAction(action, ev);
         }
     }
 

--- a/src/components/misc/actioncal/ActionItem.jsx
+++ b/src/components/misc/actioncal/ActionItem.jsx
@@ -56,7 +56,7 @@ export default class ActionItem extends React.Component {
 
     onClick(ev) {
         if (this.props.onClick) {
-            this.props.onClick(this.props.action);
+            this.props.onClick(this.props.action, ev);
         }
     }
 }

--- a/src/components/panes/LocationPane.jsx
+++ b/src/components/panes/LocationPane.jsx
@@ -16,7 +16,6 @@ import {
 } from '../../actions/location';
 
 import { 
-    retrieveLocationTag,
     addTagsToLocation,
     retrieveTagsForLocation,
     removeTagFromLocation
@@ -35,7 +34,6 @@ export default class LocationPane extends PaneBase {
             this.props.dispatch(retrieveLocation(locId));
         }
 
-        this.props.dispatch(retrieveLocationTag(locId))
         this.props.dispatch(retrieveTagsForLocation(locId))
     }
 

--- a/src/components/panes/QueryPane.jsx
+++ b/src/components/panes/QueryPane.jsx
@@ -60,8 +60,13 @@ export default class QueryPane extends PaneBase {
         }
     }
 
-    onPersonItemClick(personItem) {
-        this.openPane('person', personItem.data.id);
+    onPersonItemClick(personItem, ev) {
+        if (ev && ev.altKey) {
+            this.openPane('editperson', personItem.data.id);
+        }
+        else {
+            this.openPane('person', personItem.data.id);
+        }
     }
 
     onEditClick(ev) {

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -65,7 +65,7 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         }
         else {
             viewComponent = <ActionList actionList={ actionList }
-                onItemClick={ item => this.onSelectAction(item.data) }/>
+                onItemClick={ (item, ev) => this.onSelectAction(item.data, ev) }/>
         }
 
         return viewComponent;

--- a/src/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -95,8 +95,13 @@ export default class CampaignSectionPaneBase extends RootPaneBase {
         this.openPane('actionday', dateStr);
     }
 
-    onSelectAction(action) {
-        this.openPane('action', action.id);
+    onSelectAction(action, ev) {
+        if (ev && ev.altKey) {
+            this.openPane('editaction', action.id);
+        }
+        else {
+            this.openPane('action', action.id);
+        }
     }
 
     onEditCampaign(campaign) {

--- a/src/components/sections/dialog/AllCallAssignmentsPane.jsx
+++ b/src/components/sections/dialog/AllCallAssignmentsPane.jsx
@@ -24,7 +24,7 @@ export default class AllCallAssignmentsPane extends RootPaneBase {
         return (
             <CallAssignmentList
                 callAssignmentList={ data.assignmentList }
-                onItemClick={ this.onClickAssignment.bind(this) } />
+                onItemClick={ this.onAssignmentClick.bind(this) } />
         );
     }
 
@@ -41,7 +41,12 @@ export default class AllCallAssignmentsPane extends RootPaneBase {
         this.openPane('addcallassignment');
     }
 
-    onClickAssignment(assignment) {
-        this.openPane('callassignment', assignment.data.id);
+    onAssignmentClick(assignment, ev) {
+        if (ev && ev.altKey) {
+            this.openPane('editcallassignment', assignment.data.id);
+        }
+        else {
+            this.openPane('callassignment', assignment.data.id);
+        }
     }
 }

--- a/src/components/sections/maps/LocationsPane.jsx
+++ b/src/components/sections/maps/LocationsPane.jsx
@@ -22,7 +22,7 @@ export default class LocationsPane extends RootPaneBase {
         return (
             <div>
                 <LocationList locationList={ locationList }
-                    onItemClick={ this.onLocationSelect.bind(this) }/>
+                    onItemClick={ this.onLocationClick.bind(this) }/>
             </div>
         );
     }
@@ -40,7 +40,12 @@ export default class LocationsPane extends RootPaneBase {
         this.openPane('addlocation');
     }
 
-    onLocationSelect(loc) {
-        this.openPane('location', loc.data.id);
+    onLocationClick(loc, ev) {
+        if (ev && ev.altKey) {
+            this.openPane('editlocation', loc.data.id);
+        }
+        else {
+            this.openPane('location', loc.data.id);
+        }
     }
 }

--- a/src/components/sections/maps/MapOverviewPane.jsx
+++ b/src/components/sections/maps/MapOverviewPane.jsx
@@ -5,6 +5,11 @@ import RootPaneBase from '../RootPaneBase';
 import LocationMap from '../../misc/LocationMap';
 import { retrieveLocations } from '../../../actions/location';
 
+let altKeyDown = false;
+
+let onKeyDown = ev => altKeyDown = altKeyDown || ev.keyCode == 18;
+let onKeyUp = ev => altKeyDown = !(altKeyDown && ev.keyCode == 18);
+
 
 @connect(state => state)
 export default class MapOverviewPane extends RootPaneBase {
@@ -12,6 +17,16 @@ export default class MapOverviewPane extends RootPaneBase {
         super.componentDidMount();
 
         this.props.dispatch(retrieveLocations());
+    }
+
+    componentDidMount() {
+        window.addEventListener('keydown', onKeyDown);
+        window.addEventListener('keyup', onKeyUp);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('keydown', onKeyDown);
+        window.removeEventListener('keyup', onKeyUp);
     }
 
     renderPaneContent() {
@@ -37,6 +52,11 @@ export default class MapOverviewPane extends RootPaneBase {
     }
 
     onLocationSelect(loc) {
-        this.openPane('location', loc.data.id);
+        if (altKeyDown) {
+            this.openPane('editlocation', loc.data.id);
+        }
+        else {
+            this.openPane('location', loc.data.id);
+        }
     }
 }

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -161,9 +161,15 @@ export default class PeopleListPane extends RootPaneBase {
         return tools;
     }
 
-    onItemClick(item) {
+    onItemClick(item, ev) {
         let person = item.data;
-        this.openPane('person', person.id);
+
+        if (ev && ev.altKey) {
+            this.openPane('editperson', person.id);
+        }
+        else {
+            this.openPane('person', person.id);
+        }
     }
 
     onItemSelect(item, selected) {


### PR DESCRIPTION
This PR adds a feature where alt-clicking an item in a list (or in the case of locations, on a map) does not opens the respective edit panes for the item's type. Alt-clicking a person in `PersonList` opens the `EditPersonPane` instead of the `PersonPane`.

This is particularly nice in the case of actions in the calendar. While planning a campaign, you rarely want to open the `ActionPane`, but instead edit the action using the `EditActionPane`.