### PR TITLE
Misc improvements

### DIFF
--- a/locale/alerts/en.yaml
+++ b/locale/alerts/en.yaml
@@ -1,0 +1,5 @@
+error:
+    rejected:
+        http403: |-
+            You attempted something you're not authorized to do. Please verify
+            your access level or speak to a more senior official.

--- a/locale/alerts/sv.yaml
+++ b/locale/alerts/sv.yaml
@@ -1,0 +1,5 @@
+error:
+    rejected:
+        http403: |-
+            Du försökte göra något som inte är tillåtet. Var god kontrollera din
+            behörighetsnivå eller tala med någon ansvarig.

--- a/locale/dashboard/en.yaml
+++ b/locale/dashboard/en.yaml
@@ -8,3 +8,6 @@ footer:
     info: >-
         Zetkin is developed by Zetkin Foundation, to improve organizing in
         activist organizations.
+header:
+    h1: Welcome {user},
+    h2: Let's organize {org}!

--- a/locale/dashboard/sv.yaml
+++ b/locale/dashboard/sv.yaml
@@ -8,3 +8,6 @@ footer:
     info: |
         Zetkin utvecklas av Zetkin Foundation med syfte att revolutionera
         aktivistisk organisering.
+header:
+    h1: Välkommen {user},
+    h2: Nu organiserar vi {org}!

--- a/src/actions/alert.js
+++ b/src/actions/alert.js
@@ -1,0 +1,8 @@
+import * as types from '.';
+
+
+export function pollAlertMessages() {
+    return {
+        type: types.POLL_ALERT_MESSAGES,
+    };
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -231,3 +231,6 @@ export const REMOVE_ROUTES_FROM_CANVASS_ASSIGNMENT = 'REMOVE_ROUTE_FROM_CANVASS_
 
 // Redux actions related to visits
 export const RETRIEVE_HOUSEHOLD_VISITS = 'RETRIEVE_HOUSEHOLD_VISITS';
+
+// Actions related to alert messages
+export const POLL_ALERT_MESSAGES = 'POLL_ALERT_MESSAGES';

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,6 +3,7 @@ import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
 
+import AlertMessages from './misc/AlertMessages';
 import GoogleAnalytics from './misc/GoogleAnalytics';
 import Header from './header/Header';
 import Dashboard from './dashboard/Dashboard';
@@ -65,6 +66,7 @@ export default class App extends React.Component {
                             { section }
                         </div>
                         <KeyboardShortcuts/>
+                        <AlertMessages/>
                     </div>
                     <script type="text/json"
                         id="App-initialState"

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { FormattedMessage as Msg } from 'react-intl';
 import React from 'react';
 
 import Footer from './Footer';
@@ -9,7 +10,9 @@ import { moveWidget } from '../../actions/dashboard';
 import { gotoSection } from '../../actions/view';
 
 const mapStateToProps = (state, props) => ({
+    activeOrganization: state.user.activeMembership.organization,
     shortcuts: state.dashboard.shortcuts,
+    user: state.user.user,
     widgets: state.dashboard.widgets,
 });
 
@@ -55,9 +58,15 @@ export default class Dashboard extends React.Component {
             );
         }
 
+        const org = this.props.activeOrganization.title;
+        const user = this.props.user.first_name;
 
         return (
             <div className="Dashboard">
+                <header className="Dashboard-header">
+                    <Msg tagName="h1" id="dashboard.header.h1" values={{ org, user }}/>
+                    <Msg tagName="h2" id="dashboard.header.h2" values={{ org, user }}/>
+                </header>
                 <ul className="Dashboard-favorites">
                     { favoriteElements }
                 </ul>

--- a/src/components/dashboard/Dashboard.scss
+++ b/src/components/dashboard/Dashboard.scss
@@ -1,3 +1,20 @@
+.Dashboard-header {
+    text-align: center;
+    margin: 3em 0 0;
+
+    h1 {
+        font-size: 3em;
+        margin: 0;
+        color: $c-ui-darker;
+    }
+
+    h2 {
+        font-size: 2em;
+        margin: 0.5em 0 0;
+        color: $c-ui-darker;
+    }
+}
+
 .Dashboard-favorites {
     @include list-unstyled;
     padding: 0.417em;

--- a/src/components/misc/AlertMessages.jsx
+++ b/src/components/misc/AlertMessages.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { FormattedMessage as Msg } from 'react-intl';
+import {
+    pollAlertMessages,
+} from '../../actions/alert';
+
+
+const mapStateToProps = state => ({
+    messages: state.alerts.messages,
+});
+
+@connect(mapStateToProps)
+export default class AlertMessages extends React.Component {
+    componentWillReceiveProps(nextProps) {
+        if (this.props.messages.length == 0 && nextProps.messages.length > 0) {
+            // First message, start polling
+            this.pollTimer = setInterval(() => this.props.dispatch(pollAlertMessages()), 2000);
+        }
+        else if (nextProps.messages.length == 0) {
+            // No more messages, stop polling
+            clearInterval(this.pollTimer);
+        }
+    }
+
+    render() {
+        const messageItems = this.props.messages.map(msg => {
+            const labelId = 'alerts.' + msg.type;
+
+            return (
+                <li key={ msg.id } className="AlertMessages-messageItem">
+                    <Msg id={ labelId }/>
+                </li>
+            );
+        });
+
+        return (
+            <div className="AlertMessages">
+                <ul className="AlertMessages-messageList">
+                    { messageItems }
+                </ul>
+            </div>
+        );
+    }
+}

--- a/src/components/misc/AlertMessages.scss
+++ b/src/components/misc/AlertMessages.scss
@@ -25,26 +25,23 @@
 @keyframes AlertMessages-messageItem-inOutAnimation {
     0% {
         opacity: 0;
-        top: 4em;
+        transform: translate(0, 4em);
     }
 
     5% {
         opacity: 1;
-        top: 0;
+        transform: translate(0, 0);
     }
 
     20% {
         opacity: 1;
-        top: 0;
     }
 
     70% {
         opacity: 0;
-        top: 0;
     }
 
     100% {
         opacity: 0;
-        top: 0;
     }
 }

--- a/src/components/misc/AlertMessages.scss
+++ b/src/components/misc/AlertMessages.scss
@@ -1,0 +1,50 @@
+.AlertMessages {
+    position: fixed;
+    bottom: 3em;
+    left: 2em;
+    z-index: 9999;
+
+    width: 80%;
+    max-width: 40em;
+
+    .AlertMessages-messageItem {
+        position: relative;
+        padding: 1em;
+        margin: 1em 0;
+        background-color: $c-brand-main;
+        border-radius: 0.5em;
+        box-shadow: 0 0 1em rgba(0,0,0,0.2);
+
+        font-size: 1.3em;
+        color: white;
+
+        animation: AlertMessages-messageItem-inOutAnimation 12s;
+    }
+}
+
+@keyframes AlertMessages-messageItem-inOutAnimation {
+    0% {
+        opacity: 0;
+        top: 4em;
+    }
+
+    5% {
+        opacity: 1;
+        top: 0;
+    }
+
+    20% {
+        opacity: 1;
+        top: 0;
+    }
+
+    70% {
+        opacity: 0;
+        top: 0;
+    }
+
+    100% {
+        opacity: 0;
+        top: 0;
+    }
+}

--- a/src/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -20,12 +20,13 @@ export default class CampaignPlayer extends React.Component {
     componentWillReceiveProps(nextProps) {
         const actions = nextProps.actions;
 
-        if (this.props.centerLat != nextProps.centerLat
-            || this.props.centerLng != nextProps.centerLng) {
+        if (this.props.actions != nextProps.actions) {
+            let bounds = new google.maps.LatLngBounds();
+            this.props.actions.forEach(action => {
+                bounds.extend(action.location);
+            });
 
-            this.map.setCenter(new google.maps.LatLng(
-                nextProps.centerLat, nextProps.centerLng
-            ));
+            this.map.fitBounds(bounds);
         }
 
         if (actions.length) {
@@ -55,12 +56,8 @@ export default class CampaignPlayer extends React.Component {
     }
 
     componentDidMount() {
-        const centerLat = this.props.centerLat;
-        const centerLng = this.props.centerLng;
         const ctrDOMNode = ReactDOM.findDOMNode(this.refs.mapContainer);
         const mapOptions = {
-            center: { lat: centerLat, lng: centerLng },
-            zoom: 12,
             disableDefaultUI: true,
             zoomControl: true,
             zoomControlOptions: {
@@ -75,6 +72,13 @@ export default class CampaignPlayer extends React.Component {
             maxIntensity: 1.5,
             radius: 50
         });
+
+        let bounds = new google.maps.LatLngBounds();
+        this.props.actions.forEach(action => {
+            bounds.extend(action.location);
+        });
+
+        this.map.fitBounds(bounds);
     }
 
     componentWillUnmount() {

--- a/src/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -82,7 +82,9 @@ export default class CampaignPlayer extends React.Component {
     }
 
     render() {
-        const actions = this.props.actions;
+        let actions = this.props.actions.concat();
+        actions.sort((a0, a1) => new Date(a0.start_time) - new Date(a1.start_time));
+
         const startTime = actions.length?
             new Date(actions[0].start_time).getTime() : 0;
         const endTime = actions.length?

--- a/src/components/misc/campaignplayer/CampaignPlayer.jsx
+++ b/src/components/misc/campaignplayer/CampaignPlayer.jsx
@@ -20,9 +20,9 @@ export default class CampaignPlayer extends React.Component {
     componentWillReceiveProps(nextProps) {
         const actions = nextProps.actions;
 
-        if (this.props.actions != nextProps.actions) {
+        if (this.props.actions != nextProps.actions && nextProps.actions) {
             let bounds = new google.maps.LatLngBounds();
-            this.props.actions.forEach(action => {
+            nextProps.actions.forEach(action => {
                 bounds.extend(action.location);
             });
 

--- a/src/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -6,6 +6,7 @@ import CampaignPlayer from '../../misc/campaignplayer/CampaignPlayer';
 import ActionMiniCalendar from '../../misc/actioncal/ActionMiniCalendar';
 import { getLocationAverage } from '../../../utils/location';
 import { retrieveActions } from '../../../actions/action';
+import { retrieveCampaigns } from '../../../actions/campaign';
 import { retrieveLocations } from '../../../actions/location';
 import { retrieveActivities } from '../../../actions/activity';
 import { filteredActionList } from '../../../store/actions';

--- a/src/components/sections/campaign/CampaignPlaybackPane.jsx
+++ b/src/components/sections/campaign/CampaignPlaybackPane.jsx
@@ -53,12 +53,11 @@ export default class CampaignPlaybackPane extends CampaignSectionPaneBase {
 
             let locList = this.props.locations.locationList;
             let locations = locList.items.map(i => i.data);
-            let center = getLocationAverage(locList);
 
             return (
                 <CampaignPlayer key="player"
                     actions={ actions } locations={ locations }
-                    centerLat={ center.lat } centerLng={ center.lng }/>
+                    />
             );
         }
     }

--- a/src/components/sections/campaign/CampaignPlaybackPane.scss
+++ b/src/components/sections/campaign/CampaignPlaybackPane.scss
@@ -8,6 +8,14 @@
         width: 300px;
     }
 
+    .CampaignPlayer {
+        position: absolute;
+        top: 17em;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
+
     @include medium-screen {
         .campaignselect {
             width: 300px;

--- a/src/components/sections/index.js
+++ b/src/components/sections/index.js
@@ -26,10 +26,8 @@ export const SECTIONS = {
                 startPane: InvitePane },
             { path: 'import',
                 startPane: ImportPane },
-            /*
             { path: 'manage',
                 startPane: ManagePeoplePane },
-                */
         ],
     },
     campaign: {

--- a/src/store/alerts.js
+++ b/src/store/alerts.js
@@ -1,0 +1,36 @@
+import * as types from '../actions';
+import makeRandomString from '../utils/makeRandomString';
+
+
+// Remove messages that are more than 30 seconds old
+let cleanOldMessages = messages => {
+    const now = new Date();
+    return messages
+        .filter(msg => (now - msg.time) < 8000);
+};
+
+export default function alerts(state = null, action) {
+    if (action.type.indexOf('_REJECTED') > 0) {
+        // Only support 403 messages for now
+        if (action.payload.httpStatus == 403) {
+            return Object.assign({}, state, {
+                messages: cleanOldMessages(state.messages)
+                    .concat([{
+                        id: makeRandomString(),
+                        time: new Date(),
+                        type: 'error.rejected.http' + action.payload.httpStatus,
+                        action: action,
+                    }]),
+            });
+        }
+    }
+    else if (action.type == types.POLL_ALERT_MESSAGES) {
+        return Object.assign({}, state, {
+            messages: cleanOldMessages(state.messages),
+        });
+    }
+
+    return state || {
+        messages: [],
+    };
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,7 @@ import actions from './actions';
 import actionResponses from './actionResponses';
 import activities from './activities';
 import addresses from './addresses';
+import alerts from './alerts';
 import callAssignments from './callAssignments';
 import calls from './calls';
 import canvassAssignments from './canvassAssignments';
@@ -44,6 +45,7 @@ const appReducer = combineReducers({
     actionResponses,
     activities,
     addresses,
+    alerts,
     callAssignments,
     calls,
     canvassAssignments,


### PR DESCRIPTION
This PR contains a number of smaller improvements to the Organize interface.

### Manage section
The manage section that was implemented in the last release but hidden, is now made visible.

### Welcome message on dashboard
As outlined in #730, a message is added on the dashboard that includes the name of the current organization.

![image](https://user-images.githubusercontent.com/550212/39088095-863e154a-45ac-11e8-857c-7f35a76bcf5a.png)

### Campaign playback
Fixes three issues related to the `CampaignPlayer`. One undocumented issue related to how the order in which actions were stored affected the playback span, one missing import in `CampaignPlaybackPane` and a third one as described in #658.

### Alert messages when unauthorized
Adds a framework for alert messages to display in the bottom left corner, and logic to display a message whenever an API request results in a 403 (unauthorized) error.

![image](https://user-images.githubusercontent.com/550212/39092815-ba5f04ec-4615-11e8-9e0c-1fa40b91b800.png)

Issues #745, #746, #747 and #748 describe future improvements to and use cases for this framework.
