### PR TITLE
Prevent changing user's role

### DIFF
--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -35,3 +35,6 @@ callAssignmentTemplates:
 staticMap:
     setPositionLink: "Klicka för att ange position"
     noCoordinates: "Ingen position"
+
+officialList:
+    userLabel: "Din egen roll är låst"

--- a/src/components/misc/officiallist/OfficialList.jsx
+++ b/src/components/misc/officiallist/OfficialList.jsx
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 import React from 'react';
+import { connect } from 'react-redux';
 import { DropTarget } from 'react-dnd';
 
 import OfficialListItem from './OfficialListItem';
@@ -40,6 +41,7 @@ export default class OfficialList extends React.Component {
         addMsg: React.PropTypes.string.isRequired,
         selectLinkMsg: React.PropTypes.string.isRequired,
         officials: React.PropTypes.array.isRequired,
+        userProfile: React.PropTypes.object.isRequired,
         onSelect: React.PropTypes.func.isRequired,
         onRemove: React.PropTypes.func.isRequired,
         onAdd: React.PropTypes.func,
@@ -66,11 +68,16 @@ export default class OfficialList extends React.Component {
 
         return (
             <ul className={ classes }>
-            { this.props.officials.map(o => (
-                <OfficialListItem key={ o.id } official={ o }
-                    onSelect={ this.props.onSelect.bind(this) }
-                    onRemove={ this.props.onRemove.bind(this) }/>
-            )) }
+            { this.props.officials.map(o => {
+                let isUser = (o.id == this.props.userProfile.id);
+
+                return (
+                    <OfficialListItem key={ o.id } official={ o }
+                        isUser={ isUser }
+                        onSelect={ this.props.onSelect.bind(this) }
+                        onRemove={ this.props.onRemove.bind(this) }/>
+                );
+            }) }
                 { addItem }
             </ul>
         );

--- a/src/components/misc/officiallist/OfficialListItem.jsx
+++ b/src/components/misc/officiallist/OfficialListItem.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { FormattedMessage as Msg } from 'react-intl';
+import cx from 'classnames';
 
 import DraggableAvatar from '../DraggableAvatar';
 
@@ -7,6 +9,7 @@ export default class OfficialListItem extends React.Component {
     static propTypes = {
         onSelect: React.PropTypes.func.isRequired,
         onRemove: React.PropTypes.func,
+        isUser: React.PropTypes.bool,
         official: React.PropTypes.shape({
             role: React.PropTypes.string.isRequired,
             id: React.PropTypes.any.isRequired,     // TODO: Use string
@@ -19,15 +22,32 @@ export default class OfficialListItem extends React.Component {
         let official = this.props.official;
         let name = official.first_name + ' ' + official.last_name;
 
-        // TODO: Add buttons to edit or remove from list
+        let classes = cx('OfficialListItem', {
+            user: this.props.isUser,
+        });
+
+        let removeButton = null;
+        if (this.props.isUser) {
+            removeButton = (
+                <div className="OfficialListItem-userLabel">
+                    <Msg id="misc.officialList.userLabel"/>
+                </div>
+            );
+        }
+        else {
+            removeButton = (
+                <a className="OfficialListItem-removeButton"
+                    onClick={ this.onRemove.bind(this) }></a>
+            );
+        }
+
         return (
-            <li className="OfficialListItem"
+            <li className={ classes }
                 onClick={ this.props.onSelect.bind(this, official) }>
 
                 <DraggableAvatar person={ official }/>
                 <span className="OfficialListItem-name">{ name }</span>
-                <a className="OfficialListItem-removeButton"
-                    onClick={ this.onRemove.bind(this) }></a>
+                { removeButton }
             </li>
         );
     }

--- a/src/components/misc/officiallist/OfficialListItem.jsx
+++ b/src/components/misc/officiallist/OfficialListItem.jsx
@@ -3,6 +3,7 @@ import { FormattedMessage as Msg } from 'react-intl';
 import cx from 'classnames';
 
 import DraggableAvatar from '../DraggableAvatar';
+import Avatar from '../Avatar';
 
 
 export default class OfficialListItem extends React.Component {
@@ -26,26 +27,31 @@ export default class OfficialListItem extends React.Component {
             user: this.props.isUser,
         });
 
-        let removeButton = null;
+        let avatar;
+        let removeButton;
+
         if (this.props.isUser) {
             removeButton = (
                 <div className="OfficialListItem-userLabel">
                     <Msg id="misc.officialList.userLabel"/>
                 </div>
             );
+
+            avatar = <Avatar person={ official }/>;
         }
         else {
             removeButton = (
                 <a className="OfficialListItem-removeButton"
                     onClick={ this.onRemove.bind(this) }></a>
             );
+
+            avatar = <DraggableAvatar person={ official }/>;
         }
 
         return (
             <li className={ classes }
                 onClick={ this.props.onSelect.bind(this, official) }>
-
-                <DraggableAvatar person={ official }/>
+                { avatar }
                 <span className="OfficialListItem-name">{ name }</span>
                 { removeButton }
             </li>

--- a/src/components/misc/officiallist/OfficialListItem.scss
+++ b/src/components/misc/officiallist/OfficialListItem.scss
@@ -49,9 +49,5 @@
                 color: $c-ui-dark;
             }
         }
-
-        .DraggableAvatar {
-            cursor: default;
-        }
     }
 }

--- a/src/components/misc/officiallist/OfficialListItem.scss
+++ b/src/components/misc/officiallist/OfficialListItem.scss
@@ -6,7 +6,7 @@
         margin: 1em 0;
     }
 
-    .OfficialListItem-removeButton {
+    .OfficialListItem-removeButton, .OfficialListItem-userLabel {
         display: block;
         position: absolute;
         bottom: 0;
@@ -15,6 +15,9 @@
         height: 3em;
         text-align: center;
         padding: 0.5em;
+    }
+
+    .OfficialListItem-removeButton {
         background-color: darken(white, 3);
         cursor: pointer;
 
@@ -22,6 +25,11 @@
             @include icon($fa-var-remove);
             line-height: 2em;
         }
+    }
+
+    .OfficialListItem-userLabel {
+        color: white;
+        transition: color 0.3s;
     }
 
     &:hover {
@@ -33,5 +41,17 @@
     .Avatar {
         width: 100%;
         height: auto;
+    }
+
+    &.user {
+        &:hover {
+            .OfficialListItem-userLabel {
+                color: $c-ui-dark;
+            }
+        }
+
+        .DraggableAvatar {
+            cursor: default;
+        }
     }
 }

--- a/src/components/sections/settings/OfficialsPane.jsx
+++ b/src/components/sections/settings/OfficialsPane.jsx
@@ -13,14 +13,19 @@ import {
 } from '../../../actions/official';
 
 
-@connect(state => ({ officials: state.officials }))
+const mapStateToProps = state => ({
+    activeMembership: state.user.activeMembership,
+    officialList: state.officials.officialList,
+});
+
+@connect(mapStateToProps)
 export default class OfficialsPane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveOfficials());
     }
 
     renderPaneContent() {
-        let officialList = this.props.officials.officialList;
+        let officialList = this.props.officialList;
         let admins = officialList.items
             .filter(i => i.data.role === 'admin')
             .map(i => i.data);
@@ -29,11 +34,14 @@ export default class OfficialsPane extends RootPaneBase {
             .filter(i => i.data.role === 'organizer')
             .map(i => i.data);
 
+        let userProfile = this.props.activeMembership.profile;
+
         return [
             <div className="OfficialsPane-admins" key="admins">
                 <Msg tagName="h1" id="panes.officials.admins.h"/>
                 <Msg tagName="p" id="panes.officials.admins.desc"/>
                 <OfficialList officials={ admins }
+                    userProfile={ userProfile }
                     addMsg="panes.officials.admins.add"
                     selectLinkMsg="panes.officials.admins.selectLink"
                     onAdd={ this.onAdd.bind(this, 'admin') }
@@ -45,6 +53,7 @@ export default class OfficialsPane extends RootPaneBase {
                 <Msg tagName="h1" id="panes.officials.organizers.h"/>
                 <Msg tagName="p" id="panes.officials.organizers.desc"/>
                 <OfficialList officials={ organizers }
+                    userProfile={ userProfile }
                     addMsg="panes.officials.organizers.add"
                     selectLinkMsg="panes.officials.organizers.selectLink"
                     onAdd={ this.onAdd.bind(this, 'organizer') }


### PR DESCRIPTION
This PR prevents the user from changing their own role in `OfficialsPane`, by substituting `DraggableAvatar` for the regular `Avatar` component and adding a label that explains that the role is locked.

![prevent-change-role](https://cloud.githubusercontent.com/assets/550212/23068799/57674a4e-f525-11e6-881c-b14d4ff9196f.gif)

Fixes #384