### PR TITLE
Add assignment to CallPane

### DIFF
--- a/src/components/panes/CallPane.scss
+++ b/src/components/panes/CallPane.scss
@@ -11,6 +11,16 @@
     }
 }
 
+.CallPane-info {
+    color: lighten($c-text, 40);
+}
+
+.CallPane-infoCallAssignment {
+    &:before {
+        @include icon($fa-var-list-ul);
+    }
+}
+
 .CallPane-target {
     margin-bottom: 1em;
 


### PR DESCRIPTION
This PR adds the title of a Call assignment to CallPane (the pane that inspects a specific report form the call log). We are following the same layout as in Survey submissions.

The title is retrieved from the assignment by fetching the right assignment based on a specified assignment ID in the call object. Since we can't load the assignment before we have the call and this id, we will have to await this first.

When rendering, we add the div with class `CallPane-info` and add the title to this.

Fix #865 


![screen shot 2018-12-13 at 18 10 00](https://user-images.githubusercontent.com/1271517/49955549-60ded080-ff03-11e8-9139-9deb7cc8ac6f.png)
