### PR TITLE
Canvass route address panes

### DIFF
--- a/locale/lists/addressList/en.yaml
+++ b/locale/lists/addressList/en.yaml
@@ -1,0 +1,4 @@
+header:
+    number: Number
+    street: Street name
+    suffix: Suffix

--- a/locale/lists/addressList/sv.yaml
+++ b/locale/lists/addressList/sv.yaml
@@ -1,0 +1,4 @@
+header:
+    number: Nummer
+    street: Gatunamn
+    suffix: Suffix

--- a/locale/panes/allRoutes/en.yaml
+++ b/locale/panes/allRoutes/en.yaml
@@ -1,6 +1,9 @@
 filters:
+    street:
+        label: Addresses on street
+        nullOption: (Any street)
     tag:
-        label: Routes containing tag
+        label: Addresses tagged
         nullOption: (All addresses)
 routePanel:
     drafts:

--- a/locale/panes/allRoutes/sv.yaml
+++ b/locale/panes/allRoutes/sv.yaml
@@ -1,6 +1,9 @@
 filters:
+    street:
+        label: Adresser på gata
+        nullOption: (Vilken gata som helst)
     tag:
-        label: Rutter som innehåller etikett
+        label: Adresser med etiketten
         nullOption: (Alla adresser)
 routePanel:
     drafts:

--- a/locale/panes/routeContent/en.yaml
+++ b/locale/panes/routeContent/en.yaml
@@ -1,0 +1,9 @@
+addresses:
+    item:
+        deleteButton: Delete
+        households: >-
+            {count, plural,
+                =1 {One household}
+                other {# households}
+            }
+    h: Addresses in route

--- a/locale/panes/routeContent/sv.yaml
+++ b/locale/panes/routeContent/sv.yaml
@@ -1,0 +1,9 @@
+addresses:
+    item:
+        deleteButton: Radera
+        households: >-
+            {count, plural,
+                =1 {Ett hushåll}
+                other {# hushåll}
+            }
+    h: Adresser i den här rutten

--- a/locale/panes/selectStreetAddress/en.yaml
+++ b/locale/panes/selectStreetAddress/en.yaml
@@ -1,2 +1,11 @@
+saveButton: |
+    {numSelected, plural,
+        =0 {Close without selecting}
+        =1 {Select one address}
+        other {Select # addresses}
+    }
 title: Select addresses from {street}
-saveButton: Save selection
+views:
+    all: All
+    even: Even numbers
+    odd: Odd numbers

--- a/locale/panes/selectStreetAddress/en.yaml
+++ b/locale/panes/selectStreetAddress/en.yaml
@@ -1,0 +1,2 @@
+title: Select addresses from {street}
+saveButton: Save selection

--- a/locale/panes/selectStreetAddress/sv.yaml
+++ b/locale/panes/selectStreetAddress/sv.yaml
@@ -1,2 +1,11 @@
+saveButton: |
+    {numSelected, plural,
+        =0 {Close without selecting}
+        =1 {Select one address}
+        other {Select # addresses}
+    }
 title: Välj adresser från {street}
-saveButton: Spara urval
+views:
+    all: Alla
+    even: Jämna nummer
+    odd: Udda nummer

--- a/locale/panes/selectStreetAddress/sv.yaml
+++ b/locale/panes/selectStreetAddress/sv.yaml
@@ -1,0 +1,2 @@
+title: Välj adresser från {street}
+saveButton: Spara urval

--- a/src/actions/selection.js
+++ b/src/actions/selection.js
@@ -4,14 +4,14 @@ import { getListItemById } from '../utils/store';
 
 
 export function createSelection(objType, selectedIds,
-                                instructions, doneCallback) {
+                                instructions, doneCallback, meta) {
 
     let id = '$' + makeRandomString(6);
     selectedIds = selectedIds || [];
 
     return {
         type: types.CREATE_SELECTION,
-        payload: { id, objType, selectedIds, instructions, doneCallback },
+        payload: { id, objType, selectedIds, instructions, doneCallback, meta },
     };
 }
 

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -158,11 +158,20 @@ export default class RelSelectInput extends InputBase {
 
 
     getFilteredObjects() {
+        let filter = this.state.inputValue;
+        let filterLen = filter? filter.length : 0;
+        let minLen = this.props.minFilterLength || 0;
+
+        // Return an empty array if the filter is not long enough
+        if (filterLen < minLen) {
+            return [];
+        }
+
         // Filter objects based on input value, unless it's undefined or
         // an empty string in which case all objects should be displayed.
         return this.props.objects.filter(o =>
-            (!this.state.inputValue || this.getLabel(o).toLowerCase()
-                .indexOf(this.state.inputValue.toLowerCase()) >= 0));
+            (!filter || this.getLabel(o).toLowerCase()
+                .indexOf(filter.toLowerCase()) >= 0));
     }
 
     onInputChange(ev) {
@@ -290,6 +299,7 @@ RelSelectInput.propTypes = {
     valueField: React.PropTypes.string,
     labelField: React.PropTypes.string,
     labelFunc: React.PropTypes.func,
+    minFilterLength: React.PropTypes.number,
     nullLabel: React.PropTypes.string,
     showCreateOption: React.PropTypes.bool,
     showEditLink: React.PropTypes.bool,

--- a/src/components/lists/AddressList.jsx
+++ b/src/components/lists/AddressList.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import cx from 'classnames';
+
+import List from './List';
+import AddressListItem from './items/AddressListItem';
+
+
+export default class AddressList extends React.Component {
+    static propTypes = {
+        allowBulkSelection: React.PropTypes.bool,
+        bulkSelection: React.PropTypes.object,
+        enablePagination: React.PropTypes.bool,
+        onItemSelect: React.PropTypes.func,
+        onItemClick: React.PropTypes.func,
+        addressList: React.PropTypes.shape({
+            error: React.PropTypes.object,
+            isPending: React.PropTypes.bool,
+            items: React.PropTypes.array,
+        }).isRequired,
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        return (nextProps.addressList !== this.props.addressList
+            || nextProps.bulkSelection !== this.props.bulkSelection);
+    }
+
+    render() {
+        const columns = [
+            {
+                'street': 'lists.addressList.header.street',
+                'number': 'lists.addressList.header.number',
+                'suffix': 'lists.addressList.header.suffix',
+            },
+        ];
+
+        return (
+            <List className="AddressList"
+                headerColumns={ columns } itemComponent={ AddressListItem }
+                list={ this.props.addressList }
+                enablePagination={ !!this.props.enablePagination }
+                allowBulkSelection={ this.props.allowBulkSelection }
+                bulkSelection={ this.props.bulkSelection }
+                onItemSelect={ this.props.onItemSelect }
+                onItemClick={ this.props.onItemClick }
+                onLoadPage={ this.props.onLoadPage }
+                />
+        );
+    }
+}

--- a/src/components/lists/AddressList.scss
+++ b/src/components/lists/AddressList.scss
@@ -1,0 +1,35 @@
+.AddressList {
+    font-size: 1.0em;
+
+    .ListHeader {
+        @include col-offset(2,12);
+        margin-bottom: 1em;
+        padding-left: 1em;
+    }
+
+    .ListItem.ListItem-withCheckbox {
+        background: $c-ui-bg;
+        box-shadow: none;
+        border-radius: 0;
+        border-bottom: 1px solid darken($c-ui-bg, 10);
+        margin: 0;
+
+        &:hover {
+            background: darken($c-ui-bg, 1);
+        }
+    }
+
+    &.List .List-selectAllCheckbox {
+        @include col(2,12);
+    }
+
+    .ListItem.ListItem-withCheckbox  {
+        > :nth-child(2) {
+            padding: 2em 1em;
+        }
+    }
+
+    .ListItem.ListItem-withCheckbox .ListItem-selection {
+        @include col(2,12);
+    }
+}

--- a/src/components/lists/items/AddressListItem.jsx
+++ b/src/components/lists/items/AddressListItem.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { stringFromAddress } from '../../../utils/location';
+
+
+export default class AddressListItem extends React.Component {
+    static propTypes = {
+        onItemClick: React.PropTypes.func,
+        data: React.PropTypes.shape({
+            id: React.PropTypes.string.isRequired,
+            street: React.PropTypes.string.isRequired,
+            number: React.PropTypes.string,
+            suffix: React.PropTypes.string,
+        })
+    }
+
+    render() {
+        let addr = this.props.data;
+
+        return (
+            <div className="AddressListItem"
+                onClick={ this.props.onItemClick }>
+
+                <div className="AddressListItem-col">
+                    { stringFromAddress(addr) }
+                </div>
+            </div>
+        );
+    }
+}
+

--- a/src/components/misc/PersonSelectWidget.jsx
+++ b/src/components/misc/PersonSelectWidget.jsx
@@ -99,6 +99,7 @@ export default class PersonSelectWidget extends React.Component {
             content.push(
                 <RelSelectInput key="input" name="person"
                     labelFunc={ p => p.first_name + ' ' + p.last_name }
+                    minFilterLength={ 2 }
                     onValueChange={ this.onInputChange.bind(this) }
                     objects={ people }
                     />

--- a/src/components/panes/RouteContentPane.jsx
+++ b/src/components/panes/RouteContentPane.jsx
@@ -4,6 +4,7 @@ import { FormattedMessage as Msg } from 'react-intl';
 
 import PaneBase from './PaneBase';
 import Button from '../misc/Button';
+import Link from '../misc/Link';
 import RelSelectInput from '../forms/inputs/RelSelectInput';
 import { getListItemById } from '../../utils/store';
 import { stringFromAddress } from '../../utils/location';
@@ -54,16 +55,16 @@ export default class RouteContentPane extends PaneBase {
 
                 return (
                     <li key={ addr.id }>
-                        <span className="RouteContentPane-addressName">
+                        <h4 className="RouteContentPane-addressName">
                             { stringFromAddress(addr) }
-                        </span>
+                        </h4>
                         <span className="RouteContentPane-addressHouseholds">
                             <Msg id="panes.routeContent.addresses.item.households"
                                 values={{ count: addr.household_count }}
                                 />
                         </span>
-                        <Button className="RouteContentPane-addressDeleteButton"
-                            labelMsg="panes.routeContent.addresses.item.deleteButton"
+                        <Link className="RouteContentPane-addressDeleteButton"
+                            msgId="panes.routeContent.addresses.item.deleteButton"
                             onClick={ this.onAddressDeleteClick.bind(this, addr) }
                             />
                     </li>
@@ -97,8 +98,8 @@ export default class RouteContentPane extends PaneBase {
                         objects={ addrObjects }
                         />
                 </div>,
-                <div key="addresses">
-                    <Msg tagName="h2" id="panes.routeContent.addresses.h"/>
+                <div key="addresses" className="RouteContentPane-addresses">
+                    <Msg tagName="h3" id="panes.routeContent.addresses.h"/>
                     <ul className="RouteContentPane-addressList">
                         { addrItems }
                     </ul>

--- a/src/components/panes/RouteContentPane.jsx
+++ b/src/components/panes/RouteContentPane.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { FormattedMessage as Msg } from 'react-intl';
+
+import PaneBase from './PaneBase';
+import Button from '../misc/Button';
+import RelSelectInput from '../forms/inputs/RelSelectInput';
+import { getListItemById } from '../../utils/store';
+import { stringFromAddress } from '../../utils/location';
+import { createSelection } from '../../actions/selection';
+
+
+const mapStateToProps = (state, props) => {
+    let routeId = props.paneData.params[0];
+    let routeList = state.routes.routeList;
+
+    return {
+        streetList: state.addresses.streetList,
+        addressById: state.addresses.addressById,
+        routeItem: getListItemById(routeList, routeId),
+    };
+};
+
+@connect(mapStateToProps)
+export default class RouteContentPane extends PaneBase {
+    componentDidMount() {
+        super.componentDidMount();
+
+        if (!this.props.surveyItem) {
+            // TODO: Retrieve route
+            //this.props.dispatch(retrieveRoute(this.getParam(0)));
+        }
+    }
+
+    getRenderData() {
+        return {
+            routeItem: this.props.routeItem,
+        }
+    }
+
+    getPaneTitle(data) {
+        if (data.routeItem && data.routeItem.data) {
+            return data.routeItem.data.id;
+        }
+        else {
+            return null;
+        }
+    }
+
+    renderPaneContent(data) {
+        if (data.routeItem) {
+            let addrItems = data.routeItem.data.addresses.map(addrId => {
+                let addr = this.props.addressById[addrId];
+
+                return (
+                    <li key={ addr.id }>
+                        <span className="RouteContentPane-addressName">
+                            { stringFromAddress(addr) }
+                        </span>
+                        <span className="RouteContentPane-addressHouseholds">
+                            <Msg id="panes.routeContent.addresses.item.households"
+                                values={{ count: addr.household_count }}
+                                />
+                        </span>
+                        <Button className="RouteContentPane-addressDeleteButton"
+                            labelMsg="panes.routeContent.addresses.item.deleteButton"
+                            onClick={ this.onAddressDeleteClick.bind(this, addr) }
+                            />
+                    </li>
+                );
+            });
+
+            let prevStreet = null;
+            let addrObjects = [];
+            this.props.streetList.items.forEach(streetItem => {
+                let street = streetItem.data;
+
+                // filter out addresses that are already in this route
+                let unusedAddresses = street.addresses.filter(addrId =>
+                    (data.routeItem.data.addresses.indexOf(addrId) < 0));
+
+                if (unusedAddresses.length) {
+                    addrObjects.push(street);
+                    unusedAddresses.forEach(addrId => {
+                        addrObjects.push(this.props.addressById[addrId]);
+                    });
+                }
+            });
+
+            return [
+                <div key="add">
+                    <RelSelectInput name="address"
+                        labelFunc={ o => o.title || stringFromAddress(o) }
+                        showCreateOption={ false } allowNull={ false }
+                        onValueChange={ this.onAddAddressChange.bind(this) }
+                        objects={ addrObjects }
+                        />
+                </div>,
+                <div key="addresses">
+                    <Msg tagName="h2" id="panes.routeContent.addresses.h"/>
+                    <ul className="RouteContentPane-addressList">
+                        { addrItems }
+                    </ul>
+                </div>
+            ];
+        }
+        else {
+            // TODO: Show loading indicator?
+            return null;
+        }
+    }
+
+    onAddAddressChange(name, value) {
+        if (value[0] == '$') {
+            let meta = { streetId: value };
+            let action = createSelection('address', null, null, ids => {
+                console.log(ids);
+            }, meta);
+
+            this.props.dispatch(action);
+            this.openPane('selectstreetaddr', action.payload.id);
+        }
+        else {
+            // TODO: Add address
+        }
+    }
+
+    onAddressDeleteClick(addr) {
+        // TODO: Handle delete
+    }
+}

--- a/src/components/panes/RouteContentPane.jsx
+++ b/src/components/panes/RouteContentPane.jsx
@@ -91,6 +91,7 @@ export default class RouteContentPane extends PaneBase {
                 <div key="add">
                     <RelSelectInput name="address"
                         labelFunc={ o => o.title || stringFromAddress(o) }
+                        minFilterLength={ 3 }
                         showCreateOption={ false } allowNull={ false }
                         onValueChange={ this.onAddAddressChange.bind(this) }
                         objects={ addrObjects }

--- a/src/components/panes/RouteContentPane.scss
+++ b/src/components/panes/RouteContentPane.scss
@@ -1,0 +1,51 @@
+.RouteContentPane {
+
+    .RouteContentPane-addresses {
+        h3 {
+            &:before {
+                @include icon($fa-var-map-marker);
+            }
+        }
+    }
+
+    .RouteContentPane-addressList {
+        font-size: 1.3em;
+
+        li {
+            border-bottom: 1px solid darken($c-ui-bg, 10);
+            padding: 1em 0;
+            position: relative;
+        }
+    }
+
+    .RouteContentPane-addressName {
+        margin:0 0 0.5em 0;
+
+    }
+
+    .RouteContentPane-addressHouseholds {
+        font-size: 0.9em;
+        color: lighten($c-text, 50);
+        &:before {
+            @include icon($fa-var-home);
+        }
+    }
+
+    .RouteContentPane-addressDeleteButton {
+        position: absolute;
+        top: 1.5em;
+        right: 0;
+        color: lighten($c-text, 60);
+
+        @include icon-button($fa-var-trash);
+
+        max-width: 2em;
+        overflow: hidden;
+        transition: max-width 0.3s ease;
+
+        &:hover {
+            color: lighten($c-text, 30);
+            max-width: 5em;
+        }
+    }
+}

--- a/src/components/panes/RoutePane.jsx
+++ b/src/components/panes/RoutePane.jsx
@@ -142,8 +142,7 @@ export default class RoutePane extends PaneBase {
     }
 
     onClickEdit(ev) {
-        // TODO: Open edit pane
-        //this.openPane('editroute', this.getParam(0));
+        this.openPane('routecontent', this.getParam(0));
     }
 
     onOwnerSelect(person) {

--- a/src/components/panes/SelectStreetAddressPane.jsx
+++ b/src/components/panes/SelectStreetAddressPane.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { FormattedMessage as Msg, injectIntl } from 'react-intl';
+
+import AddressList from '../lists/AddressList';
+import Button from '../misc/Button';
+import PaneBase from './PaneBase';
+import { getListItemById } from '../../utils/store';
+
+import {
+    addToSelection,
+    finishSelection,
+    removeFromSelection
+} from '../../actions/selection';
+
+
+const mapStateToProps = (state, props) => {
+    let selectionId = props.paneData.params[0];
+    let selectionList = state.selections.selectionList;
+    let selectionItem = getListItemById(selectionList, selectionId);
+
+    let addresses = null;
+    let streetItem = null;
+    if (selectionItem) {
+        let streetId = selectionItem.data.meta.streetId;
+        streetItem = getListItemById(state.addresses.streetList, streetId);
+
+        addresses = streetItem.data.addresses
+            .map(addrId => state.addresses.addressById[addrId]);
+    }
+
+    return {
+        streetItem,
+        selectionItem,
+        addresses,
+    };
+};
+
+@connect(mapStateToProps)
+@injectIntl
+export default class SelectStreetAddressPane extends PaneBase {
+    componentDidMount() {
+        super.componentDidMount();
+
+        if (!this.props.selectionItem) {
+            this.closePane();
+        }
+    }
+
+    getPaneTitle(data) {
+        if (this.props.streetItem) {
+            return this.props.intl.formatMessage(
+                { id: 'panes.selectStreetAddress.title' },
+                { street: this.props.streetItem.data.title });
+        }
+        else {
+            return null;
+        }
+    }
+
+    renderPaneContent(data) {
+        if (this.props.streetItem) {
+            // Mimic a list structure
+            let addrList = {
+                items: this.props.addresses.map(addr => ({
+                    data: addr,
+                })),
+            };
+
+            return [
+                <AddressList key="addresses" addressList={ addrList }
+                    allowBulkSelection={ true }
+                    bulkSelection={ this.props.selectionItem.data }
+                    onItemSelect={ this.onItemSelect.bind(this) }
+                    />
+            ];
+        }
+        else {
+            // TODO: Show loading indicator?
+            return null;
+        }
+    }
+
+    renderPaneFooter() {
+        let numSelected = this.props.selectionItem.data.selectedIds.length;
+        return (
+            <Button className="SelectStreetAddressPane-saveButton"
+                labelMsg="panes.selectStreetAddress.saveButton"
+                labelValues={{ numSelected }}
+                onClick={ this.onSaveButtonClick.bind(this) }
+                />
+        );
+    }
+
+    onItemSelect(item, selected) {
+        let selectionId = this.getParam(0);
+
+        if (selected) {
+            this.props.dispatch(addToSelection(selectionId, item.data.id));
+        }
+        else {
+            this.props.dispatch(removeFromSelection(selectionId, item.data.id));
+        }
+    }
+
+    onSaveButtonClick() {
+        let selectionId = this.getParam(0);
+        this.props.dispatch(finishSelection(selectionId));
+        this.closePane();
+    }
+}

--- a/src/components/panes/SelectStreetAddressPane.scss
+++ b/src/components/panes/SelectStreetAddressPane.scss
@@ -1,0 +1,5 @@
+.SelectStreetAddressPane {
+    .AddressList {
+        margin: 2em 0;
+    }
+}

--- a/src/components/panes/index.js
+++ b/src/components/panes/index.js
@@ -43,6 +43,7 @@ import RoutePane from './RoutePane';
 import RouteContentPane from './RouteContentPane';
 import SelectPeoplePane from './SelectPeoplePane';
 import SelectLocationTagsPane from './SelectLocationTagsPane';
+import SelectStreetAddressPane from './SelectStreetAddressPane';
 import SelectPersonTagsPane from './SelectPersonTagsPane';
 import SurveyPane from './SurveyPane';
 import SurveyOutlinePane from './SurveyOutlinePane';
@@ -95,6 +96,7 @@ var _panes = {
     'selectpeople': SelectPeoplePane,
     'selectlocationtags': SelectLocationTagsPane,
     'selectpersontags': SelectPersonTagsPane,
+    'selectstreetaddr': SelectStreetAddressPane,
     'survey': SurveyPane,
     'surveyoutline': SurveyOutlinePane,
     'surveysubmission': SurveySubmissionPane,

--- a/src/components/panes/index.js
+++ b/src/components/panes/index.js
@@ -40,6 +40,7 @@ import PersonPane from './PersonPane';
 import PlaceLocationPane from './PlaceLocationPane';
 import QueryPane from './QueryPane';
 import RoutePane from './RoutePane';
+import RouteContentPane from './RouteContentPane';
 import SelectPeoplePane from './SelectPeoplePane';
 import SelectLocationTagsPane from './SelectLocationTagsPane';
 import SelectPersonTagsPane from './SelectPersonTagsPane';
@@ -90,6 +91,7 @@ var _panes = {
     'placelocation': PlaceLocationPane,
     'query': QueryPane,
     'route': RoutePane,
+    'routecontent': RouteContentPane,
     'selectpeople': SelectPeoplePane,
     'selectlocationtags': SelectLocationTagsPane,
     'selectpersontags': SelectPersonTagsPane,

--- a/src/store/addresses.js
+++ b/src/store/addresses.js
@@ -1,4 +1,5 @@
 import * as types from '../actions';
+import makeRandomString from '../utils/makeRandomString';
 import {
     createList,
 } from '../utils/store';
@@ -42,17 +43,40 @@ export default function addresses(state = null, action) {
     else if (action.type == types.RETRIEVE_ADDRESSES + '_FULFILLED') {
         let addresses = action.payload;
 
+        let streets = [];
+        let streetsByTitle = {};
+        addresses.forEach(addr => {
+            if (addr.street) {
+                let street = streetsByTitle[addr.street];
+
+                if (!street) {
+                    street = {
+                        id: '$' + makeRandomString(6),
+                        title: addr.street,
+                        addresses: [],
+                    };
+
+                    streets.push(street);
+                    streetsByTitle[street.title] = street;
+                }
+
+                street.addresses.push(addr.id);
+            }
+        });
+
         return Object.assign({}, state, {
             addressById: addresses.reduce((byId, a) => {
                 byId[a.id] = a;
                 return byId
             }, {}),
             addressList: createList(addresses),
+            streetList: createList(streets),
         });
     }
     else {
         return state || {
             addressList: createList(),
+            streetList: createList(),
         };
     }
 }

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -44,3 +44,8 @@ export function dmsStringFromLatLng(lat, lng) {
 
     return latStr + ' ' + lngStr;
 }
+
+
+export function stringFromAddress(addr) {
+    return (addr.street || '') + ' ' + (addr.number || '') + (addr.suffix || '');
+}


### PR DESCRIPTION
This PR adds the `RouteContentPane` and the `SelectStreetAddressPane`, which lets the user edit route content by adding addresses. Since this has not been hooked up to the API, this is just a UI with some in-memory storage for now.