### PR TITLE
Minimum search string

### DIFF
--- a/locale/header/en.yaml
+++ b/locale/header/en.yaml
@@ -1,4 +1,5 @@
 search:
+    keepTyping: Keep typing to start searching...
     matches:
         actionDay: |-
             {count, plural,

--- a/locale/header/sv.yaml
+++ b/locale/header/sv.yaml
@@ -1,4 +1,5 @@
 search:
+    keepTyping: Fortsätt skriva för att söka...
     matches:
         actionDay: |-
             {count, plural,

--- a/src/actions/search/index.js
+++ b/src/actions/search/index.js
@@ -15,37 +15,39 @@ export function search(query) {
             queue.abort();
         }
 
-        queue = new SearchQueue(z, orgId, query, lang);
+        if (query.length > 2) {
+            queue = new SearchQueue(z, orgId, query, lang);
 
-        if (!scope || scope == 'campaign') {
-            queue.addProc(new procs.ActionDaySearchProc(dispatch));
-            queue.addProc(new procs.CampaignSearchProc(dispatch));
-            queue.addProc(new procs.ActivitySearchProc(dispatch));
-        }
+            if (!scope || scope == 'campaign') {
+                queue.addProc(new procs.ActionDaySearchProc(dispatch));
+                queue.addProc(new procs.CampaignSearchProc(dispatch));
+                queue.addProc(new procs.ActivitySearchProc(dispatch));
+            }
 
-        if (!scope || scope == 'dialog') {
-            queue.addProc(new procs.CallAssignmentSearchProc(dispatch));
-        }
+            if (!scope || scope == 'dialog') {
+                queue.addProc(new procs.CallAssignmentSearchProc(dispatch));
+            }
 
-        if (!scope || scope == 'people') {
-            queue.addProc(new procs.PersonQuerySearchProc(dispatch));
-            queue.addProc(new procs.PersonSearchProc(dispatch));
-        }
+            if (!scope || scope == 'people') {
+                queue.addProc(new procs.PersonQuerySearchProc(dispatch));
+                queue.addProc(new procs.PersonSearchProc(dispatch));
+            }
 
-        if (!scope || scope == 'maps') {
-            queue.addProc(new procs.LocationSearchProc(dispatch));
-        }
+            if (!scope || scope == 'maps') {
+                queue.addProc(new procs.LocationSearchProc(dispatch));
+            }
 
-        if (!scope || scope == 'survey') {
-            queue.addProc(new procs.SurveySearchProc(dispatch));
-            queue.addProc(new procs.SurveySubmissionSearchProc(dispatch));
+            if (!scope || scope == 'survey') {
+                queue.addProc(new procs.SurveySearchProc(dispatch));
+                queue.addProc(new procs.SurveySubmissionSearchProc(dispatch));
+            }
         }
 
         dispatch({
             type: types.SEARCH,
             meta: { query },
             payload: {
-                promise: queue.run(),
+                promise: queue? queue.run() : Promise.resolve(),
             },
         });
     }

--- a/src/components/header/search/Search.jsx
+++ b/src/components/header/search/Search.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { injectIntl } from 'react-intl';
+import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 
 import LoadingIndicator from '../../misc/LoadingIndicator';
 import ScopeSelect from './ScopeSelect';
@@ -52,7 +52,16 @@ export default class Search extends React.Component {
             classes.push('focused');
         }
 
-        if (results.length || searchStore.isPending) {
+        if (searchStore.isActive && searchStore.query && searchStore.query.length < 3) {
+            resultList = (
+                <ul className="Search-results">
+                    <li className="Search-keepTyping">
+                        <Msg id="header.search.keepTyping"/>
+                    </li>
+                </ul>
+            );
+        }
+        else if (results.length || searchStore.isPending) {
             let loadingIndicator = null;
             if (searchStore.isPending) {
                 loadingIndicator = (

--- a/src/components/header/search/Search.scss
+++ b/src/components/header/search/Search.scss
@@ -47,6 +47,13 @@
 
 
 }
+
+.Search-keepTyping {
+    padding: 0.8em 4em 0.8em 1em;
+    font-size: 1.1em;
+    text-align: center;
+}
+
 .Search-results {
     display: block;
     position: absolute;


### PR DESCRIPTION
This PR adds back a feature that was there before the search refactor, restricting searches to a minimum of three characters. It now also shows a message until the string is long enough.