### PR TITLE
sv.yaml: callAssignment form: Fix typo in label, ringar -> ringare

### DIFF
--- a/locale/forms/callAssignment/sv.yaml
+++ b/locale/forms/callAssignment/sv.yaml
@@ -1,5 +1,5 @@
 callerNotes:
-    disabled: Tillåt inte att ringar gör anteckningar
+    disabled: Tillåt inte att ringare gör anteckningar
     enabled: Tillåt ringare att göra fritextanteckningar
     label: Ringares anteckningar
 coolDown: Timmar mellan återförsök


### PR DESCRIPTION
This PR is a typo fix.