### PR TITLE
Enhanced assignment query UI

### DIFF
--- a/locale/panes/callAssignment/sv.yaml
+++ b/locale/panes/callAssignment/sv.yaml
@@ -8,8 +8,8 @@ instructions:
     editLink: "Redigera instruktionerna"
 target:
     h: "Målgrupp"
-    editTargetLink: "Redigera målgruppsfilter"
-    editGoalLink: "Redigera målfilter"
+    editTargetLink: "Redigera målgrupp"
+    editGoalLink: "Redigera syfte"
     stats:
         goal: "Personer återstår"
         target: "Personer i målgruppen"

--- a/locale/panes/editQuery/sv.yaml
+++ b/locale/panes/editQuery/sv.yaml
@@ -1,4 +1,8 @@
-title: "Redigera sökfråga"
+title:
+    standalone: "Redigera smart sökning"
+    callassignment_target: "Redigera målgruppssökning"
+    callassignment_goal: "Redigera syftessökning"
+
 filterHeader: "Filter"
 filterIntro: |
     En sökfråga består av en kedja av filter, där varje filter adderar

--- a/src/components/filters/CampaignFilter.jsx
+++ b/src/components/filters/CampaignFilter.jsx
@@ -59,7 +59,7 @@ export default class CampaignFilter extends FilterBase {
         let campaignSelect = null;
         if (this.state.op == 'in_spec' || this.state.op == 'notin_spec') {
             campaignSelect = (
-                <RelSelectInput name="campaign"
+                <RelSelectInput name="campaign" key="campaignSelect"
                     labelMsg="filters.campaign.campaign"
                     objects={ campaigns } value={ this.state.campaign }
                     onValueChange={ this.onChangeSimpleField.bind(this) }

--- a/src/components/panes/CallAssignmentPane.jsx
+++ b/src/components/panes/CallAssignmentPane.jsx
@@ -147,13 +147,15 @@ export default class CallAssignmentPane extends PaneBase {
                     <div className="CallAssignmentPane-stats">
                         <div>
                             <div key="targetStats"
-                                className="CallAssignmentPane-targetStats">
+                                className="CallAssignmentPane-targetStats"
+                                onClick={ this.onClickEditTarget.bind(this) }>
                                 { targetStats }
                             </div>
                         </div>
                         <div>
                             <div key="goalStats"
-                                className="CallAssignmentPane-goalStats">
+                                className="CallAssignmentPane-goalStats"
+                                onClick={ this.onClickEditGoal.bind(this) }>
                                 { goalStats }
                             </div>
                         </div>

--- a/src/components/panes/CallAssignmentPane.scss
+++ b/src/components/panes/CallAssignmentPane.scss
@@ -75,12 +75,14 @@
         a {
             @include col(6,12);
             text-align: center;
+            cursor: pointer;
         }
 
         .CallAssignmentPane-stats {
             min-height: 92px;
             margin-bottom: 10px;
             & > div {
+                cursor: pointer;
                 @include col(6,12);
             }
             div > div {

--- a/src/components/panes/EditQueryPane.jsx
+++ b/src/components/panes/EditQueryPane.jsx
@@ -36,9 +36,12 @@ export default class EditQueryPane extends PaneBase {
     }
 
     getPaneTitle(data) {
-        const formatMessage = this.props.intl.formatMessage;
-        return formatMessage(
-            { id: 'panes.editQuery.title' });
+        let type = (data.queryItem && data.queryItem.data)?
+                data.queryItem.data.type : 'standalone';
+
+        let msgId = 'panes.editQuery.title.' + type;
+
+        return this.props.intl.formatMessage({ id: msgId });
     }
 
     renderPaneContent(data) {

--- a/src/components/panes/EditQueryPane.jsx
+++ b/src/components/panes/EditQueryPane.jsx
@@ -45,10 +45,17 @@ export default class EditQueryPane extends PaneBase {
         if (data.queryItem && !data.queryItem.isPending) {
             let query = data.queryItem.data;
             let filters = query.filter_spec;
+            let form = null;
+
+            if (query.type == 'standalone') {
+                form = (
+                    <QueryForm key="form" ref="form" query={ query }
+                        onSubmit={ this.onSubmit.bind(this) }/>
+                );
+            }
 
             return [
-                <QueryForm key="form" ref="form" query={ query }
-                    onSubmit={ this.onSubmit.bind(this) }/>,
+                form,
                 <Msg tagName="h3" key="filterHeader"
                     id="panes.editQuery.filterHeader"/>,
                 <Msg tagName="p" key="filterIntro"

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -66,7 +66,8 @@ export default function queries(state = null, action) {
 
         case types.RETRIEVE_CALL_ASSIGNMENTS + '_FULFILLED':
             let assignments = action.payload.data.data;
-            let queries = assignments.map(a => a.target);
+            let queries = assignments.map(a => a.target)
+                .concat(assignments.map(a => a.goal));
 
             return Object.assign({}, state, {
                 queryList: updateOrAddListItems(state.queryList,


### PR DESCRIPTION
This PR makes several minor improvements to the call assignment query editing interface. It uses the new `type` attribute on queries to determine what content to show in `EditQueryPane` (form unnecessary for call assignment queries). It also fixes some minor issues regarding queries in the `CallAssignmentPane`.