### PR TITLE
run_dev script: include a 24-digit character TOKEN_SECRET

### DIFF
--- a/bin/run_dev
+++ b/bin/run_dev
@@ -6,6 +6,7 @@ docker run \
     -v $PWD/locale:/var/app/locale \
     -v $PWD/src:/var/app/src \
     --name organize_zetk_in \
+    --env TOKEN_SECRET=012345678901234567891234 \
     --env ZETKIN_LOGIN_URL=http://login.dev.zetkin.org \
     --env ZETKIN_APP_ID=b420d6e07e3d41d096d0a964ab85e780 \
     --env ZETKIN_APP_KEY=YWE3MzJlYWMtM2Q1Ny00NjQ4LWFjOTUtNDdjMTIxZmUxMDk5 \

--- a/bin/run_dev.cmd
+++ b/bin/run_dev.cmd
@@ -6,6 +6,7 @@ docker run ^
     -v %cd%/locale:/var/app/locale ^
     -v %cd%/src:/var/app/src ^
     --name organize_zetk_in ^
+    --env TOKEN_SECRET=012345678901234567891234 ^
     --env ZETKIN_LOGIN_URL=http://login.dev.zetkin.org ^
     --env ZETKIN_APP_ID=b420d6e07e3d41d096d0a964ab85e780 ^
     --env ZETKIN_APP_KEY=YWE3MzJlYWMtM2Q1Ny00NjQ4LWFjOTUtNDdjMTIxZmUxMDk5 ^


### PR DESCRIPTION
This avoids this error in startup:

> [node] (node:62) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Encryption secret must be a 24 character string!