### PR TITLE
Optimized duplicate search

### DIFF
--- a/src/server/api/duplicates.js
+++ b/src/server/api/duplicates.js
@@ -15,19 +15,19 @@ const dupApi = express();
 const calcSimilarity = (master, other) => {
     let score = 0;
 
-    if (master.first_name.trim() == other.first_name.trim()) score += 6;
-    if (master.last_name.trim() == other.last_name.trim()) score += 6;
+    if (master.n_first_name == other.n_first_name) score += 6;
+    if (master.n_last_name == other.n_last_name) score += 6;
     if (master.ext_id && master.ext_id == other.ext_id) score += 20;
 
     // Add 6 for identical e-mails, subtract 2 for different
-    let mEmail = master.email? master.email.toLowerCase() : null;
-    let oEmail = other.email? other.email.toLowerCase() : null;
+    let mEmail = master.m_email;
+    let oEmail = other.m_email;
     if (mEmail && mEmail == oEmail) score += 6;
     else if (mEmail && oEmail && mEmail != oEmail) score -= 2;
 
     // Add 6 for identical phone numbers, subtract 2 for different
-    let mPhone = master.phone? master.phone.replace(/\D/g, '') : null;
-    let oPhone = other.phone? other.phone.replace(/\D/g, '') : null;
+    let mPhone = master.m_phone;
+    let oPhone = other.m_phone;
     if (mPhone && mPhone == oPhone) score += 6;
     else if (mPhone && oPhone && mPhone != oPhone) score -= 2;
 
@@ -38,9 +38,17 @@ dupApi.get('/:orgId/people', (req, res, next) => {
     req.z.resource('orgs', req.params.orgId, 'people')
         .get()
         .then(result => {
-            let people = result.data.data;
             let master;
             let duplicates = [];
+
+            let people = result.data.data.map(p => {
+                p.n_phone = p.phone? p.phone.replace(/\D/g, '') : null;
+                p.n_email = p.email? p.email.toLowerCase() : null;
+                p.n_first_name = p.first_name.trim().toLowerCase();
+                p.n_last_name = p.last_name.trim().toLowerCase();
+
+                return p;
+            });
 
             while (master = people.pop()) {
                 let duplicate = {


### PR DESCRIPTION
This PR optimizes the duplicate search using the following strategies:

* Calculate normalized values for person attributes once, and reuse
* Don't pop/splice lists, use indices and flags instead
* Don't create a duplicate object unless duplicates are found

## Benchmarks
These benchmarks were measured using real-life data in a mid-size and large organization respectively. The times in seconds are measured using the Chrome dev tools when making a request to the duplicate search endpoint for each of the organizations before and after the change.

| Case | Trial 1 | Trial 2 | Trial 3 | Trial 4 | Trial 5| Avg boost
|:-----|-------:|-------:|-------:|-------:|-------:|--------:|
| Mid-size org, before | 9.23 | 8.15 | 4.65 | 4.75 | 4.66 |
| Mid-size org, after | 1.77 | 1.63 | 1.67 | 1.59 | 1.62 | 4x
| Large org, before | 35.11 | 14.16 | 15.28 | 13.63 | 15.59 |
| Large org, after | 1.75 | 1.53 | 1.52 | 1.46 | 1.71 | 12x

Closes #866