### PR TITLE
Implement loading state for Avatar images

### DIFF
--- a/src/components/lists/items/elements/ParticipantItem.scss
+++ b/src/components/lists/items/elements/ParticipantItem.scss
@@ -5,7 +5,7 @@
         margin: 0;
     }
 
-    img {
+    .Avatar {
         width: 3em;
         height: auto;
     }

--- a/src/components/misc/Avatar.jsx
+++ b/src/components/misc/Avatar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 import { connect } from 'react-redux';
 
 
@@ -9,6 +10,15 @@ const mapStateToProps = state => ({
 
 @connect(mapStateToProps)
 export default class Avatar extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            pending: true,
+            error: false,
+        };
+    }
+
     render() {
         const person = this.props.person;
         const avatarDomain = '//api.' + process.env.ZETKIN_DOMAIN;
@@ -19,12 +29,41 @@ export default class Avatar extends React.Component {
             person.first_name + ' ' + person.last_name :
             person.name? person.name : '';
 
+        const classes = cx('Avatar', {
+            pending: this.state.pending,
+            error: this.state.error,
+        });
+
         return (
-            <img className="Avatar"
-                src={ src } alt={ alt } title={ alt }
-                onClick={ this.props.onClick }
-                />
+            <div className={ classes }>
+                <img ref="image"
+                    src={ src } alt={ alt } title={ alt }
+                    onLoad={ this.onLoad.bind(this) }
+                    onError={ this.onError.bind(this) }
+                    onClick={ this.props.onClick }
+                    />
+            </div>
         );
+    }
+
+    componentDidMount() {
+        if (this.refs.image.complete) {
+            this.onLoad();
+        }
+    }
+
+    onLoad() {
+        this.setState({
+            pending: false,
+            error: false,
+        });
+    }
+
+    onError() {
+        this.setState({
+            pending: false,
+            error: true,
+        });
     }
 }
 

--- a/src/components/misc/Avatar.scss
+++ b/src/components/misc/Avatar.scss
@@ -1,0 +1,30 @@
+.Avatar {
+    display: inline-block;
+    width: 100%;
+    height: auto;
+
+    img {
+        width: 100%;
+        height: auto;
+        opacity: 1;
+        transition: opacity 0.5s;
+    }
+
+    &.pending {
+        background-color: rgba(0,0,0, 0.02);
+        animation: Avatar-pending-animation 0.6s;
+        animation-iteration-count: infinite;
+        animation-direction: alternate;
+
+        img {
+            opacity: 0;
+            padding-top: 100%;
+        }
+    }
+}
+
+@keyframes Avatar-pending-animation {
+    100% {
+        background-color: rgba(0,0,0, 0.05);
+    }
+}

--- a/src/components/misc/DraggableAvatar.scss
+++ b/src/components/misc/DraggableAvatar.scss
@@ -1,9 +1,4 @@
 .DraggableAvatar {
     cursor: -webkit-grab;
     cursor: grab;
-
-    .Avatar {
-        width: 100%;
-        height: auto;
-    }
 }


### PR DESCRIPTION
This PR adds a loading state for `Avatar` images. While the `img` loads, the avatar is displayed as a mostly translucent, pulsating square. When the image finishes loading, it fades in.