### PR TITLE
Tweak add buttons

### DIFF
--- a/locale/panes/allActions/en.yaml
+++ b/locale/panes/allActions/en.yaml
@@ -1,3 +1,4 @@
+addButton: Add action
 filters:
     afterDate: After date
     beforeDate: Before date

--- a/locale/panes/allActions/sv.yaml
+++ b/locale/panes/allActions/sv.yaml
@@ -1,3 +1,4 @@
+addButton: Lägg till ny aktion
 filters:
     afterDate: Från datum
     beforeDate: Till datum

--- a/src/components/sections/campaign/AllActionsPane.jsx
+++ b/src/components/sections/campaign/AllActionsPane.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import Button from '../../misc/Button';
+
 import CampaignSectionPaneBase from './CampaignSectionPaneBase';
 import ActionList from '../../lists/ActionList';
 import ActionCalendar from '../../misc/actioncal/ActionCalendar';
@@ -81,6 +83,10 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
             <ViewSwitch key="viewSwitch" states={ viewStates }
                 selected={ this.state.viewMode }
                 onSwitch={ this.onViewSwitch.bind(this) }/>,
+            <Button key="addButton"
+                className="allActionsPane-addButton"
+                labelMsg="panes.allActions.addButton"
+                onClick={ this.onAddClick.bind(this) }/>,
         ];
     }
 
@@ -88,5 +94,9 @@ export default class AllActionsPane extends CampaignSectionPaneBase {
         this.setState({
             viewMode: state
         });
+    }
+
+    onAddClick() {
+        this.openPane('addaction');
     }
 }

--- a/src/components/sections/campaign/AllActionsPane.scss
+++ b/src/components/sections/campaign/AllActionsPane.scss
@@ -1,0 +1,6 @@
+.allActionsPane {
+    .allActionsPane-addButton {
+        @include inline-button($icon: $fa-var-plus);
+        float: right;
+    }
+}

--- a/src/components/sections/dialog/AllCallAssignmentsPane.jsx
+++ b/src/components/sections/dialog/AllCallAssignmentsPane.jsx
@@ -31,7 +31,7 @@ export default class AllCallAssignmentsPane extends RootPaneBase {
     getPaneTools(data) {
         return [
             <Button key="addButton"
-                className="AllCallAssignmentsPane-addButton"
+                className="allCallAssignmentsPane-addButton"
                 labelMsg="panes.allCallAssignments.addButton"
                 onClick={ this.onAddClick.bind(this) }/>,
         ];

--- a/src/components/sections/dialog/AllCallAssignmentsPane.scss
+++ b/src/components/sections/dialog/AllCallAssignmentsPane.scss
@@ -1,0 +1,6 @@
+.allCallAssignmentsPane {
+    .allCallAssignmentsPane-addButton {
+        @include inline-button($icon: $fa-var-plus);
+        float: right;
+    }
+}

--- a/src/components/sections/maps/LocationsPane.scss
+++ b/src/components/sections/maps/LocationsPane.scss
@@ -1,7 +1,7 @@
 .LocationsPane {
-
     .LocationsPane-addLocationButton {
         @include inline-button($icon: $fa-var-plus);
+        float: right;
     }
 
 }

--- a/src/components/sections/people/PeopleListPane.scss
+++ b/src/components/sections/people/PeopleListPane.scss
@@ -1,6 +1,7 @@
 .PeopleListPane {
     .PeopleListPane-addButton {
         @include inline-button($icon: $fa-var-plus);
+        float: right;
     }
 
 }

--- a/src/components/sections/survey/SurveyListPane.scss
+++ b/src/components/sections/survey/SurveyListPane.scss
@@ -1,0 +1,6 @@
+.SurveyListPane {
+    .SurveyListPane-addButton {
+        @include inline-button($icon: $fa-var-plus);
+        float: right;
+    }
+}


### PR DESCRIPTION
Adding button to add Action (open addActionPane) in the toolbar of AllActionsPane.

By this, a vulnerability from a UX point of view arouse. Two essentially different types of buttons - those that alters the current pane (how and what to view) and those that moves to a different setting (like creating a new of what is listed in the mother pane). Having these in a mixed order would make them to compete for users attention and understanding of the area and the tools within.

By separating these types of buttons, the users learns that there is dedicated places for these different actions which increases the workflow speed.

In UX design, the right corners is usually recommended for confirming or to continue to next step in workflow, in this context - to create or add something. The left corners are either for canceling/reverting workflow or to change the current context - or how to view it.

Thus, I floated the add button to the right like this:

![screen shot 2017-04-21 at 16 37 55](https://cloud.githubusercontent.com/assets/1271517/25283477/3ce82894-26b4-11e7-95dd-7dc313a1f14c.png)

In order to keep consistency in the UI, I also changed this in the other root panes with add buttons.