### PR TITLE
Call filters

### DIFF
--- a/locale/panes/callLog/en.yaml
+++ b/locale/panes/callLog/en.yaml
@@ -1,0 +1,8 @@
+filters:
+    oa:
+        label: Flagged for official action
+        options:
+            all: All calls regardless of flagging
+            needed: All flagged calls
+            notTaken: Flagged calls where action is needed
+            taken: Flagged calls where action was taken

--- a/locale/panes/callLog/sv.yaml
+++ b/locale/panes/callLog/sv.yaml
@@ -1,0 +1,8 @@
+filters:
+    oa:
+        label: Flaggad för funktionärsåtgärd
+        options:
+            all: Alla samtal oavsett flaggning
+            needed: Alla flaggade samtal
+            notTaken: Flaggade samtal där åtgärd krävs
+            taken: Flaggade samtal där åtgärd vidtagits

--- a/src/actions/call.js
+++ b/src/actions/call.js
@@ -1,16 +1,31 @@
 import * as types from '.';
 
 
-export function retrieveCalls(page = 0, perPage = 100) {
+export function retrieveCalls(page = 0, filters = {}) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;
+
+        let filterStrings = [];
+
+        switch (filters.oa) {
+            case 'needed':
+                filterStrings.push(['organizer_action_needed', '==', 1])
+                break;
+            case 'taken':
+                filterStrings.push(['organizer_action_taken', '==', 1])
+                break;
+            case 'notTaken':
+                filterStrings.push(['organizer_action_needed', '==', 1])
+                filterStrings.push(['organizer_action_taken', '==', 0])
+                break;
+        }
 
         dispatch({
             type: types.RETRIEVE_CALLS,
             meta: { page },
             payload: {
                 promise: z.resource('orgs', orgId, 'calls')
-                    .get(page, perPage),
+                    .get(page, 100, filterStrings),
             }
         });
     };

--- a/src/components/sections/RootPaneBase.jsx
+++ b/src/components/sections/RootPaneBase.jsx
@@ -13,6 +13,7 @@ export default class RootPaneBase extends React.Component {
         this.state = {
             scrolled: false,
             showFilters: false,
+            filters: {}
         };
     }
 
@@ -52,7 +53,7 @@ export default class RootPaneBase extends React.Component {
         });
 
         let filterDrawer = null;
-        let filters = this.getPaneFilters(data);
+        let filters = this.getPaneFilters(data, this.state.filters);
         var toolbar = this.getPaneTools(data);
 
         if (filters || toolbar) {
@@ -131,7 +132,7 @@ export default class RootPaneBase extends React.Component {
         return null;
     }
 
-    getPaneFilters(data) {
+    getPaneFilters(data, filters) {
         return null;
     }
 
@@ -176,10 +177,22 @@ export default class RootPaneBase extends React.Component {
         }
     }
 
+    onFilterChange(name, value) {
+        this.setState({
+            filters: {
+                [name]: value,
+            }
+        });
+    }
+
     onFilterButtonClick() {
         this.setState({
             showFilters: !this.state.showFilters,
         });
+
+        if (this.onFiltersApply) {
+            this.onFiltersApply(this.state.filters);
+        }
     }
 
     onCloseClick(ev) {

--- a/src/components/sections/dialog/CallLogPane.jsx
+++ b/src/components/sections/dialog/CallLogPane.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { FormattedMessage as Msg } from 'react-intl';
 
 import CallList from '../../lists/CallList';
 import RootPaneBase from '../RootPaneBase';
+import SelectInput from '../../forms/inputs/SelectInput';
 import { retrieveCalls } from '../../../actions/call';
 
 
-@connect(state => state)
+const mapStateToProps = state => ({
+    callList: state.calls.callList,
+});
+
+@connect(mapStateToProps)
 export default class CallLogPane extends RootPaneBase {
     componentDidMount() {
         this.props.dispatch(retrieveCalls());
@@ -14,8 +20,27 @@ export default class CallLogPane extends RootPaneBase {
 
     getRenderData() {
         return {
-            callList: this.props.calls.callList,
+            callList: this.props.callList,
         };
+    }
+
+    getPaneFilters(data, filters) {
+        let oaOptions = {
+            'all': 'panes.callLog.filters.oa.options.all',
+            'needed': 'panes.callLog.filters.oa.options.needed',
+            'taken': 'panes.callLog.filters.oa.options.taken',
+            'notTaken': 'panes.callLog.filters.oa.options.notTaken',
+        };
+
+        return [
+            <div key="oa">
+                <Msg tagName="label" id="panes.callLog.filters.oa.label"/>
+                <SelectInput name="oa" options={ oaOptions }
+                    value={ filters.oa || 'all' }
+                    optionLabelsAreMessages={ true }
+                    onValueChange={ this.onFilterChange.bind(this) }/>
+            </div>
+        ];
     }
 
     renderPaneContent(data) {
@@ -31,7 +56,13 @@ export default class CallLogPane extends RootPaneBase {
         this.openPane('call', call.id);
     }
 
+    onFiltersApply(filters) {
+        this.setState({ filters });
+
+        this.props.dispatch(retrieveCalls(0, filters));
+    }
+
     onLoadPage(page) {
-        this.props.dispatch(retrieveCalls(page));
+        this.props.dispatch(retrieveCalls(page, this.state.filters));
     }
 }


### PR DESCRIPTION
This PR adds a filter drawer for the call log. It also makes some changes to the surrounding frameworks, making it easier to create stateful filter drawers in the future.

![image](https://cloud.githubusercontent.com/assets/550212/24608561/536159f6-1877-11e7-9344-d0b5c5d224cb.png)

This contains the most urgent filters explained in #445. The rest can be added later.