### PR TITLE
Action calendar styling 

### DIFF
--- a/src/components/misc/actioncal/ActionCalendar.scss
+++ b/src/components/misc/actioncal/ActionCalendar.scss
@@ -1,5 +1,30 @@
 .ActionCalendar {
 
+    .ActionWeek {
+        @include flex-container;
+
+        @include medium-screen {
+            display: block;
+        }
+
+        h2 {
+            font-size: 1.2em;
+            font-weight: normal;
+            margin-top: 0.5em;
+            width: 4%;
+
+            @include medium-screen {
+                width: auto;
+            }
+        }
+
+        &::after {
+            content: "";
+            display: block;
+            clear: both;
+        }
+    }
+
     .ActionDay {
         h4 {
             &:hover {
@@ -24,26 +49,5 @@
         top: calc(50% - 0.8em);
         right: 0.25em;
         cursor: -webkit-grab;
-    }
-}
-
-@include medium-screen {
-    .ActionCalendar{
-        .ActionWeek {
-            @include flex-container;
-
-            h2 {
-                font-size: 1.2em;
-                font-weight: normal;
-                width: 4%;
-                margin-top: 0.5em;
-            }
-
-            &::after {
-                content: "";
-                display: block;
-                clear: both;
-            }
-        }
     }
 }

--- a/src/components/misc/actioncal/ActionDay.scss
+++ b/src/components/misc/actioncal/ActionDay.scss
@@ -1,11 +1,21 @@
 .ActionDay {
-    position: relative;
+    @include flex;
     border-left: 1px solid #F1F1F1;
-    padding-bottom: 2em;
     color: darken($c-ui-darker, 10);
+    padding-bottom: 2em;
+    position: relative;
+
+    &:last-child {
+        border-right: 1px solid #f4f4f4;
+    }
 
     &:hover {
         background-color: darken($c-ui-bg, 1);
+    }
+
+    &:hover .ActionDay-addButton {
+        opacity: 1;
+        visibility: visible;
     }
 
     h4 {
@@ -22,10 +32,24 @@
     }
 
     .cloneHint {
-        display: none;
+        position: absolute;
+        left: 1em;
+        right: 1em;
+        bottom: 1em;
+        text-align: center;
+        color: #999;
+
+        @include medium-screen {
+            display: none;
+        }
+
+        code {
+            @include key-reference
+            background-color: darken(#eee, 3);
+        }
     }
 
-    &.dragOver{
+    &.dragOver {
         background-color: #eee;
 
         .ActionDay-addButton {
@@ -35,15 +59,21 @@
 }
 
 .ActionDay-addButton {
-    display: block;
-    width: 100%;
     background-color: #eee;
     border-width: 0;
-    cursor: pointer;
-    text-align: center;
     color: #aaa;
-
+    cursor: pointer;
+    display: block;
+    text-align: center;
     transition: opacity 0.3s 0.1s;
+    width: 100%;
+    visibility: hidden;
+    opacity: 0;
+
+    @include medium-screen {
+        visibility: visible;
+        opacity: 1;
+    }
 
     &::before {
         @include icon($fa-var-plus);
@@ -51,39 +81,5 @@
 
     &:hover {
         background-color: darken(#eee, 1);
-    }
-}
-@include medium-screen {
-
-    .ActionDay {
-        @include flex;
-
-        &:last-child {
-            border-right: 1px solid #f4f4f4;
-        }
-
-        .cloneHint {
-            display: block;
-            position: absolute;
-            left: 1em;
-            right: 1em;
-            bottom: 1em;
-            text-align: center;
-            color: #999;
-
-            code {
-                @include key-reference
-                background-color: darken(#eee, 3);
-            }
-        }
-    }
-
-    .ActionDay-addButton {
-        visibility: hidden;
-        opacity: 0;
-    }
-    .ActionDay:hover .ActionDay-addButton  {
-        visibility: visible;
-        opacity: 1;
     }
 }

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -5,7 +5,7 @@
     min-width: 400px;
     background-color: $c-ui-bg;
     color: lighten($c-text, .3);
-    z-index: 4;
+    z-index: 5;
 
     .PaneBase-content {
         padding: 0 2em 2em;


### PR DESCRIPTION
I've made some changes in the Action Calendar styling. It had turned the other way round due to new media queries (small screens had the desktop styling and vice versa). I hope and think it looks as it should now, but please take a closer look. 

<img width="1267" alt="actions_calendar" src="https://user-images.githubusercontent.com/5261152/50522235-2dd33a00-0aca-11e9-9f3a-f4527c9c50ea.png">
