### PR TITLE
Person IO null rows

### DIFF
--- a/src/server/api/bulk.js
+++ b/src/server/api/bulk.js
@@ -78,7 +78,7 @@ let operations = {
                     req.body.objects.indexOf(p.id) >= 0);
 
                 let lastCell = xlsx.utils.encode_cell(
-                    { c: Object.keys(FIELDS).length, r: people.length + 1 });
+                    { c: Object.keys(FIELDS).length, r: people.length });
 
                 let wb = {
                     SheetNames: ['Zetkin'],

--- a/src/utils/import.js
+++ b/src/utils/import.js
@@ -44,10 +44,13 @@ export function parseWorkbook(data) {
                     return cell? cell.v : undefined;
                 });
 
-                table.rows.push({
-                    included: true,
-                    values: rowValues,
-                });
+                // Only include if there are non-null values in the row
+                if (!!rowValues.find(v => v != null)) {
+                    table.rows.push({
+                        included: true,
+                        values: rowValues,
+                    });
+                }
             }
 
             // Iterate from right to left, finding completely empty columns


### PR DESCRIPTION
This PR fixes an issue which was causing an all-null row to be included at the end of an exported XLSX file. It also tweaks the importer to ignore such rows, should they still occur, e.g. in old files.

Fixes #484 