### PR TITLE
Person select widget

### DIFF
--- a/locale/misc/en.yaml
+++ b/locale/misc/en.yaml
@@ -29,6 +29,8 @@ personSelectWidget:
     selectInstructions: Select a person from the list or drop here to select.
     selectLink: select one
     undoLink: Go back
+relSelectInput:
+    placeholder: Start typing to find or create
 staticMap:
     noCoordinates: No position
     setPositionLink: Click to set position

--- a/locale/misc/en.yaml
+++ b/locale/misc/en.yaml
@@ -24,6 +24,11 @@ inviteBox:
     sendButton: Send
 officialList:
     userLabel: Can't change own role
+personSelectWidget:
+    changeInstructions: Drop another person here or { selectLink } to change.
+    selectInstructions: Select a person from the list or drop here to select.
+    selectLink: select one
+    undoLink: Go back
 staticMap:
     noCoordinates: No position
     setPositionLink: Click to set position

--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -33,6 +33,8 @@ personSelectWidget:
     selectInstructions: Välj en person från listan eller dra och släpp här för att välja.
     selectLink: välj en
     undoLink: Gå tillbaka
+relSelectInput:
+    placeholder: Skriv för att hitta eller skapa
 staticMap:
     noCoordinates: Ingen position
     setPositionLink: Klicka för att ange position

--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -28,6 +28,11 @@ inviteBox:
     sendButton: Skicka
 officialList:
     userLabel: Din egen roll är låst
+personSelectWidget:
+    changeInstructions: Släpp en person här eller { selectLink } för att byta.
+    selectInstructions: Välj en person från listan eller dra och släpp här för att välja.
+    selectLink: välj en
+    undoLink: Gå tillbaka
 staticMap:
     noCoordinates: Ingen position
     setPositionLink: Klicka för att ange position

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -1,4 +1,4 @@
-import { FormattedMessage as Msg } from 'react-intl';
+import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 import ReactDOM from 'react-dom';
 import React from 'react';
 import cx from 'classnames';
@@ -6,6 +6,7 @@ import cx from 'classnames';
 import InputBase from './InputBase';
 
 
+@injectIntl
 export default class RelSelectInput extends InputBase {
     constructor(props) {
         super(props);
@@ -101,9 +102,13 @@ export default class RelSelectInput extends InputBase {
             this.values.push('-');
         }
 
+        let placeholder = this.props.intl.formatMessage(
+            { id: 'misc.relSelectInput.placeholder' });
+
         return (
             <div className={ classes }>
                 <input type="text" ref="input" value={ inputValue }
+                    placeholder={ placeholder }
                     onChange={ this.onInputChange.bind(this) }
                     onFocus={ this.onFocus.bind(this) }
                     onKeyDown={ this.onKeyDown.bind(this) }

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -41,13 +41,12 @@ export default class RelSelectInput extends InputBase {
         const objects = this.props.objects;
         const showEditLink = this.props.showEditLink;
         const valueField = this.props.valueField;
-        const labelField = this.props.labelField;
         const selected = (value && objects)?
             objects.find(o => o[valueField] == value) : null;
 
         var inputValue = this.state.inputValue;
         if (inputValue === undefined) {
-            inputValue = (selected? selected[labelField] : '');
+            inputValue = (selected? label(selected) : '');
         }
 
         const classes = cx({
@@ -112,7 +111,6 @@ export default class RelSelectInput extends InputBase {
                 <ul ref="objectList">
                 {filteredObjects.map(function(obj, idx) {
                     const value = obj[valueField];
-                    const label = obj[labelField];
                     const classes = cx({
                         'selected': (obj == selected),
                         'focused': (idx === this.state.focusedIndex)
@@ -128,7 +126,7 @@ export default class RelSelectInput extends InputBase {
                         <li key={ value } className={ classes }>
                             <label className="RelSelectInput-itemLabel"
                                 onMouseDown={ this.onClickOption.bind(this, obj) }>
-                                { label }
+                                { this.getLabel(obj) }
                             </label>
                             { editLink }
                         </li>
@@ -141,12 +139,24 @@ export default class RelSelectInput extends InputBase {
         );
     }
 
+    getLabel(obj) {
+        if (this.props.labelField) {
+            return obj[this.props.labelField];
+        }
+        else if (this.props.labelFunc) {
+            return this.props.labelFunc(obj);
+        }
+        else {
+            return obj[this.props.valueField];
+        }
+    };
+
+
     getFilteredObjects() {
         // Filter objects based on input value, unless it's undefined or
         // an empty string in which case all objects should be displayed.
-        const labelField = this.props.labelField;
         return this.props.objects.filter(o =>
-            (!this.state.inputValue || o[labelField].toLowerCase()
+            (!this.state.inputValue || this.getLabel(o).toLowerCase()
                 .indexOf(this.state.inputValue.toLowerCase()) >= 0));
     }
 
@@ -274,6 +284,7 @@ RelSelectInput.propTypes = {
     objects: React.PropTypes.array.isRequired,
     valueField: React.PropTypes.string,
     labelField: React.PropTypes.string,
+    labelFunc: React.PropTypes.func,
     nullLabel: React.PropTypes.string,
     showCreateOption: React.PropTypes.bool,
     showEditLink: React.PropTypes.bool,
@@ -287,7 +298,6 @@ RelSelectInput.defaultProps = {
     showCreateOption: true,
     showEditLink: false,
     valueField: 'id',
-    labelField: 'title',
     nullLabel: 'None'
 };
 

--- a/src/components/forms/inputs/RelSelectInput.scss
+++ b/src/components/forms/inputs/RelSelectInput.scss
@@ -4,6 +4,10 @@
 
     input[type=text] {
         @include input-base;
+
+        &::placeholder {
+            color: darken(white, 30);
+        }
     }
 
     ul {

--- a/src/components/misc/DraggableAvatar.jsx
+++ b/src/components/misc/DraggableAvatar.jsx
@@ -24,10 +24,6 @@ const personSource = {
             dropResult.onAddParticipant(person);
         }
 
-        if (targetType == 'contact' && dropResult.onSetContact) {
-            dropResult.onSetContact(person);
-        }
-
         // TODO: Use a more generalized interface like this everywhere?
         if (dropResult.onDropPerson) {
             dropResult.onDropPerson(person, targetType);

--- a/src/components/misc/PersonSelectWidget.jsx
+++ b/src/components/misc/PersonSelectWidget.jsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import cx from 'classnames';
+import { connect } from 'react-redux';
+import { DropTarget } from 'react-dnd';
+import { FormattedMessage as Msg } from 'react-intl';
+
+import DraggableAvatar from './DraggableAvatar';
+import Link from './Link';
+import Person from './elements/Person';
+import RelSelectInput from '../forms/inputs/RelSelectInput';
+import { retrievePeople } from '../../actions/person';
+import { getListItemById } from '../../utils/store';
+
+
+const contactTarget = {
+    canDrop(props, monitor) {
+        return true;
+    },
+
+    drop(props) {
+        return {
+            targetType: 'person',
+            onDropPerson: person => {
+                if (props.onSelect) {
+                    props.onSelect(person);
+                }
+            }
+        }
+    }
+};
+
+const collectPerson = (connect, monitor) => ({
+    connectDropTarget: connect.dropTarget(),
+    isPersonOver: monitor.isOver(),
+    canDropPerson: monitor.canDrop()
+});
+
+const mapStateToProps = state => ({
+    personList: state.people.personList,
+});
+
+
+@connect(mapStateToProps)
+@DropTarget('person', contactTarget, collectPerson)
+export default class PersonSelectWidget extends React.Component {
+    static propTypes = {
+        person: React.PropTypes.object,
+        personList: React.PropTypes.object,
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            forceShowInput: false,
+        };
+    }
+
+    componentDidMount() {
+        if (!this.props.person) {
+            this.props.dispatch(retrievePeople());
+        }
+    }
+
+    componentWillUpdate(nextProps, nextState) {
+        let inputWasVisible = this.state.forceShowInput || !this.props.person;
+        let inputWillBeVisible = nextState.forceShowInput || !nextProps.person;
+
+        if (inputWillBeVisible && !inputWasVisible) {
+            if (nextProps.personList && nextProps.personList.isPending) {
+                return;
+            }
+
+            this.props.dispatch(retrievePeople());
+        }
+    }
+
+    render() {
+        let content = [];
+        let classes = cx('PersonSelectWidget', {
+            selected: !!this.props.person,
+            selecting: !this.props.person,
+            changing: this.state.forceShowInput,
+        });
+
+        if (this.props.person) {
+            content.push(
+                <DraggableAvatar key="avatar"
+                    person={ this.props.person }
+                    />,
+                <a key="clearLink"
+                    className="PersonSelectWidget-clearLink"
+                    onClick={ this.onClearLinkClick.bind(this) }>
+                    <i className="fa fa-remove"></i>
+                </a>
+            );
+        }
+
+        if (this.state.forceShowInput || !this.props.person) {
+            let personList = this.props.personList;
+            let people = personList.items? personList.items.map(i => i.data) : [];
+
+            content.push(
+                <RelSelectInput key="input"
+                    labelFunc={ p => p.first_name + ' ' + p.last_name }
+                    onValueChange={ this.onInputChange.bind(this) }
+                    objects={ people }
+                    />
+            );
+
+            if (this.state.forceShowInput) {
+                content.push(
+                    <p key="instructions"
+                        className="PersonSelectWidget-instructions">
+                        <Link msgId="misc.personSelectWidget.undoLink"
+                            onClick={ this.onUndoLinkClick.bind(this) }
+                            />
+                    </p>
+                );
+            }
+            else {
+                content.push(
+                    <p key="instructions"
+                        className="PersonSelectWidget-instructions">
+                        <Msg id="misc.personSelectWidget.selectInstructions"
+                            />
+                    </p>
+                );
+            }
+        }
+        else {
+            let selectLink = (
+                <Link msgId="misc.personSelectWidget.selectLink"
+                    onClick={ this.onSelectLinkClick.bind(this) }
+                    />
+            );
+
+            content.push(
+                <Person key="name"
+                    person={ this.props.person }
+                    />,
+                <p key="instructions"
+                    className="PersonSelectWidget-instructions">
+                    <Msg id="misc.personSelectWidget.changeInstructions"
+                        values={{ selectLink }}
+                        />
+                </p>,
+            );
+        }
+
+        return this.props.connectDropTarget(
+            <div className={ classes }>
+                { content }
+            </div>
+        );
+    }
+
+    onInputChange(name, value) {
+        let item = getListItemById(this.props.personList, value);
+
+        if (item) {
+            this.setState({
+                forceShowInput: false,
+            }, () => {
+                if (this.props.onSelect) {
+                    this.props.onSelect(item.data)
+                }
+            });
+        }
+    }
+
+    onSelectLinkClick() {
+        this.setState({
+            forceShowInput: true
+        });
+    }
+
+    onClearLinkClick() {
+        if (this.props.onSelect) {
+            this.props.onSelect(null);
+        }
+    }
+
+    onUndoLinkClick() {
+        this.setState({
+            forceShowInput: false,
+        });
+    }
+}

--- a/src/components/misc/PersonSelectWidget.jsx
+++ b/src/components/misc/PersonSelectWidget.jsx
@@ -58,7 +58,7 @@ export default class PersonSelectWidget extends React.Component {
 
     componentDidMount() {
         if (!this.props.person) {
-            this.props.dispatch(retrievePeople());
+            this.props.dispatch(retrievePeople(null, null));
         }
     }
 
@@ -71,7 +71,7 @@ export default class PersonSelectWidget extends React.Component {
                 return;
             }
 
-            this.props.dispatch(retrievePeople());
+            this.props.dispatch(retrievePeople(null, null));
         }
     }
 

--- a/src/components/misc/PersonSelectWidget.scss
+++ b/src/components/misc/PersonSelectWidget.scss
@@ -1,0 +1,81 @@
+.PersonSelectWidget {
+    @include ghost-placeholder();
+
+    position: relative;
+    height: 74px;
+    text-align: left;
+    color: #333;
+
+    .DraggableAvatar {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        width: 50px;
+        height: 50px;
+    }
+
+    .Person {
+        position: absolute;
+        top: 16px;
+        left: 70px;
+        right: 10px;
+        font-size: 20px;
+        white-space: nowrap;
+        z-index: 0;
+    }
+
+    .RelSelectInput {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        right: 10px;
+        width: auto;
+    }
+
+    .PersonSelectWidget-instructions {
+        position: absolute;
+        top: 32px;
+        left: 10px;
+        right: 10px;
+
+        font-size: 11px !important;
+        line-height: 0.95em !important;
+        color: #999;
+    }
+
+    .PersonSelectWidget-clearLink {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 1;
+
+        opacity: 0.1;
+        transition: opacity 0.2s;
+    }
+
+    &:hover {
+        .PersonSelectWidget-clearLink {
+            opacity: 0.5;
+
+            &:hover {
+                opacity: 0.8;
+            }
+        }
+    }
+
+    &.changing, &.selected {
+        .RelSelectInput {
+            left: 70px;
+        }
+
+        .PersonSelectWidget-instructions {
+            left: 70px;
+        }
+    }
+
+    &.changing, &.selecting {
+        .PersonSelectWidget-instructions {
+            top: 38px;
+        }
+    }
+}

--- a/src/components/panes/ActionPane.scss
+++ b/src/components/panes/ActionPane.scss
@@ -158,28 +158,6 @@
         }
     }
 
-    .ActionPane-contactDropTarget {
-        @include ghost-placeholder();
-        position: relative;
-
-        .ContactSlot {
-            display: inline-block;
-            @include col(2,12, $align: middle);
-            width: 3em;
-            font-size: 1.5em;
-
-            figure {
-                margin-left: -0.5em;
-            }
-        }
-
-        span {
-            @include col(10,12, $align: middle);
-            font-size: 1.3em;
-            color: lighten($c-text, 50);
-        }
-    }
-
     .ParticipantList {
         float: none;
     }


### PR DESCRIPTION
This PR adds a new widget called `PersonSelectWidget`, suitable for selecting a single person inline, e.g. the contact for an action or the manager for a campaign. It supports both drag/drop and selecting from a list (`RelSelectInput`).

![image](https://cloud.githubusercontent.com/assets/550212/26275417/0779cee8-3d60-11e7-900e-e90047459d17.png)
![image](https://cloud.githubusercontent.com/assets/550212/26275413/fa321394-3d5f-11e7-869c-1ce86aeb0dd8.png)
![image](https://cloud.githubusercontent.com/assets/550212/26275415/011885bc-3d60-11e7-9f08-c88d220416d7.png)

The PR also implements this new widget in a few locations.

Fixes #602
Fixes #603