### PR TITLE
Multi-select in lists

### DIFF
--- a/src/components/lists/List.jsx
+++ b/src/components/lists/List.jsx
@@ -12,6 +12,17 @@ function r(obj, fieldPath) {
     return path.reduce((o, e) => o[e], obj);
 }
 
+
+let shiftKeyDown = false;
+
+const onKeyDown = ev => {
+    if (ev.keyCode == 16) shiftKeyDown = true;
+};
+
+const onKeyUp = ev => {
+    if (ev.keyCode == 16) shiftKeyDown = false;
+};
+
 export default class List extends React.Component {
     static propTypes = {
         list: React.PropTypes.shape({
@@ -37,6 +48,18 @@ export default class List extends React.Component {
         super(props);
 
         this.state = {};
+        this.lastSelectedId = null;
+    }
+
+    componentDidMount() {
+        shiftKeyDown = false;
+        window.addEventListener('keydown', onKeyDown);
+        window.addEventListener('keyup', onKeyUp);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('keydown', onKeyDown);
+        window.removeEventListener('keyup', onKeyUp);
     }
 
     render() {
@@ -128,7 +151,7 @@ export default class List extends React.Component {
                             itemComponent={ this.props.itemComponent }
                             showCheckbox={ this.props.allowBulkSelection }
                             selected={ selected }
-                            onItemSelect={ this.props.onItemSelect }
+                            onItemSelect={ this.onItemSelect.bind(this) }
                             onItemClick={ this.props.onItemClick }/>
                     );
                 }) }
@@ -144,6 +167,30 @@ export default class List extends React.Component {
             .forEach(i => {
                 this.props.onItemSelect(i, ev.target.checked);
             });
+    }
+
+    onItemSelect(item, selected) {
+        if (this.props.onItemSelect) {
+            let prevItem = this.props.list.items.find(i =>
+                i.data && i.data.id === this.lastSelectedId);
+
+            if (selected && shiftKeyDown && prevItem) {
+                let prevIdx = this.props.list.items.indexOf(prevItem);
+                let curIdx = this.props.list.items.indexOf(item);
+
+                let start = Math.min(prevIdx, curIdx);
+                let end = Math.max(prevIdx, curIdx);
+
+                for (let i = start; i <= end; i++) {
+                    this.props.onItemSelect(this.props.list.items[i], true);
+                }
+            }
+            else {
+                this.props.onItemSelect(item, selected);
+            }
+
+            this.lastSelectedId = selected? item.data.id : null;
+        }
     }
 
     onLoadMoreClick() {

--- a/src/components/lists/List.jsx
+++ b/src/components/lists/List.jsx
@@ -87,8 +87,34 @@ export default class List extends React.Component {
             }
         }
 
+        let selectAllCheckbox;
+        if (this.props.allowBulkSelection) {
+            let allSelected = false;
+
+            if (selectedIds.length && selectedIds.length == items.length) {
+                allSelected = true;
+                for (let i = 0; i < items.length; i++) {
+                    let item = items[i];
+                    if (!item.data || selectedIds.indexOf(item.data.id) < 0) {
+                        allSelected = false;
+                        break;
+                    }
+                }
+            }
+
+            selectAllCheckbox = (
+                <div className="List-selectAllCheckbox">
+                    <input type="checkbox"
+                        checked={ allSelected }
+                        onChange={ this.onSelectAllChange.bind(this) }
+                        />
+                </div>
+            );
+        }
+
         return (
             <div className={ classes }>
+                { selectAllCheckbox }
                 { header }
 
                 <ul key="List-items">
@@ -110,6 +136,14 @@ export default class List extends React.Component {
                 { loadMoreLink }
             </div>
         );
+    }
+
+    onSelectAllChange(ev) {
+        this.props.list.items
+            .filter(i => !!i.data)
+            .forEach(i => {
+                this.props.onItemSelect(i, ev.target.checked);
+            });
     }
 
     onLoadMoreClick() {

--- a/src/components/lists/List.scss
+++ b/src/components/lists/List.scss
@@ -1,9 +1,11 @@
 .List {
     width: 100%;
     font-size: 1.3em;
+    position: relative;
 
     .ListHeader {
         position: relative;
+        z-index: 0;
         height: 15px;
 
         li {
@@ -15,6 +17,13 @@
 
     @include medium-screen {
         max-width: 720px;
+    }
+
+    .List-selectAllCheckbox {
+        @include col(1,12, $first:true, $last:true);
+        position: absolute;
+        z-index: 1;
+        text-align: center;
     }
 
     .List-loadMoreLink {

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -36,7 +36,6 @@ export default class PeopleListPane extends RootPaneBase {
 
         this.state = {
             selectedQueryId: undefined,
-            bulkSelectionId: undefined,
         };
     }
 
@@ -62,7 +61,7 @@ export default class PeopleListPane extends RootPaneBase {
     }
 
     getRenderData() {
-        let selectionId = this.state.bulkSelectionId;
+        let selectionId = this.bulkSelectionId;
         let selectionList = this.props.selections.selectionList;
         let selectionItem = getListItemById(selectionList, selectionId);
 
@@ -176,15 +175,13 @@ export default class PeopleListPane extends RootPaneBase {
     }
 
     onItemSelect(item, selected) {
-        let selectionId = this.state.bulkSelectionId;
+        let selectionId = this.bulkSelectionId;
         if (!selectionId) {
             let action = createSelection('bulk', null, null);
             selectionId = action.payload.id;
 
+            this.bulkSelectionId = selectionId
             this.props.dispatch(action);
-            this.setState({
-                bulkSelectionId: selectionId
-            });
         }
 
         if (selected) {

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -52,6 +52,12 @@ export default class PeopleListPane extends RootPaneBase {
         }
     }
 
+    componentWillUpdate(nextProps, nextState) {
+        if (nextState.selectedQueryId != this.state.selectedQueryId) {
+            this.bulkSelectionId = null;
+        }
+    }
+
     componentDidMount() {
         super.componentDidMount();
 


### PR DESCRIPTION
This PR adds UI for selecting multiple items in a list. A checkbox at the top lets the user select all the (visible) items in a list. Holding shift while clicking selects all the items between two items.

![multi-select](https://cloud.githubusercontent.com/assets/550212/23333201/cd6fb916-fb87-11e6-972b-ef5d59f748ac.gif)

Closes #464 