### PR TITLE
Campaign drafts

### DIFF
--- a/locale/forms/campaign/en.yaml
+++ b/locale/forms/campaign/en.yaml
@@ -1,2 +1,6 @@
 description: Description
+published:
+    draft: Draft (visible to officials only)
+    label: Visibility
+    published: Published
 title: Title

--- a/locale/forms/campaign/sv.yaml
+++ b/locale/forms/campaign/sv.yaml
@@ -1,2 +1,6 @@
 description: Beskrivning
+published:
+    draft: Utkast (synlig bara för funktionärer)
+    label: Synlighet
+    published: Publicerad
 title: Titel

--- a/src/actions/campaign.js
+++ b/src/actions/campaign.js
@@ -5,11 +5,6 @@ export function createCampaign(data) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;
 
-        // TODO: Remove this when interface exposes option
-        data = Object.assign({}, data, {
-            published: true,
-        });
-
         dispatch({
             type: types.CREATE_CAMPAIGN,
             payload: {

--- a/src/components/forms/CampaignForm.jsx
+++ b/src/components/forms/CampaignForm.jsx
@@ -1,31 +1,48 @@
 import React from 'react';
 
 import Form from './Form';
+import SelectInput from './inputs/SelectInput';
 import TextArea from './inputs/TextArea';
 import TextInput from './inputs/TextInput';
 
 
 export default class ActivityForm extends React.Component {
     render() {
-        var campaign = this.props.campaign || {};
+        const campaign = this.props.campaign || {};
+
+        const published = campaign.published? 'published' : 'draft';
+        const publishedOptions = {
+            published: 'forms.campaign.published.published',
+            draft: 'forms.campaign.published.draft',
+        };
 
         return (
             <Form ref="form" {...this.props }>
                 <TextInput labelMsg="forms.campaign.title" name="title"
                     initialValue={ campaign.title }/>
+                <SelectInput labelMsg="forms.campaign.published.label" name="published"
+                    initialValue={ published }
+                    options={ publishedOptions }
+                    optionLabelsAreMessages={ true }
+                    />
                 <TextArea labelMsg="forms.campaign.description" name="info_text"
                     initialValue={ campaign.info_text }/>
-
             </Form>
         );
     }
 
     getValues() {
-        return this.refs.form.getValues();
+        let values = this.refs.form.getValues();
+        values.published = (values.published == 'published');
+        return values;
     }
 
     getChangedValues() {
-        return this.refs.form.getChangedValues();
+        let values = this.refs.form.getChangedValues();
+        if (values.published) {
+            values.published = (values.published == 'published');
+        }
+        return values;
     }
 }
 

--- a/src/components/panes/AddCampaignPane.jsx
+++ b/src/components/panes/AddCampaignPane.jsx
@@ -20,7 +20,8 @@ export default class AddCampaignPane extends PaneBase {
 
     renderPaneContent(data) {
         const initialData = {
-            title: this.getParam(0)
+            title: this.getParam(0),
+            published: true,
         };
 
         return (


### PR DESCRIPTION
This PR exposes the `published` property of campaigns in `CampaignForm` so that it's possible to change it when creating/editing a campaign.

Fixes #402