### PR TITLE
README: note the SMS challenge number, update the APP_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ Basic user     | testuser@example.com    | password
 
 To sign in to this app, Zetkin Organize, you will need to sign in using the
 _testadmin@example.com_ user.
+
+Answer the SMS challenge using `999999` (six nines).

--- a/bin/run_dev
+++ b/bin/run_dev
@@ -8,8 +8,8 @@ docker run \
     --name organize_zetk_in \
     --env TOKEN_SECRET=012345678901234567891234 \
     --env ZETKIN_LOGIN_URL=http://login.dev.zetkin.org \
-    --env ZETKIN_APP_ID=c690938258d842cba406a492b9bcfa24 \
-    --env ZETKIN_APP_KEY=MmEyYjRhOGQtMWFjMS00Y2VhLTgwY2EtNDE1NDA1YmNhMTJj \
+    --env ZETKIN_APP_ID=e406f49779ed460c9d2117ab58bfeb64 \
+    --env ZETKIN_APP_KEY=NjUyYTdmYWItODg4MS00MDcxLTkyM2MtM2IyMmE0Zjc3ODBj \
     --env ZETKIN_DOMAIN=dev.zetkin.org \
     --env TOKEN_SECRET=012345678901234567890123 \
     -p 80:80 \


### PR DESCRIPTION
This PR updates the README to include instructions for logging in: the SMS challenge is set to the fixed number `999999` in development.

Also: update the APP_ID