### PR TITLE
Missing survey options

### DIFF
--- a/locale/forms/survey/sv.yaml
+++ b/locale/forms/survey/sv.yaml
@@ -4,3 +4,7 @@ access: "Åtkomst"
 accessOptions:
     open: "Öppen för vem som helst"
     auth: "Endast för anslutna användare"
+signature: "Policy för signering"
+signatureOptions:
+    anon: "Tillåt anonyma svar"
+    sign: "Kräv signatur med namn och e-post"

--- a/locale/forms/surveyQuestion/sv.yaml
+++ b/locale/forms/surveyQuestion/sv.yaml
@@ -4,3 +4,11 @@ responseType: Svarstyp
 responseTypeOptions:
     options: Svarsalternativ
     text: Fritext
+textWidget: Typ av textfält
+textWidgetOptions:
+    multi: Flera rader
+    single: Enkelrad
+optionsWidget: Flervalsregler
+optionsWidgetOptions:
+    checkbox: Tillåt flera svarsalternativ
+    radio: Tillåt bara ett svarsalternativ

--- a/src/components/forms/SurveyForm.jsx
+++ b/src/components/forms/SurveyForm.jsx
@@ -18,10 +18,17 @@ export default class SurveyForm extends React.Component {
 
     render() {
         let survey = this.props.survey || {};
-        let options = {
+        let accessOptions = {
             'open': 'forms.survey.accessOptions.open',
             'auth': 'forms.survey.accessOptions.auth',
         };
+
+        let signatureOptions = {
+            'anon': 'forms.survey.signatureOptions.anon',
+            'sign': 'forms.survey.signatureOptions.sign',
+        };
+
+        survey.signature = survey.allow_anonymous? 'anon' : 'sign';
 
         return (
             <Form className="SurveyForm" ref="form" { ...this.props }>
@@ -31,16 +38,31 @@ export default class SurveyForm extends React.Component {
                     initialValue={ survey.info_text }/>
                 <SelectInput labelMsg="forms.survey.access" name="access"
                     initialValue={ survey.access }
-                    options={ options } optionLabelsAreMessages={ true }/>
+                    options={ accessOptions } optionLabelsAreMessages={ true }/>
+                <SelectInput labelMsg="forms.survey.signature" name="signature"
+                    initialValue={ survey.signature }
+                    options={ signatureOptions } optionLabelsAreMessages={ true }/>
             </Form>
         );
     }
 
     getValues() {
-        return this.refs.form.getValues();
+        let values = this.refs.form.getValues();
+        values.allow_anonymous = (values.signature == 'anon');
+        delete values['signature'];
+
+        console.log(values);
+        return values;
     }
 
     getChangedValues() {
-        return this.refs.form.getChangedValues();
+        let values = this.refs.form.getChangedValues();
+        if ('signature' in values) {
+            values.allow_anonymous = (values.signature == 'anon');
+            delete values['signature'];
+        }
+
+        console.log(values);
+        return values;
     }
 }

--- a/src/components/forms/SurveyForm.jsx
+++ b/src/components/forms/SurveyForm.jsx
@@ -51,7 +51,6 @@ export default class SurveyForm extends React.Component {
         values.allow_anonymous = (values.signature == 'anon');
         delete values['signature'];
 
-        console.log(values);
         return values;
     }
 
@@ -62,7 +61,6 @@ export default class SurveyForm extends React.Component {
             delete values['signature'];
         }
 
-        console.log(values);
         return values;
     }
 }


### PR DESCRIPTION
This PR adds survey options that are in the API but were previously not accessible through the Organize UI:

* Whether to allow anonymous signatures on surveys
* Widget settings (`response_config`) for questions