### PR TITLE
Move styling to Input

### DIFF
--- a/src/components/forms/inputs/DateInput.scss
+++ b/src/components/forms/inputs/DateInput.scss
@@ -1,6 +1,0 @@
-.DateInput {
-    input[type=date] {
-        @include input-base;
-        font-family:inherit;
-    }
-}

--- a/src/components/forms/inputs/InputBase.jsx
+++ b/src/components/forms/inputs/InputBase.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
+import cx from 'classnames';
 
 
 export default class InputBase extends React.Component {
@@ -16,6 +17,8 @@ export default class InputBase extends React.Component {
 
     render() {
         let label = null;
+        let classes = cx('InputBase', this.props.className);
+
         if (this.props.labelMsg) {
             label = (
                 <Msg tagName="label"
@@ -23,7 +26,7 @@ export default class InputBase extends React.Component {
             );
         }
         return (
-            <div className={ this.props.className }>
+            <div className={ classes }>
                 { label }
                 { this.renderInput() }
             </div>

--- a/src/components/forms/inputs/InputBase.scss
+++ b/src/components/forms/inputs/InputBase.scss
@@ -1,0 +1,7 @@
+.InputBase {
+    input,
+    textarea,
+    select {
+        @include input-base;
+    }
+}

--- a/src/components/forms/inputs/RelSelectInput.scss
+++ b/src/components/forms/inputs/RelSelectInput.scss
@@ -3,8 +3,6 @@
     width: 100%;
 
     input[type=text] {
-        @include input-base;
-
         &::placeholder {
             color: darken(white, 30);
         }

--- a/src/components/forms/inputs/SelectInput.jsx
+++ b/src/components/forms/inputs/SelectInput.jsx
@@ -31,10 +31,12 @@ export default class SelectInput extends InputBase {
         }
 
         return (
-            <select value={ this.props.value || '0' }
-                onChange={ this.onChange.bind(this) }>
-                { optionElements }
-            </select>
+            <div className="SelectInput">
+                <select value={ this.props.value || '0' }
+                    onChange={ this.onChange.bind(this) }>
+                    { optionElements }
+                </select>
+            </div>
         );
     }
 

--- a/src/components/forms/inputs/SelectInput.scss
+++ b/src/components/forms/inputs/SelectInput.scss
@@ -1,4 +1,4 @@
-select {
+.SelectInput select {
     background: inherit;
     font-family: inherit;
     height: 33px;

--- a/src/components/forms/inputs/SelectInput.scss
+++ b/src/components/forms/inputs/SelectInput.scss
@@ -1,10 +1,9 @@
-select{
-    @include input-base;
+select {
     background: inherit;
     font-family: inherit;
     height: 33px;
 
-    &:focus{
+    &:focus {
         padding: calc(0.25em - 1px);
     }
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -33,14 +33,6 @@
 @mixin form-base {
     color: lighten($c-text, 40);
 
-    input,
-    input[type="text"],
-    input[type="email"],
-    textarea,
-    input[type="password"] {
-        @include input-base;
-    }
-
     input[type="submit"] {
         @include button;
         display: block;


### PR DESCRIPTION
This PR moves styling relating to input fields from a global mixin called `form-base` to be more component specific. This styling is now in the component `InputBase`. All Input components inherits this.

We are however still to use the global mixin `input-base`, since this is shared with components outside of this scope.

Also removed unnecessary use of `input-base` in some of the input components.

Fix #568