### PR TITLE
Survey linking hints

### DIFF
--- a/locale/panes/linkSubmission/en.yaml
+++ b/locale/panes/linkSubmission/en.yaml
@@ -1,3 +1,5 @@
+createButton: Create {firstName} {lastName}
+createEmptyButton: Create new person
 instructions: |-
     Linking a submission to a person in the person database is necessary to be
     able to find that person based on survey searches.
@@ -6,4 +8,11 @@ person:
 saveButton:
     linkLabel: Link submission
     unlinkLabel: Unlink submission
+suggestions:
+    empty: |-
+        Zetkin tried finding a matching person from the database but found
+        nothing.
+    found: |-
+        Click a suggestion to select that person.
+    h: Suggestions
 title: Link survey submission

--- a/src/components/panes/AddPersonPane.jsx
+++ b/src/components/panes/AddPersonPane.jsx
@@ -16,8 +16,14 @@ export default class AddPersonPane extends PaneBase {
     }
 
     renderPaneContent(data) {
+        const initialData = {
+            first_name: this.getParam(0),
+            last_name: this.getParam(1),
+            email: this.getParam(2),
+        };
+
         return (
-            <PersonForm ref="personForm"
+            <PersonForm ref="personForm" person={ initialData }
                 onSubmit={ this.onSubmit.bind(this) }/>
         );
     }

--- a/src/components/panes/LinkSubmissionPane.jsx
+++ b/src/components/panes/LinkSubmissionPane.jsx
@@ -2,10 +2,18 @@ import React from 'react';
 import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 import { connect } from 'react-redux';
 
+import Avatar from '../misc/Avatar';
 import Button from '../misc/Button';
 import LoadingIndicator from '../misc/LoadingIndicator';
+import makeRandomString from '../../utils/makeRandomString';
 import PaneBase from './PaneBase';
 import PersonSelectWidget from '../misc/PersonSelectWidget';
+import {
+    beginSearch,
+    clearSearch,
+    resetSearchQuery,
+    search,
+} from '../../actions/search';
 import { getListItemById } from '../../utils/store';
 import {
     retrieveSurveySubmission,
@@ -14,6 +22,7 @@ import {
 
 
 const mapStateToProps = (state, props) => ({
+    searchStore: state.search,
     submissionItem: getListItemById(
         state.surveySubmissions.submissionList,
         props.paneData.params[0]),
@@ -28,6 +37,7 @@ export default class LinkSubmissionPane extends PaneBase {
 
         this.state = {
             originalPersonId: null,
+            suggestionSearchId: makeRandomString(),
         };
 
         if (props.submissionItem && props.submissionItem.data) {
@@ -50,6 +60,10 @@ export default class LinkSubmissionPane extends PaneBase {
         if (!this.props.submissionItem || !this.props.submissionItem.data) {
             this.props.dispatch(retrieveSurveySubmission(this.getParam(0)));
         }
+
+        if (!this.state.person) {
+            this.searchSuggestions();
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -67,10 +81,91 @@ export default class LinkSubmissionPane extends PaneBase {
         }
     }
 
-    renderPaneContent(data) {
-        let person = null;
+    componentWillUnmount() {
+        this.props.dispatch(clearSearch(this.state.suggestionSearchId));
+    }
 
+    renderPaneContent(data) {
         if (this.props.submissionItem && this.props.submissionItem.data) {
+            const respondent = this.props.submissionItem.data.respondent;
+            let actions = null;
+
+            if (!this.state.person) {
+                const content = [
+                    <Msg key="suggestionsHeader" tagName="h2"
+                        id="panes.linkSubmission.suggestions.h"
+                        />,
+                ];
+
+                const searchData = this.props.searchStore[this.state.suggestionSearchId];
+                if (searchData) {
+                    if (searchData.isPending) {
+                        content.push(
+                            <LoadingIndicator key="loadingIndicator"/>,
+                        );
+                    }
+                    else if (searchData.results && searchData.results.length) {
+                        content.push(
+                            <Msg key="foundSuggestions" tagName="p"
+                                id="panes.linkSubmission.suggestions.found"
+                                />,
+                            <ul key="suggestions" className="LinkSubmissionPane-suggestionList">
+                                {searchData.results.map(match => (
+                                    <li key={match.data.id}
+                                        className="LinkSubmissionPane-suggestion"
+                                        onClick={this.onSuggestionClick.bind(this, match.data)}
+                                        >
+                                        <Avatar person={match.data}/>
+                                        <div>
+                                            <span className="LinkSubmissionPane-suggestionName">
+                                                {`${match.data.first_name} ${match.data.last_name}`}
+                                            </span>
+                                            <span className="LinkSubmissionPane-suggestionEmail">
+                                                {match.data.email}
+                                            </span>
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        );
+                    }
+                    else {
+                        content.push(
+                            <Msg key="noSuggestions" tagName="p"
+                                id="panes.linkSubmission.suggestions.empty"
+                                />,
+                        );
+                    }
+                }
+
+                if (respondent) {
+                    content.push(
+                        <Button key="createButton"
+                            labelMsg="panes.linkSubmission.createButton"
+                            labelValues={{
+                                firstName: respondent.first_name,
+                                lastName: respondent.last_name,
+                            }}
+                            onClick={ this.onCreateClick.bind(this) }
+                            />,
+                    );
+                }
+                else {
+                    content.push(
+                        <Button key="createButton"
+                            labelMsg="panes.linkSubmission.createEmptyButton"
+                            onClick={ this.onCreateClick.bind(this) }
+                            />,
+                    );
+                }
+
+                actions = (
+                    <div key="actions" className="LinkSubmissionPane-actions">
+                        {content}
+                    </div>
+                );
+            }
+
             return [
                 <Msg key="instructions" tagName="p"
                     id="panes.linkSubmission.instructions"
@@ -82,6 +177,7 @@ export default class LinkSubmissionPane extends PaneBase {
                     person={ this.state.person }
                     onSelect={ this.onPersonSelect.bind(this) }
                     />,
+                actions,
             ];
         }
         else {
@@ -112,6 +208,39 @@ export default class LinkSubmissionPane extends PaneBase {
         this.setState({
             person: person,
         });
+
+        if (!person) {
+            this.searchSuggestions();
+        }
+    }
+
+    searchSuggestions() {
+        const subItem = this.props.submissionItem;
+        if (!subItem || !subItem.data || !subItem.data.respondent) {
+            return;
+        }
+
+        const email = subItem.data.respondent.email;
+
+        if (email) {
+            this.props.dispatch(beginSearch(this.state.suggestionSearchId, ['person']));
+            this.props.dispatch(search(this.state.suggestionSearchId, email));
+        }
+    }
+
+    onSuggestionClick(person) {
+        this.setState({ person });
+    }
+
+    onCreateClick() {
+        const subItem = this.props.submissionItem;
+        if (subItem && subItem.data && subItem.data.respondent) {
+            const respondent = subItem.data.respondent;
+            this.openPane('addperson', respondent.first_name, respondent.last_name, respondent.email);
+        }
+        else {
+            this.openPane('addperson');
+        }
     }
 
     onSubmit() {

--- a/src/components/panes/LinkSubmissionPane.scss
+++ b/src/components/panes/LinkSubmissionPane.scss
@@ -1,0 +1,32 @@
+.LinkSubmissionPane-actions {
+    margin-top: 3em;
+}
+
+.LinkSubmissionPane-suggestionList {
+    margin-bottom: 2em;
+}
+
+.LinkSubmissionPane-suggestion {
+    @include card;
+
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    padding: 0.5em;
+    margin: 0 0 0.4em;
+
+    .Avatar {
+        max-width: 3em;
+        margin-right: 1em;
+    }
+
+    div {
+        .LinkSubmissionPane-suggestionName {
+            font-size: 1.3em;
+        }
+
+        span {
+            display: block;
+        }
+    }
+}

--- a/src/components/panes/LinkSubmissionPane.scss
+++ b/src/components/panes/LinkSubmissionPane.scss
@@ -1,3 +1,9 @@
+.LinkSubmissionPane {
+    .LoadingIndicator {
+        margin: 1em 0 1.5em;
+    }
+}
+
 .LinkSubmissionPane-actions {
     margin-top: 3em;
 }


### PR DESCRIPTION
This PR adds suggestions to the `LinkSubmissionPane` to make linking survey submissions more efficient. With these changes:

* Zetkin suggests person objects that match the e-mail address of the respondent, closes #968
* The user can create a new person from the respondent information, closes #967
* The user can create a new (empty) person for anonymous submissions

![image](https://user-images.githubusercontent.com/550212/53684483-2ddff800-3d0e-11e9-8cfd-e9784f39cdbe.png)
