### PR TITLE
Org switching

### DIFF
--- a/locale/header/en.yaml
+++ b/locale/header/en.yaml
@@ -18,3 +18,4 @@ search:
 userMenu:
     accountLink: Account settings
     logOutLink: Log out
+    switchOrganization: Switch organization

--- a/locale/header/sv.yaml
+++ b/locale/header/sv.yaml
@@ -18,3 +18,4 @@ search:
 userMenu:
     accountLink: Konto-inställningar
     logOutLink: Logga ut
+    switchOrganization: Växla organisation

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,7 +11,7 @@ export const GOTO_SECTION = 'GOTO_SECTION';
 // Flux actions related to users
 export const GET_USER_INFO = 'GET_USER_INFO';
 export const GET_USER_MEMBERSHIPS = 'GET_USER_MEMBERSHIPS';
-export const SET_ACTIVE_MEMBERSHIP = 'SET_ACTIVE_MEMBERSHIP';
+export const SET_ACTIVE_ORG = 'SET_ACTIVE_ORG';
 
 // Redux actions related to people
 export const CREATE_PERSON = 'CREATE_PERSON';

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -23,9 +23,9 @@ export function getUserMemberships() {
     }
 }
 
-export function setActiveMembership(membership) {
+export function setActiveOrg(orgId) {
     return {
-        type: types.SET_ACTIVE_MEMBERSHIP,
-        payload: { membership },
+        type: types.SET_ACTIVE_ORG,
+        payload: { orgId },
     };
 }

--- a/src/components/header/OrgPicker.jsx
+++ b/src/components/header/OrgPicker.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { FormattedMessage as Msg } from 'react-intl';
 
 import { setActiveMembership } from '../../actions/user';
 
@@ -14,7 +15,8 @@ export default class OrgPicker extends React.Component {
             return (
                 <div className="OrgPicker OrgUserMenu-activeOrg">
                     <span className="OrgPicker-label">
-                        Switch organization</span>
+                        <Msg id="header.userMenu.switchOrganization"/>
+                    </span>
                     <ul className="OrgPicker-list">
                         {memberships.map(function(ms) {
                             if(ms.organization.id === activeOrg.id){

--- a/src/components/header/OrgPicker.jsx
+++ b/src/components/header/OrgPicker.jsx
@@ -18,13 +18,15 @@ export default class OrgPicker extends React.Component {
                     <ul className="OrgPicker-list">
                         {memberships.map(function(ms) {
                             if(ms.organization.id === activeOrg.id){
-                                return
+                                return;
                             }
+
+                            let href = '/?org=' + ms.organization.id;
+
                             return (
                                 <li key={ ms.organization.id }
-                                    className="OrgPicker-item"
-                                    onClick={ this.onOrgClick.bind(this, ms) }>
-                                    { ms.organization.title }
+                                    className="OrgPicker-item">
+                                    <a href={ href }>{ ms.organization.title }</a>
                                 </li>
                             );
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -18,6 +18,7 @@ import App from '../components/App';
 import ActivistPage from '../components/fullpages/ActivistPage';
 import IntlReduxProvider from '../components/IntlReduxProvider';
 import { setPanesFromUrlPath } from '../actions/view';
+import { setActiveOrg } from '../actions/user';
 
 const packageJson = require('../../../package.json');
 
@@ -102,6 +103,38 @@ export default function initApp(messages) {
         }
         else {
             renderReactPage(ActivistPage, req, res);
+        }
+    });
+
+    // Route for switching organizations
+    app.get('*', (req, res, next) => {
+        let state = req.store.getState();
+        let orgId = null;
+
+        let orgIsValid = orgId =>
+            !!state.user.memberships.find(m => m.organization.id == orgId);
+
+        if (req.query.org && orgIsValid(req.query.org)) {
+            // Will store organization from querystring in cookie and redirect.
+            // The next request will fall into the next condition.
+            res.cookie('activeOrgId', req.query.org);
+            res.redirect('/');
+            return;
+        }
+        else if (req.cookies.activeOrgId) {
+            // Will use organization from cookie, if (still) valid
+            if (orgIsValid(req.cookies.activeOrgId)) {
+                req.store.dispatch(setActiveOrg(req.cookies.activeOrgId));
+            }
+            else {
+                res.clearCookie('activeOrgId');
+            }
+
+            next();
+        }
+        else {
+            // Will use default, which is first organization
+            next();
         }
     });
 

--- a/src/store/org.js
+++ b/src/store/org.js
@@ -18,9 +18,9 @@ export default function org(state = null, action) {
                 return state;
             }
 
-        case types.SET_ACTIVE_MEMBERSHIP:
+        case types.SET_ACTIVE_ORG:
             return Object.assign({}, state, {
-                activeId: action.payload.membership.organization.id,
+                activeId: action.payload.orgId,
             });
 
         default:

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -19,9 +19,13 @@ export default function user(state = null, action) {
                     officialMemberships[0] : null,
             });
 
-        case types.SET_ACTIVE_MEMBERSHIP:
+        case types.SET_ACTIVE_ORG:
+            let orgId = action.payload.orgId;
+            let membership = state.memberships
+                .find(m => m.organization.id == orgId);
+
             return Object.assign({}, state, {
-                activeMembership: action.payload.membership
+                activeMembership: membership,
             });
 
         default:


### PR DESCRIPTION
This PR refactors the way organization switching works. Starting with this PR, switching organizations will always result in a full page refresh, and the active organization will be remembered across refreshes (and sessions) using a cookie.

Fixes #672 