### PR TITLE
New query filters

### DIFF
--- a/locale/filters/all/sv.yaml
+++ b/locale/filters/all/sv.yaml
@@ -1,0 +1,3 @@
+description: |
+    Detta filter väljer ut alla personer i hela organisationen. Det finns inga
+    inställningar.

--- a/locale/filters/random/sv.yaml
+++ b/locale/filters/random/sv.yaml
@@ -1,0 +1,1 @@
+size: Antal personer

--- a/locale/filters/sv.yaml
+++ b/locale/filters/sv.yaml
@@ -7,3 +7,4 @@ types:
     joinDate: "Inträdesdatum"
     personData: "Personuppgifter"
     personTags: "Etiketter"
+    random: "Slumpmässigt urval"

--- a/locale/filters/sv.yaml
+++ b/locale/filters/sv.yaml
@@ -1,6 +1,7 @@
 addFilter: "Lägg till filter"
 dropInstructions: "Släpp filter här för att byta ordning"
 types:
+    all: "Alla i organisationen"
     callHistory: "Ringhistorik"
     campaignParticipation: "Kampanjdeltagande"
     joinDate: "Inträdesdatum"

--- a/locale/panes/addCallAssignment/sv.yaml
+++ b/locale/panes/addCallAssignment/sv.yaml
@@ -3,6 +3,7 @@ title: "Skapa ringuppdrag"
 breadcrumbs:
     target: |
         Målgrupp{targetType, select,
+            allTarget {: Ring alla}
             tagTarget {: Ring alla med en viss etikett}
             custom {: Ingen mall}
             other {}
@@ -20,6 +21,7 @@ breadcrumbs:
 target:
     saveButton: |
         {targetType, select,
+            allTarget {Välj alla som målgrupp}
             tagTarget {Välj målgrupp utifrån etikett}
         }
     customLink: "Definiera urvalsregler manuellt senare"
@@ -45,6 +47,11 @@ form:
         för ringuppdraget.
 
 templates:
+    allTarget:
+        title: "Alla i databasen"
+        instructions: |
+            Målgruppen utgörs av alla personer i databasen.
+
     tagTarget:
         title: "Alla med en viss etikett"
         instructions: |

--- a/locale/panes/addCallAssignment/sv.yaml
+++ b/locale/panes/addCallAssignment/sv.yaml
@@ -5,6 +5,7 @@ breadcrumbs:
         Målgrupp{targetType, select,
             allTarget {: Ring alla}
             tagTarget {: Ring alla med en viss etikett}
+            randomTarget {: Ring slumpmässigt urval}
             custom {: Ingen mall}
             other {}
         }
@@ -23,6 +24,7 @@ target:
         {targetType, select,
             allTarget {Välj alla som målgrupp}
             tagTarget {Välj målgrupp utifrån etikett}
+            randomTarget {Välj slumpmässig målgrupp}
         }
     customLink: "Definiera urvalsregler manuellt senare"
     instructions: |
@@ -51,6 +53,12 @@ templates:
         title: "Alla i databasen"
         instructions: |
             Målgruppen utgörs av alla personer i databasen.
+
+    randomTarget:
+        title: "Slumpmässigt urval"
+        instructions: |
+            Målgruppen består av ett slumpmässigt urval. Hur många vill du
+            ska bli ringda?
 
     tagTarget:
         title: "Alla med en viss etikett"

--- a/src/components/filters/AllFilter.jsx
+++ b/src/components/filters/AllFilter.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FormattedMessage as Msg } from 'react-intl';
+import { connect } from 'react-redux';
+
+import FilterBase from './FilterBase';
+
+export default class AllFilter extends FilterBase {
+    renderFilterForm(config) {
+        return (
+            <Msg id="filters.all.description"/>
+        );
+    }
+
+    getConfig() {
+        return {};
+    }
+}

--- a/src/components/filters/FilterList.jsx
+++ b/src/components/filters/FilterList.jsx
@@ -67,6 +67,7 @@ export default class FilterList extends React.Component {
         const msg = id => this.context.intl.formatMessage({ id });
 
         const filterTypes = {
+            'all': msg('filters.types.all'),
             'call_history': msg('filters.types.callHistory'),
             'campaign_participation': msg('filters.types.campaignParticipation'),
             'join_date': msg('filters.types.joinDate'),

--- a/src/components/filters/FilterList.jsx
+++ b/src/components/filters/FilterList.jsx
@@ -73,6 +73,7 @@ export default class FilterList extends React.Component {
             'join_date': msg('filters.types.joinDate'),
             'person_data': msg('filters.types.personData'),
             'person_tags': msg('filters.types.personTags'),
+            'random': msg('filters.types.random'),
         };
 
         let items = [];

--- a/src/components/filters/RandomFilter.jsx
+++ b/src/components/filters/RandomFilter.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import FilterBase from './FilterBase';
+import IntInput from '../forms/inputs/IntInput';
+
+
+export default class RandomFilter extends FilterBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            size: props.config.size || 20,
+        };
+    }
+
+    componentReceivedProps(nextProps) {
+        if (nextProps.config !== this.props.config) {
+            this.setState({
+                size: nextProps.config.size,
+            });
+        }
+    }
+
+    renderFilterForm(config) {
+        return [
+            <IntInput key="size" name="size"
+                labelMsg="filters.random.size"
+                value={ this.state.size }
+                onValueChange={ this.onSizeChange.bind(this) }
+                />,
+        ];
+    }
+
+    getConfig() {
+        return {
+            size: this.state.size,
+        };
+    }
+
+    onSizeChange(name, value) {
+        this.setState({ size: value }, () =>
+            this.onConfigChange());
+    }
+}

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -4,6 +4,7 @@ import CampaignFilter from './CampaignFilter';
 import JoinDateFilter from './JoinDateFilter';
 import PersonDataFilter from './PersonDataFilter';
 import PersonTagsFilter from './PersonTagsFilter';
+import RandomFilter from './RandomFilter';
 
 const filterComponents = {
     'all': AllFilter,
@@ -12,6 +13,7 @@ const filterComponents = {
     'join_date': JoinDateFilter,
     'person_data': PersonDataFilter,
     'person_tags': PersonTagsFilter,
+    'random': RandomFilter,
 };
 
 export function resolveFilterComponent(type) {

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -1,3 +1,4 @@
+import AllFilter from './AllFilter';
 import CallHistoryFilter from './CallHistoryFilter';
 import CampaignFilter from './CampaignFilter';
 import JoinDateFilter from './JoinDateFilter';
@@ -5,6 +6,7 @@ import PersonDataFilter from './PersonDataFilter';
 import PersonTagsFilter from './PersonTagsFilter';
 
 const filterComponents = {
+    'all': AllFilter,
     'call_history': CallHistoryFilter,
     'campaign_participation': CampaignFilter,
     'join_date': JoinDateFilter,

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -230,17 +230,17 @@ export default class RelSelectInput extends InputBase {
     }
 
     onBlur(ev) {
-        const listDOMNode = ReactDOM.findDOMNode(this.refs.objectList);
-        listDOMNode.scrollTop = 0;
-
         // TODO: This is a smelly solution to the onClick/onMouseDown problem
         //       The blur event fires on mouse down, so the click event never
         //       fires if blurring hides the menu.
         setTimeout(() => {
+            const listDOMNode = ReactDOM.findDOMNode(this.refs.objectList);
+            listDOMNode.scrollTop = 0;
+
             this.setState({
                 inputFocused: false
             });
-        }, 250);
+        }, 200);
     }
 
     createObject() {

--- a/src/components/misc/callAssignmentTemplates/AllTargetTemplate.jsx
+++ b/src/components/misc/callAssignmentTemplates/AllTargetTemplate.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import AssignmentTemplate from './AssignmentTemplate';
+
+
+export default class AllTargetTemplate extends React.Component {
+    render() {
+        return (
+            <AssignmentTemplate type="allTarget"
+                selected={ this.props.selected }
+                onSelect={ this.props.onSelect }>
+            </AssignmentTemplate>
+        );
+    }
+}

--- a/src/components/misc/callAssignmentTemplates/RandomTargetTemplate.jsx
+++ b/src/components/misc/callAssignmentTemplates/RandomTargetTemplate.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import AssignmentTemplate from './AssignmentTemplate';
+import IntInput from '../../forms/inputs/IntInput';
+
+
+export default class RandomTargetTemplate extends React.Component {
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.selected && !nextProps.config.size) {
+            nextProps.onConfigChange({
+                size: 50,
+            });
+        }
+    }
+
+    render() {
+        return (
+            <AssignmentTemplate type="randomTarget"
+                selected={ this.props.selected }
+                onSelect={ this.props.onSelect }>
+
+                <IntInput name="size"
+                    value={ this.props.config.size }
+                    onValueChange={ this.onChange.bind(this) }
+                    />
+            </AssignmentTemplate>
+        );
+    }
+
+    componentDidMount() {
+        let tags = this.props.tags;
+
+        if (tags && tags.length && !this.props.config.tagId) {
+            // Emit default configuration
+            this.props.onConfigChange({
+                tagId: tags[0].id.toString(),
+            });
+        }
+    }
+
+    onChange(name, val) {
+        if (this.props.onConfigChange) {
+            this.props.onConfigChange({
+                size: val,
+            });
+        }
+    }
+}

--- a/src/components/panes/AddCallAssignmentPane.jsx
+++ b/src/components/panes/AddCallAssignmentPane.jsx
@@ -17,6 +17,7 @@ import MobilizeTemplate from '../misc/callAssignmentTemplates/MobilizeTemplate';
 import StayInTouchTemplate from '../misc/callAssignmentTemplates/StayInTouchTemplate';
 import TagTargetTemplate from '../misc/callAssignmentTemplates/TagTargetTemplate';
 import AllTargetTemplate from '../misc/callAssignmentTemplates/AllTargetTemplate';
+import RandomTargetTemplate from '../misc/callAssignmentTemplates/RandomTargetTemplate';
 
 
 const STEPS = [ 'target', 'goal', 'form' ];
@@ -90,6 +91,11 @@ export default class AddCallAssignmentPane extends PaneBase {
                     <TagTargetTemplate tags={ data.tags }
                         config={ this.state.targetConfig }
                         selected={ this.state.targetType == 'tagTarget' }
+                        onConfigChange={ this.onTargetConfigChange.bind(this) }
+                        onSelect={ this.onTargetSelect.bind(this) }/>
+                    <RandomTargetTemplate tags={ data.tags }
+                        config={ this.state.targetConfig }
+                        selected={ this.state.targetType == 'randomTarget' }
                         onConfigChange={ this.onTargetConfigChange.bind(this) }
                         onSelect={ this.onTargetSelect.bind(this) }/>
                     <Link className="AddCallAssignmentPane-customLink"
@@ -274,6 +280,14 @@ export default class AddCallAssignmentPane extends PaneBase {
                 values.target_filters = [{
                     type: 'all',
                     config: null,
+                }];
+            }
+            else if (this.state.targetType == 'randomTarget') {
+                values.target_filters = [{
+                    type: 'random',
+                    config: {
+                        'size': this.state.targetConfig.size,
+                    }
                 }];
             }
             else if (this.state.targetType == 'tagTarget') {

--- a/src/components/panes/AddCallAssignmentPane.jsx
+++ b/src/components/panes/AddCallAssignmentPane.jsx
@@ -16,6 +16,7 @@ import InformTemplate from '../misc/callAssignmentTemplates/InformTemplate';
 import MobilizeTemplate from '../misc/callAssignmentTemplates/MobilizeTemplate';
 import StayInTouchTemplate from '../misc/callAssignmentTemplates/StayInTouchTemplate';
 import TagTargetTemplate from '../misc/callAssignmentTemplates/TagTargetTemplate';
+import AllTargetTemplate from '../misc/callAssignmentTemplates/AllTargetTemplate';
 
 
 const STEPS = [ 'target', 'goal', 'form' ];
@@ -81,6 +82,11 @@ export default class AddCallAssignmentPane extends PaneBase {
                 <Msg tagName="p" key="instructions"
                     id="panes.addCallAssignment.target.instructions"/>,
                 <div key="templates">
+                    <AllTargetTemplate tags={ data.tags }
+                        config={ this.state.targetConfig }
+                        selected={ this.state.targetType == 'allTarget' }
+                        onConfigChange={ this.onTargetConfigChange.bind(this) }
+                        onSelect={ this.onTargetSelect.bind(this) }/>
                     <TagTargetTemplate tags={ data.tags }
                         config={ this.state.targetConfig }
                         selected={ this.state.targetType == 'tagTarget' }
@@ -264,7 +270,13 @@ export default class AddCallAssignmentPane extends PaneBase {
 
             let values = this.refs.form.getValues();
 
-            if (this.state.targetType == 'tagTarget') {
+            if (this.state.targetType == 'allTarget') {
+                values.target_filters = [{
+                    type: 'all',
+                    config: null,
+                }];
+            }
+            else if (this.state.targetType == 'tagTarget') {
                 values.target_filters = [{
                     type: 'person_tags',
                     config: {


### PR DESCRIPTION
This PR adds the two recently implemented filters `all` and `random`. It adds filter widgets for the query pane, and two new templates for call assignment targets based on these filters.

There are features in the `random` filter that are not supported in this version of the UI, namely seeding and fractional sizes (e.g. to select 50% instead of an exact number of people). They will be implemented in the future (#404).

Closes #355 
Closes #356 