### PR TITLE
More filters

### DIFF
--- a/locale/filters/campaign/en.yaml
+++ b/locale/filters/campaign/en.yaml
@@ -1,6 +1,12 @@
+activity:
+    label: Activity
+    nullOption: (Regardless of activity)
 campaign:
     label: Campaign
     nullOption: (Regardless of campaign)
+location:
+    label: Location
+    nullOption: (Regardless of location)
 opOptions:
     inBooked: Are booked for campaign work
     inSignedUp: Have signed up to campaign work
@@ -10,9 +16,9 @@ participantStatus: Match people who
 timeframe:
     label: Timeframe
     options:
-        after: after a certain date
-        any: at any point in time
-        before: before a certain date
-        between: between certain dates
-        future: in the future
-        past: before today
+        after: After a certain date
+        any: At any point in time
+        before: Before a certain date
+        between: Between certain dates
+        future: In the future
+        past: Before today

--- a/locale/filters/campaign/en.yaml
+++ b/locale/filters/campaign/en.yaml
@@ -1,14 +1,18 @@
-campaign: What campaign?
-dateOptions:
-    after: after a certain date
-    any: at all
-    before: before a certain date
-    between: between certain dates
-    future: in the future
-    past: before today
+campaign:
+    label: Campaign
+    nullOption: (Regardless of campaign)
 opOptions:
-    inAny: participate in any campaign
-    inSpec: participate in specific campaign
-    notInAny: don't participate in any campaign
-    notInSpec: don't participate in specific campaign
+    inBooked: Are booked for campaign work
+    inSignedUp: Have signed up to campaign work
+    notInBooked: Are not booked for campaign work
+    notInSignedUp: Have not signed up to campaign work
 participantStatus: Match people who
+timeframe:
+    label: Timeframe
+    options:
+        after: after a certain date
+        any: at any point in time
+        before: before a certain date
+        between: between certain dates
+        future: in the future
+        past: before today

--- a/locale/filters/campaign/sv.yaml
+++ b/locale/filters/campaign/sv.yaml
@@ -1,14 +1,24 @@
-campaign: Vilken kampanj?
-dateOptions:
-    after: efter ett visst datum
-    any: överhuvudtaget
-    before: innan ett visst datum
-    between: mellan vissa datum
-    future: i framtiden
-    past: tidigare
+activity:
+    label: Aktivitet
+    nullOption: (Oavsett aktivitet)
+campaign:
+    label: Kampanj
+    nullOption: (Oavsett kampanj)
+location:
+    label: Plats
+    nullOption: (Oavsett plats)
 opOptions:
-    inAny: deltar i någon kampanj
-    inSpec: deltar i följande kampanj
-    notInAny: inte deltar i någon kampanj
-    notInSpec: inte deltar i följande kampanj
-participantStatus: Matcha personer som
+    inBooked: Är bokade på kampanjarbete
+    inSignedUp: Har anmält sig till kampanjarbete
+    notInBooked: Inte är bokade på kampanjarbete
+    notInSignedUp: Inte har anmält sig till kampanjarbete
+participantStatus: Matcha personer som…
+timeframe:
+    label: Tidsram
+    options:
+        after: Efter ett visst datum
+        any: När som helst
+        before: Före ett visst datum
+        between: Mellan två datum
+        future: I framtiden
+        past: Fram till idag

--- a/locale/filters/en.yaml
+++ b/locale/filters/en.yaml
@@ -8,6 +8,7 @@ types:
     personData: Personal data
     personTags: Tags
     random: Random selection
+    subQuery: Linked Smart Search query
     surveyOption: Survey response (options)
     surveyResponse: Survey response (text)
     surveySubmission: Survey submission

--- a/locale/filters/subQuery/en.yaml
+++ b/locale/filters/subQuery/en.yaml
@@ -1,0 +1,7 @@
+assignment:
+    goal: '{ assignment } (goal query)'
+    target: '{ assignment } (target query)'
+queryLabel: 'Select people who match…'
+types:
+    callAssignment: Call assignment target/goal queries
+    standalone: Regular Smart Search queries

--- a/locale/filters/subQuery/sv.yaml
+++ b/locale/filters/subQuery/sv.yaml
@@ -1,0 +1,7 @@
+assignment:
+    goal: '{ assignment } (syftessökning)'
+    target: '{ assignment } (målgruppssökning)'
+queryLabel: 'Välj personer som matchar…'
+types:
+    callAssignment: Målgrupps- och syftessökningar i ringuppdrag
+    standalone: Vanliga smarta sökningar

--- a/locale/filters/sv.yaml
+++ b/locale/filters/sv.yaml
@@ -8,6 +8,7 @@ types:
     personData: Personuppgifter
     personTags: Etiketter
     random: Slumpmässigt urval
+    subQuery: Länkad Smart Sökning
     surveyOption: Enkätsvar (svarsalternativ)
     surveyResponse: Enkätsvar (fritext)
     surveySubmission: Inskickad enkät

--- a/src/components/filters/CampaignFilter.jsx
+++ b/src/components/filters/CampaignFilter.jsx
@@ -8,13 +8,19 @@ import DateInput from '../forms/inputs/DateInput';
 import SelectInput from '../forms/inputs/SelectInput';
 import RelSelectInput from '../forms/inputs/RelSelectInput';
 import { retrieveCampaigns } from '../../actions/campaign';
+import { retrieveActivities } from '../../actions/activity';
+import { retrieveLocations } from '../../actions/location';
 
 
 const mapStateToProps = state => {
     const campaignList = state.campaigns.campaignList;
+    const locationList = state.locations.locationList;
+    const activityList = state.activities.activityList;
 
     return {
+        activityList,
         campaignList,
+        locationList,
     };
 };
 
@@ -34,10 +40,18 @@ export default class CampaignFilter extends FilterBase {
     componentDidMount() {
         super.componentDidMount();
 
-        const campaignList = this.props.campaignList;
+        const { campaignList, activityList, locationList } = this.props;
 
         if (campaignList.items.length == 0 && !campaignList.isPending) {
             this.props.dispatch(retrieveCampaigns());
+        }
+
+        if (activityList.items.length == 0 && !activityList.isPending) {
+            this.props.dispatch(retrieveActivities());
+        }
+
+        if (locationList.items.length == 0 && !locationList.isPending) {
+            this.props.dispatch(retrieveLocations());
         }
     }
 
@@ -68,6 +82,20 @@ export default class CampaignFilter extends FilterBase {
         campaignItems.forEach(item => {
             const campaign = item.data;
             CAMPAIGN_OPTIONS[campaign.id] = campaign.title;
+        });
+
+        const LOCATION_OPTIONS = {};
+        const locationItems = this.props.locationList.items || [];
+        locationItems.forEach(item => {
+            const location = item.data;
+            LOCATION_OPTIONS[location.id] = location.title;
+        });
+
+        const ACTIVITY_OPTIONS = {};
+        const activityItems = this.props.activityList.items || [];
+        activityItems.forEach(item => {
+            const activity = item.data;
+            ACTIVITY_OPTIONS[activity.id] = activity.title;
         });
 
         let afterInput = null;
@@ -103,6 +131,20 @@ export default class CampaignFilter extends FilterBase {
                 onValueChange={ this.onChangeSimpleField.bind(this) }
                 />,
 
+            <SelectInput key="activity" name="activity"
+                labelMsg="filters.campaign.activity.label"
+                options={ ACTIVITY_OPTIONS } value={ this.state.activity }
+                nullOptionMsg="filters.campaign.activity.nullOption"
+                onValueChange={ this.onChangeSimpleField.bind(this) }
+                />,
+
+            <SelectInput key="location" name="location"
+                labelMsg="filters.campaign.location.label"
+                options={ LOCATION_OPTIONS } value={ this.state.location }
+                nullOptionMsg="filters.campaign.location.nullOption"
+                onValueChange={ this.onChangeSimpleField.bind(this) }
+                />,
+
             <SelectInput key="timeframe" name="timeframe"
                 labelMsg="filters.campaign.timeframe.label"
                 options={ DATE_OPTIONS } value={ this.state.timeframe }
@@ -119,6 +161,8 @@ export default class CampaignFilter extends FilterBase {
         return {
             operator: opFields[0],
             campaign: this.state.campaign,
+            activity: this.state.activity,
+            location: this.state.location,
             state: (opFields[1] == 'su')? 'signed_up' : 'booked',
             before: this.state.before,
             after: this.state.after,
@@ -168,6 +212,8 @@ function stateFromConfig(config) {
     let state = {
         op: opPrefix + '_' + opSuffix,
         campaign: config.campaign,
+        activity: config.activity,
+        location: config.location,
         before: config.before,
         after: config.after,
     }

--- a/src/components/filters/FilterList.jsx
+++ b/src/components/filters/FilterList.jsx
@@ -50,16 +50,6 @@ export default class FilterList extends React.Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.filters != this.props.filters) {
-            this.setState({
-                filters: nextProps.filters.map(f => Object.assign({}, f, {
-                    id: makeRandomString(10),
-                })),
-            });
-        }
-    }
-
     render() {
         let filters = this.state.filters;
         let filterElements = [];

--- a/src/components/filters/FilterList.jsx
+++ b/src/components/filters/FilterList.jsx
@@ -63,6 +63,7 @@ export default class FilterList extends React.Component {
             'person_data': msg('filters.types.personData'),
             'person_tags': msg('filters.types.personTags'),
             'random': msg('filters.types.random'),
+            'sub_query': msg('filters.types.subQuery'),
             'survey_submission': msg('filters.types.surveySubmission'),
             'survey_response': msg('filters.types.surveyResponse'),
             'survey_option': msg('filters.types.surveyOption'),

--- a/src/components/filters/SubQueryFilter.jsx
+++ b/src/components/filters/SubQueryFilter.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+
+import FilterBase from './FilterBase';
+import SelectInput from '../forms/inputs/SelectInput';
+
+import { retrieveCallAssignments } from '../../actions/callAssignment';
+import { retrieveQueries } from '../../actions/query';
+
+const mapStateToProps = state => {
+    const assignmentList = state.callAssignments.assignmentList;
+    const queryList = state.queries.queryList;
+
+    return {
+        assignmentList,
+        queryList,
+    };
+};
+
+
+@injectIntl
+@connect(mapStateToProps)
+export default class SubQueryFilter extends FilterBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            queryId: props.config.query_id,
+        };
+    }
+
+    componentDidMount() {
+        super.componentDidMount();
+
+        this.props.dispatch(retrieveCallAssignments());
+        this.props.dispatch(retrieveQueries());
+    }
+
+    componentReceivedProps(nextProps) {
+        if (nextProps.config !== this.props.config) {
+            this.setState({
+                queryId: nextProps.config.query_id,
+            });
+        }
+    }
+
+    renderFilterForm(config) {
+        const SA_OPTIONS = {}
+        const queryItems = this.props.queryList.items || [];
+        queryItems
+            .filter(item => item.data.type == 'standalone')
+            .forEach(item => {
+                const query = item.data;
+                SA_OPTIONS[query.id] = query.title;
+            });
+
+        const CA_OPTIONS = {}
+        const assignmentItems = this.props.assignmentList.items || [];
+        assignmentItems.forEach(item => {
+            const ca = item.data;
+
+            CA_OPTIONS[ca.target.id] = this.props.intl.formatMessage(
+                { id: 'filters.subQuery.assignment.target' },
+                { assignment: ca.title });
+
+            CA_OPTIONS[ca.goal.id] = this.props.intl.formatMessage(
+                { id: 'filters.subQuery.assignment.goal' },
+                { assignment: ca.title });
+        });
+
+        const saLabel = this.props.intl.formatMessage({ id: 'filters.subQuery.types.standalone' });
+        const caLabel = this.props.intl.formatMessage({ id: 'filters.subQuery.types.callAssignment' });
+        const OPTIONS = {
+            [saLabel]: SA_OPTIONS,
+            [caLabel]: CA_OPTIONS,
+        };
+
+        return [
+            <SelectInput key="isUser" name="is_user"
+                labelMsg="filters.subQuery.queryLabel"
+                options={ OPTIONS } value={ this.state.queryId }
+                orderAlphabetically={ true }
+                onValueChange={ this.onQuerySelect.bind(this) }
+                />,
+        ];
+    }
+
+    getConfig() {
+        return {
+            query_id: this.state.queryId,
+        };
+    }
+
+    onQuerySelect(name, value) {
+        this.setState({ queryId: value }, () => this.onConfigChange());
+    }
+}

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -4,6 +4,7 @@ import CampaignFilter from './CampaignFilter';
 import PersonDataFilter from './PersonDataFilter';
 import PersonTagsFilter from './PersonTagsFilter';
 import RandomFilter from './RandomFilter';
+import SubQueryFilter from './SubQueryFilter';
 import SurveyOptionFilter from './SurveyOptionFilter';
 import SurveyResponseFilter from './SurveyResponseFilter';
 import SurveySubmissionFilter from './SurveySubmissionFilter';
@@ -16,6 +17,7 @@ const filterComponents = {
     'person_data': PersonDataFilter,
     'person_tags': PersonTagsFilter,
     'random': RandomFilter,
+    'sub_query': SubQueryFilter,
     'survey_option': SurveyOptionFilter,
     'survey_response': SurveyResponseFilter,
     'survey_submission': SurveySubmissionFilter,

--- a/src/components/forms/inputs/SelectInput.jsx
+++ b/src/components/forms/inputs/SelectInput.jsx
@@ -15,25 +15,7 @@ export default class SelectInput extends InputBase {
     };
 
     renderInput() {
-        let keys = Object.keys(this.props.options);
-
-        if (this.props.orderAlphabetically) {
-            keys.sort((k0, k1) => this.props.options[k0].localeCompare(this.props.options[k1]));
-        }
-
-        let optionElements = keys.map(key => {
-            var label = this.props.options[key];
-
-            if (this.props.optionLabelsAreMessages) {
-                label = this.props.intl.formatMessage({ id: label });
-            }
-
-            return (
-                <option key={ key } value={ key }>
-                    { label }
-                </option>
-            );
-        });
+        let optionElements = this.elementsFromObject(this.props.options);
 
         if (this.props.nullOption || this.props.nullOptionMsg) {
             let label = this.props.nullOption;
@@ -54,6 +36,57 @@ export default class SelectInput extends InputBase {
                 { optionElements }
             </select>
         );
+    }
+
+    elementsFromObject(obj) {
+        let keys = Object.keys(obj);
+
+        if (this.props.orderAlphabetically) {
+            keys.sort((k0, k1) => {
+                let s0 = obj[k0];
+                let s1 = obj[k1];
+
+                if (typeof s0 != 'string') {
+                    s0 = k0;
+                }
+                if (typeof s1 != 'string') {
+                    s1 = k1;
+                }
+
+                return s0.localeCompare(s1);
+            });
+        }
+
+        return keys.map(key => {
+            var content = obj[key];
+
+            if (typeof content == 'string') {
+                // Strings are <option> elements, optionally localized
+                if (this.props.optionLabelsAreMessages) {
+                    content = this.props.intl.formatMessage({ id: content });
+                }
+
+                return (
+                    <option key={ key } value={ key }>
+                        { content }
+                    </option>
+                );
+            }
+            else {
+                // Non-strings must be objects, and are interpreted as
+                // <optgroup> elements, optionally localized
+                let label = key;
+                if (this.props.optionLabelsAreMessages) {
+                    label = this.props.intl.formatMessage({ id: label });
+                }
+
+                return (
+                    <optgroup key={ key } label={ label }>
+                        { this.elementsFromObject(content) }
+                    </optgroup>
+                );
+            }
+        });
     }
 
     onChange(ev) {


### PR DESCRIPTION
This PR adds a bunch of new filtering capabilities for Smart Searches:

* Include signed-up but not booked participants in campaign participation filter
* Filter by activity/location in the campaign participation filter (#845)
* New sub-query filter for both standalone queries and call assignments (#849, #850)

It also introduces support for `<optgroup>`s in `SelectInput`.