### PR TITLE
Alt phone

### DIFF
--- a/locale/forms/person/en.yaml
+++ b/locale/forms/person/en.yaml
@@ -1,3 +1,4 @@
+altPhone: Alt. phone number
 city: City
 coAddress: C/O address
 email: E-mail

--- a/locale/forms/person/sv.yaml
+++ b/locale/forms/person/sv.yaml
@@ -1,3 +1,4 @@
+altPhone: Alt. telefonnummer
 city: Stad
 coAddress: C/O-adress
 email: E-post

--- a/locale/panes/import/en.yaml
+++ b/locale/panes/import/en.yaml
@@ -7,6 +7,7 @@ column:
             external: External ID
             zetkin: Zetkin ID
         person:
+            altPhone: Alt. phone number
             city: City
             coAddress: C/O address
             email: E-mail address
@@ -67,6 +68,7 @@ settings:
             gender: Gender
             lastName: Last name
             phone: Phone number
+            altPhone: Alt. phone number
             streetAddress: Street address
             zip: Zip code
         h: Select field

--- a/locale/panes/import/sv.yaml
+++ b/locale/panes/import/sv.yaml
@@ -7,6 +7,7 @@ column:
             external: Externt ID
             zetkin: Zetkin-ID
         person:
+            altPhone: Alt. telefonnummer
             city: Ort
             coAddress: C/O-adress
             email: E-post
@@ -67,6 +68,7 @@ settings:
             gender: Kön
             lastName: Efternamn
             phone: Telefon
+            altPhone: Alt. telefon
             streetAddress: Gatuadress
             zip: Postnummer
         h: Välj fält

--- a/src/actions/person.js
+++ b/src/actions/person.js
@@ -1,11 +1,12 @@
 import * as types from './';
 
 
-export function createPerson(data) {
+export function createPerson(data, paneId) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;
         dispatch({
             type: types.CREATE_PERSON,
+            meta: { paneId },
             payload: {
                 promise: z.resource('orgs', orgId, 'people').post(data)
             }

--- a/src/components/forms/PersonForm.jsx
+++ b/src/components/forms/PersonForm.jsx
@@ -33,6 +33,8 @@ export default class PersonForm extends React.Component {
                     initialValue={ person.email }/>
                 <TextInput labelMsg="forms.person.phone" name="phone"
                     initialValue={ person.phone }/>
+                <TextInput labelMsg="forms.person.altPhone" name="alt_phone"
+                    initialValue={ person.alt_phone }/>
 
                 <TextInput labelMsg="forms.person.coAddress" name="co_address"
                     initialValue={ person.co_address }/>

--- a/src/components/lists/items/PersonListItem.jsx
+++ b/src/components/lists/items/PersonListItem.jsx
@@ -24,6 +24,8 @@ export default class PersonListItem extends React.Component {
             mailLink = <a href={ mailto }>{ person.email }</a>;
         }
 
+        const phoneNumbers = [ person.phone, person.alt_phone ].filter(pn => !!pn);
+
         return (
             <div className="PersonListItem"
                 onClick={ this.props.onItemClick }>
@@ -39,7 +41,7 @@ export default class PersonListItem extends React.Component {
                     <span className="PersonListItem-email">
                         { mailLink }</span>
                     <span className="PersonListItem-phone">
-                        { person.phone }</span>
+                        { phoneNumbers.join(', ') }</span>
                 </div>
             </div>
         );

--- a/src/components/misc/importer/ImporterColumnHead.jsx
+++ b/src/components/misc/importer/ImporterColumnHead.jsx
@@ -23,6 +23,7 @@ export default class ImporterColumnHead extends React.Component {
             'person.last_name': col('colOptions.person.lastName'),
             'person.email': col('colOptions.person.email'),
             'person.phone': col('colOptions.person.phone'),
+            'person.alt_phone': col('colOptions.person.altPhone'),
             'person.co_address': col('colOptions.person.coAddress'),
             'person.street_address': col('colOptions.person.streetAddress'),
             'person.zip_code': col('colOptions.person.zip'),

--- a/src/components/misc/importer/settings/PersonDataColumnSettings.jsx
+++ b/src/components/misc/importer/settings/PersonDataColumnSettings.jsx
@@ -26,6 +26,7 @@ export default class PersonDataColumnSettings extends React.Component {
             'last_name': col('lastName'),
             'email': col('email'),
             'phone': col('phone'),
+            'alt_phone': col('altPhone'),
             'co_address': col('coAddress'),
             'street_address': col('streetAddress'),
             'zip_code': col('zip'),

--- a/src/components/panes/AddPersonPane.jsx
+++ b/src/components/panes/AddPersonPane.jsx
@@ -36,7 +36,6 @@ export default class AddPersonPane extends PaneBase {
         var form = this.refs.personForm;
         var values = form.getValues();
 
-        this.props.dispatch(createPerson(values));
-        this.closePane();
+        this.props.dispatch(createPerson(values, this.props.paneData.id));
     }
 }

--- a/src/components/panes/PersonPane.jsx
+++ b/src/components/panes/PersonPane.jsx
@@ -98,6 +98,7 @@ export default class PersonPane extends PaneBase {
             };
 
             const formatMessage = this.props.intl.formatMessage;
+            const phoneNumbers = [ person.phone, person.alt_phone ].filter(pn => !!pn);
 
             return [
                 <DraggableAvatar key="avatar" ref="avatar" person={ person }/>,
@@ -106,7 +107,7 @@ export default class PersonPane extends PaneBase {
                         { name: 'user', msgId: person.is_user ?
                             'panes.person.user.connected' : 'panes.person.user.notConnected' },
                         { name: 'email', value: person.email },
-                        { name: 'phone', value: person.phone },
+                        { name: 'phone', value: phoneNumbers.join(', ') },
                         { name: 'address', value: addrFields.length? addrFields : null },
                         { name: 'editLink', msgId: 'panes.person.editLink', onClick: this.onClickEdit.bind(this) }
                     ]}

--- a/src/store/view.js
+++ b/src/store/view.js
@@ -251,6 +251,22 @@ export default function viewState(state = null, action) {
             }),
         });
     }
+    else if (action.type == types.CREATE_PERSON + '_FULFILLED') {
+        return Object.assign({}, state, {
+            panes: state.panes.map(paneData => {
+                if (action.meta && paneData.id == action.meta.paneId) {
+                    return {
+                        id: '$' + makeRandomString(6),
+                        type: 'person',
+                        params: [ action.payload.data.data.id ],
+                    };
+                }
+                else {
+                    return paneData;
+                }
+            }),
+        });
+    }
     else if (action.type == types.MERGE_PERSON_DUPLICATES + '_FULFILLED') {
         // Close the relevant pane
         let openPanes = state.panes.filter(paneData => paneData.id != action.meta.paneId);


### PR DESCRIPTION
This PR adds the new `Person.alt_phone` field to relevant places in the UI.

* `PersonForm` (when adding/editing a person), fixes #822
* `PersonPane` (display both numbers)
* `PersonListItem` (display both numbers)
* Importer UI, fixes #823