### PR TITLE
BulkOpPane: avoid action exports of more than 100 items

### DIFF
--- a/locale/panes/bulkOp/en.yaml
+++ b/locale/panes/bulkOp/en.yaml
@@ -18,3 +18,4 @@ headers:
                 =1 {one person}
                 other {# persons}}
 submitButton: Perform operation
+tooLargeActionExport: Action Export too large, max number supported is { maxActionsSupportedInExport }

--- a/locale/panes/bulkOp/sv.yaml
+++ b/locale/panes/bulkOp/sv.yaml
@@ -18,3 +18,4 @@ headers:
                 =1 {en person}
                 other {# personer}}
 submitButton: Utför
+tooLargeActionExport: Action Export too large, max number supported is { maxActionsSupportedInExport }

--- a/src/components/panes/BulkOpPane.jsx
+++ b/src/components/panes/BulkOpPane.jsx
@@ -66,6 +66,18 @@ export default class BulkOpPane extends PaneBase {
 
     renderPaneFooter(data) {
         if (this.state.config) {
+            if (this.getParam(0) === 'action.export') {
+                let maxActionsSupportedInExport = 100;
+
+                if (data.selection.selectedIds.length > maxActionsSupportedInExport) {
+                    return (
+                        <Button labelMsg="panes.bulkOp.tooLargeActionExport"
+                            className="tooLargeActionExport"
+                            labelValues={{ maxActionsSupportedInExport }}/>
+                    );
+                }
+            }
+
             return (
                 <Button labelMsg="panes.bulkOp.submitButton"
                     onClick={ this.onSubmitButtonClick.bind(this) }/>

--- a/src/components/panes/BulkOpPane.scss
+++ b/src/components/panes/BulkOpPane.scss
@@ -1,0 +1,8 @@
+.PaneBase {
+    .PaneBase-footer {
+        button.tooLargeActionExport {
+            background-color: $c-ui-warning;
+            border-color: darken($c-ui-warning, 10);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a hard-coded limit of "max 100 actions in an actions export".

- an explanation is rendered in the Footer of the pane
- a warning color (SCSS orange) visualizes the warning-ness

## Needs

- A clearer indication that this is unsupported.
- Not a `<Button>`.

Example (where the limit is set to 10 not 100, in order to hit the limit)

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/211/44103701-3d16daf0-9fed-11e8-9435-5c00ef127577.png">


See #875.