### PR TITLE
action importing: Cast parseTime input to String before using it as a String

### DIFF
--- a/src/store/actionImport.js
+++ b/src/store/actionImport.js
@@ -311,7 +311,7 @@ function parseTime(str) {
         return null;
     }
 
-    const fields = str.split(/[\.:]+/);
+    const fields = String(str).split(/[\.:]+/);
     if (fields.length && fields.length <= 3) {
         let h = parseInt(fields[0])
         if (isNaN(h)) return null;


### PR DESCRIPTION
This PR does one part of #812: Cast possible string input in `parseTime(str)` to String in order to try splitting on a regex.

