### PR TITLE
Avatar sizing (and other improvements)

### DIFF
--- a/src/actions/search/index.js
+++ b/src/actions/search/index.js
@@ -20,17 +20,20 @@ export function search(query) {
 
             if (!scope || scope == 'campaign') {
                 queue.addProc(new procs.ActionDaySearchProc(dispatch));
+            }
+
+            if (!scope || scope == 'people') {
+                queue.addProc(new procs.PersonQuerySearchProc(dispatch));
+                queue.addProc(new procs.PersonSearchProc(dispatch));
+            }
+
+            if (!scope || scope == 'campaign') {
                 queue.addProc(new procs.CampaignSearchProc(dispatch));
                 queue.addProc(new procs.ActivitySearchProc(dispatch));
             }
 
             if (!scope || scope == 'dialog') {
                 queue.addProc(new procs.CallAssignmentSearchProc(dispatch));
-            }
-
-            if (!scope || scope == 'people') {
-                queue.addProc(new procs.PersonQuerySearchProc(dispatch));
-                queue.addProc(new procs.PersonSearchProc(dispatch));
             }
 
             if (!scope || scope == 'maps') {

--- a/src/components/header/search/matches/MatchBase.scss
+++ b/src/components/header/search/matches/MatchBase.scss
@@ -10,9 +10,9 @@
     }
 
 
-    img {
+    img, .Avatar {
         max-height: 3em;
-        width: auto;
+        max-width: 3em;
     }
 }
 

--- a/src/components/lists/items/elements/ParticipantItem.scss
+++ b/src/components/lists/items/elements/ParticipantItem.scss
@@ -6,7 +6,7 @@
     }
 
     .Avatar {
-        width: 3em;
+        width: 2.95em;
         height: auto;
     }
 }

--- a/src/components/lists/items/elements/ParticipantList.scss
+++ b/src/components/lists/items/elements/ParticipantList.scss
@@ -24,9 +24,9 @@
     .ParticipantList-moreParticipants {
         position: absolute;
         top: 0;
-        right: 0;
-        width: 3em;
-        height: 3em;
+        right: 0.15em;
+        width: 2.95em;
+        height: 2.95em;
         line-height: 3em;
         margin: 0.25em;
         text-align: center;


### PR DESCRIPTION
This PR contains two bug fixes and one separate improvement:

* Tweaks avatar sizing in `ActionListItem` participant list, fixes #890
* Tweaks avatar sizing in search matches, fixes #887 
* Re-orders search ops so that searching for people is prioritized over (almost) everything else