### PR TITLE
Hide send reminder ActionBox button for past actions

### DIFF
--- a/locale/panes/action/en.yaml
+++ b/locale/panes/action/en.yaml
@@ -16,6 +16,7 @@ reminders:
     received:
         all: All participants have received reminders
         notAll: Not all participants have received reminders
+        notAllActionPassed: Not all participants have received reminders. The time of the action has passed
 responses:
     guide: Click in list to book
     h: Sign-ups

--- a/src/components/panes/ActionPane.jsx
+++ b/src/components/panes/ActionPane.jsx
@@ -148,34 +148,46 @@ export default class ActionPane extends PaneBase {
 
                 if (participants.find(p => !p.reminder_sent)) {
                     // Not all have reminders yet.
-                    reminderStatus = "waiting";
-
-                    let missingContact = null;
-
-                    if (action.contact) {
-                        reminderButton = (
-                            <Button
-                                className="ActionPane-reminderButton"
-                                labelMsg="panes.action.reminders.button"
-                                onClick={ this.onClickReminders.bind(this) }/>
+                    if (endDate < Date.now()) {
+                        // Action date has passed
+                        reminderStatus = "missing"
+                        reminderStatusMsg = (
+                            <div>
+                                <p className={ reminderStatus }>
+                                    <Msg id="panes.action.reminders.received.notAllActionPassed"/>
+                                </p>
+                            </div>
                         );
                     }
                     else {
-                        missingContact = (
-                            <p className="missingContact">
-                                <Msg id="panes.action.reminders.missingContact"/>
-                            </p>
+                        reminderStatus = "waiting";
+                        let missingContact = null;
+
+                        if (action.contact) {
+                            reminderButton = (
+                                <Button
+                                    className="ActionPane-reminderButton"
+                                    labelMsg="panes.action.reminders.button"
+                                    onClick={ this.onClickReminders.bind(this) }/>
+                            );
+                        }
+                        else {
+                            missingContact = (
+                                <p className="missingContact">
+                                    <Msg id="panes.action.reminders.missingContact"/>
+                                </p>
+                            );
+                        }
+
+                        reminderStatusMsg = (
+                            <div>
+                                <p className={ reminderStatus }>
+                                    <Msg id="panes.action.reminders.received.notAll"/>
+                                </p>
+                                { missingContact }
+                            </div>
                         );
                     }
-
-                    reminderStatusMsg = (
-                        <div>
-                            <p className={ reminderStatus }>
-                                <Msg id="panes.action.reminders.received.notAll"/>
-                            </p>
-                            { missingContact }
-                        </div>
-                    );
                 }
                 else {
                     // All have reminders

--- a/src/components/panes/ActionPane.scss
+++ b/src/components/panes/ActionPane.scss
@@ -132,9 +132,15 @@
                     }
                 }
 
-                &.waiting, &.missing {
+                &.waiting {
                     &::before {
                         @include icon($fa-var-hourglass-o);
+                    }
+                }
+
+                &.missing {
+                    &::before {
+                        @include icon($fa-var-hourglass-end);
                     }
                 }
 

--- a/src/components/panes/ActionPane.scss
+++ b/src/components/panes/ActionPane.scss
@@ -132,7 +132,7 @@
                     }
                 }
 
-                &.waiting {
+                &.waiting, &.missing {
                     &::before {
                         @include icon($fa-var-hourglass-o);
                     }


### PR DESCRIPTION
If not all participants notifications has been sent, checks to see if time of action has passed. If so, displays related message with reminder status "missing".

Fixes #974 

![skarmavbild 2019-02-20 kl 15 00 31](https://user-images.githubusercontent.com/32640644/53096828-4c7d0c80-3520-11e9-9128-e84f2679e160.png)
