### PR TITLE
QueryPane: InfoList with description and search result count

### DIFF
--- a/locale/panes/query/en.yaml
+++ b/locale/panes/query/en.yaml
@@ -1,1 +1,3 @@
 editLink: Edit this Smart Search query
+summary:
+    size: '{size, plural, =0 {No search results} =1 {One search result} other {# search results}}'

--- a/locale/panes/query/sv.yaml
+++ b/locale/panes/query/sv.yaml
@@ -1,1 +1,3 @@
 editLink: Redigera den här Smarta sökningen
+summary:
+    size: '{size, plural, =0 {Inga sökträffar} =1 {En sökträff} other {# sökträffar}}'

--- a/src/components/panes/QueryPane.jsx
+++ b/src/components/panes/QueryPane.jsx
@@ -7,7 +7,7 @@ import InfoList from '../misc/InfoList';
 import PersonList from '../lists/PersonList';
 import { getListItemById } from '../../utils/store';
 import { retrieveQuery, retrieveQueryMatches } from '../../actions/query';
-
+import LoadingIndicator from '../misc/LoadingIndicator';
 
 const mapStateToProps = (state, props) => ({
     queryItem: getListItemById(state.queries.queryList,
@@ -57,17 +57,29 @@ export default class QueryPane extends PaneBase {
         let item = data.queryItem;
         if (item && item.data && item.data.matchList) {
             let matchList = item.data.matchList;
+            let content = [];
 
-            return [
-                <InfoList key="infoList"
-                    data={[
-                        { name: 'desc', value: data.queryItem.data.info_text },
-                        { name: 'size', msgId: 'panes.query.summary.size', msgValues: { size: matchList.items.length } },
-                    ]}
-                />,
-                <PersonList key="peopleList" personList={ matchList }
-                    onItemClick={ this.onPersonItemClick.bind(this) }/>
+            let summary = [
+              { name: 'desc', value: data.queryItem.data.info_text },
             ];
+
+            if (!matchList.isPending) {
+                summary.push({ name: 'size',
+                               msgId: 'panes.query.summary.size',
+                               msgValues: { size: matchList.items.length } });
+            }
+
+            content = content.concat([
+                <InfoList key="infoList" data={summary} />,
+            ]);
+
+            if (!matchList.isPending) {
+                content = content.concat([<PersonList key="peopleList" personList={ matchList }
+                               onItemClick={ this.onPersonItemClick.bind(this) }/>])
+            } else {
+                content = content.concat([<LoadingIndicator />]);
+            }
+            return content;
         }
     }
 

--- a/src/components/panes/QueryPane.jsx
+++ b/src/components/panes/QueryPane.jsx
@@ -3,6 +3,7 @@ import { FormattedMessage as Msg } from 'react-intl';
 import { connect } from 'react-redux';
 
 import PaneBase from './PaneBase';
+import InfoList from '../misc/InfoList';
 import PersonList from '../lists/PersonList';
 import { getListItemById } from '../../utils/store';
 import { retrieveQuery, retrieveQueryMatches } from '../../actions/query';
@@ -58,6 +59,12 @@ export default class QueryPane extends PaneBase {
             let matchList = item.data.matchList;
 
             return [
+                <InfoList key="infoList"
+                    data={[
+                        { name: 'desc', value: data.queryItem.data.info_text },
+                        { name: 'size', msgId: 'panes.query.summary.size', msgValues: { size: matchList.items.length } },
+                    ]}
+                />,
                 <PersonList key="peopleList" personList={ matchList }
                     onItemClick={ this.onPersonItemClick.bind(this) }/>
             ];

--- a/src/components/panes/QueryPane.scss
+++ b/src/components/panes/QueryPane.scss
@@ -8,4 +8,21 @@
             @include icon($fa-var-pencil);
         }
     }
+
+    .InfoList {
+      margin-bottom: 2em;
+    }
+
+    .InfoListItem-desc {
+        font-style: italic;
+        &::before {
+            @include icon($fa-var-info-circle);
+        }
+    }
+
+    .InfoListItem-size {
+        &::before {
+            @include icon($fa-var-users);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds an `InfoList` section to Smart Searches:

- description
- search result count

Closes #564
Closes #855