### PR TITLE
Add availability statuses notred, notgreen

### DIFF
--- a/locale/panes/allActions/da.yaml
+++ b/locale/panes/allActions/da.yaml
@@ -4,7 +4,20 @@ filters:
         label: Aktivitet
         nullOption: (Uanset aktivitet)
     afterDate: Efter dato
+    availability:
+        label: Deltagerstatus
+        nullOption: (Uanset deltagerantal)
+        options:
+            green: "Status grøn: nok tilgængelige"
+            red: "Status rød: to eller flere mangler"
+            yellow: "Status gul: en person mangler"
+            notgreen: "Status ikke grøn: en eller flere mangler"
+            notred: "Status ikke rød: mangler som mest én"
     beforeDate: Før dato
+    location:
+        label: Plads
+        nullOption: (Uanset plads)
+importButton: Importér aktioner
 viewModes:
     calendar: Kalender
     list: Liste

--- a/locale/panes/allActions/en.yaml
+++ b/locale/panes/allActions/en.yaml
@@ -11,6 +11,8 @@ filters:
             green: "Status green: enough available"
             red: "Status red: two or more missing"
             yellow: "Status yellow: one person missing"
+            notgreen: "Status not green: one or more missing"
+            notred: "Status not red: at most one missing"
     beforeDate: Before date
     location:
         label: Location

--- a/locale/panes/allActions/sv.yaml
+++ b/locale/panes/allActions/sv.yaml
@@ -11,6 +11,8 @@ filters:
             green: "Status grön: tillräckligt många"
             red: "Status röd: saknas två eller fler"
             yellow: "Status gul: saknas en person"
+            notgreen: "Status ej grön: saknas en eller flera personer"
+            notred: "Status ej röd: saknas som mest en person"
     beforeDate: Till datum
     location:
         label: Plats

--- a/src/components/lists/items/ActionListItem.jsx
+++ b/src/components/lists/items/ActionListItem.jsx
@@ -178,7 +178,7 @@ export default class ActionListItem extends React.Component {
         const bookingDiff = (action.num_participants_required - participants.length);
         let indicator;
 
-        if (bookingDiff >= 2)
+        if (bookingDiff >= 2 || participants.length == 0)
             indicator = 'danger';
         else if (bookingDiff >= 1)
             indicator = 'low';

--- a/src/components/sections/campaign/CampaignSectionPaneBase.jsx
+++ b/src/components/sections/campaign/CampaignSectionPaneBase.jsx
@@ -40,6 +40,8 @@ export default class CampaignSectionPaneBase extends RootPaneBase {
             'red': 'panes.allActions.filters.availability.options.red',
             'yellow': 'panes.allActions.filters.availability.options.yellow',
             'green': 'panes.allActions.filters.availability.options.green',
+            'notgreen': 'panes.allActions.filters.availability.options.notgreen',
+            'notred': 'panes.allActions.filters.availability.options.notred',
         };
 
         return [


### PR DESCRIPTION
This PR fixes #915.

- Actions Calendar filters: introduce `notgreen`, `notred` statuses
- Translate statuses (da, en, sv)
- Change: `red` now also includes "an action which requires 1 and needs 1 participant" (whereas before red meant: "an action which needs 2 participants", which would exclude all 1-person jobs) See #918 374

## Rendering the ActionList

When rendering the participation level indicator, we mark _any_ activity with 0 participants as "red".

<img width="754" alt="image" src="https://user-images.githubusercontent.com/211/45585126-97df1f00-b8df-11e8-8bbe-eaca49484f44.png">
