### PR TITLE
Bulk create survey options

### DIFF
--- a/locale/misc/en.yaml
+++ b/locale/misc/en.yaml
@@ -49,8 +49,11 @@ surveyOutline:
             text: Text
     option:
         addButton: Add response option
+        addBulkButton: Add multiple
+        bulkInstructions: Type one option per line.
         cancelButton: Cancel
         deleteButton: Delete
         saveButton: Save
+        saveBulkButton: Create {numLines, plural, =1 {one option} other {# options}}
 tagCloud:
     addButton: Add tag

--- a/src/actions/survey.js
+++ b/src/actions/survey.js
@@ -142,6 +142,32 @@ export function createSurveyOption(surveyId, elementId, data) {
     };
 }
 
+export function createSurveyOptions(surveyId, elementId, options) {
+    return ({ dispatch, getState, z }) => {
+        const orgId = getState().org.activeId;
+
+        // Dispatch CREATE_SURVEY_OPTION actions in sequence
+        let promise = Promise.resolve();
+        options.forEach(option => {
+            promise = promise
+                .then(() => {
+                    const req = z.resource('orgs', orgId, 'surveys', surveyId,
+                        'elements', elementId, 'options').post(option)
+
+                    dispatch({
+                        type: types.CREATE_SURVEY_OPTION,
+                        meta: { surveyId, elementId },
+                        payload: {
+                            promise: req,
+                        },
+                    });
+
+                    return req;
+                });
+        });
+    };
+}
+
 export function updateSurveyOption(surveyId, elementId, optionId, data) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;

--- a/src/components/misc/surveyOutline/SurveyQuestionOutline.jsx
+++ b/src/components/misc/surveyOutline/SurveyQuestionOutline.jsx
@@ -64,21 +64,23 @@ export default class SurveyQuestionOutline extends React.Component {
                     />
             );
 
-            addSection = [
-                <Msg key="instructions" tagName="p"
-                    id="misc.surveyOutline.option.bulkInstructions"
-                    />,
-                <textarea key="bulkText"
-                    value={ this.state.bulkText }
-                    onChange={ this.onBulkTextChange.bind(this) }
-                    />,
-                saveButton,
-                <Button key="cancelBulkButton"
-                    className="SurveyQuestionOutline-cancelBulkButton"
-                    labelMsg="misc.surveyOutline.option.cancelButton"
-                    onClick={ this.onOptionCancel.bind(this) }
-                    />,
-            ];
+            addSection = (
+                <div className="SurveyQuestionOutline-addBulk">
+                    <Msg tagName="p"
+                        id="misc.surveyOutline.option.bulkInstructions"
+                        />
+                    <textarea
+                        value={ this.state.bulkText }
+                        onChange={ this.onBulkTextChange.bind(this) }
+                        />
+                    <Button
+                        className="SurveyQuestionOutline-cancelBulkButton"
+                        labelMsg="misc.surveyOutline.option.cancelButton"
+                        onClick={ this.onOptionCancel.bind(this) }
+                        />
+                    { saveButton }
+                </div>
+            );
         }
         else {
             addSection = [

--- a/src/components/misc/surveyOutline/SurveyQuestionOutline.jsx
+++ b/src/components/misc/surveyOutline/SurveyQuestionOutline.jsx
@@ -1,3 +1,4 @@
+import { FormattedMessage as Msg } from 'react-intl';
 import React from 'react';
 
 import Button from '../Button';
@@ -18,6 +19,7 @@ export default class SurveyQuestionOutline extends React.Component {
         this.state = {
             adding: false,
             openOption: null,
+            bulkText: '',
         }
     }
 
@@ -38,7 +40,7 @@ export default class SurveyQuestionOutline extends React.Component {
 
         let addSection;
 
-        if (this.state.adding) {
+        if (this.state.adding === 'single') {
             addSection = (
                 <SurveyQuestionOption
                     option={{ text: '' }} open={ true }
@@ -47,12 +49,48 @@ export default class SurveyQuestionOutline extends React.Component {
                     />
             );
         }
-        else {
-            addSection = (
-                <Button labelMsg="misc.surveyOutline.option.addButton"
-                    onClick={ this.onAddButtonClick.bind(this) }
+        else if (this.state.adding === 'bulk') {
+            const numLines = this.state.bulkText
+                .split('\n')
+                .filter(s => Boolean(s))
+                .length;
+
+            const saveButton = (numLines == 0)? null : (
+                <Button key="saveBulkButton"
+                    className="SurveyQuestionOutline-saveBulkButton"
+                    labelMsg="misc.surveyOutline.option.saveBulkButton"
+                    labelValues={{ numLines }}
+                    onClick={ this.onSaveBulkButtonClick.bind(this) }
                     />
             );
+
+            addSection = [
+                <Msg key="instructions" tagName="p"
+                    id="misc.surveyOutline.option.bulkInstructions"
+                    />,
+                <textarea key="bulkText"
+                    value={ this.state.bulkText }
+                    onChange={ this.onBulkTextChange.bind(this) }
+                    />,
+                saveButton,
+                <Button key="cancelBulkButton"
+                    className="SurveyQuestionOutline-cancelBulkButton"
+                    labelMsg="misc.surveyOutline.option.cancelButton"
+                    onClick={ this.onOptionCancel.bind(this) }
+                    />,
+            ];
+        }
+        else {
+            addSection = [
+                <Button key="addButton" labelMsg="misc.surveyOutline.option.addButton"
+                    className="SurveyQuestionOutline-addButton"
+                    onClick={ this.onAddButtonClick.bind(this, 'single') }
+                    />,
+                <Button key="bulkButton" labelMsg="misc.surveyOutline.option.addBulkButton"
+                    className="SurveyQuestionOutline-bulkButton"
+                    onClick={ this.onAddButtonClick.bind(this, 'bulk') }
+                    />
+            ];
         }
 
         return (
@@ -72,10 +110,31 @@ export default class SurveyQuestionOutline extends React.Component {
         }
     }
 
-    onAddButtonClick() {
+    onAddButtonClick(type) {
         this.setState({
             openOption: null,
-            adding: true,
+            bulkText: '',
+            adding: type,
+        });
+    }
+
+    onBulkTextChange(ev) {
+        this.setState({
+            bulkText: ev.target.value,
+        });
+    }
+
+    onSaveBulkButtonClick() {
+        if (this.props.onOptionsCreate) {
+            const lines = this.state.bulkText
+                .split('\n')
+                .filter(line => Boolean(line));
+
+            this.props.onOptionsCreate(lines);
+        }
+
+        this.setState({
+            adding: false,
         });
     }
 
@@ -99,6 +158,7 @@ export default class SurveyQuestionOutline extends React.Component {
     onOptionCancel(o) {
         this.setState({
             openOption: null,
+            adding: false,
         });
     }
 

--- a/src/components/misc/surveyOutline/SurveyQuestionOutline.scss
+++ b/src/components/misc/surveyOutline/SurveyQuestionOutline.scss
@@ -1,6 +1,26 @@
 .SurveyQuestionOutline {
+    .SurveyQuestionOutline-addBulk {
+        @include card;
+        padding: 1em;
+
+        p {
+            margin: 0 0 0.5em;
+        }
+    }
+
     .SurveyQuestionOutline-addButton {
         @include inline-button($icon:$fa-var-plus);
+    }
+
+    .SurveyQuestionOutline-cancelBulkButton {
+        @include inline-button($icon:$fa-var-times);
+    }
+
+    .SurveyQuestionOutline-saveBulkButton {
+        @include inline-button($icon:$fa-var-floppy-o,
+            $color: $c-brand-comp-light);
+        margin: 0;
+        float: right;
     }
 
     .Button {
@@ -8,6 +28,7 @@
     }
 
     textarea {
+        font-size: 1.2em;
         display: block;
         width: 100%;
         height: 6em;

--- a/src/components/misc/surveyOutline/SurveyQuestionOutline.scss
+++ b/src/components/misc/surveyOutline/SurveyQuestionOutline.scss
@@ -1,5 +1,16 @@
 .SurveyQuestionOutline {
-    button {
+    .SurveyQuestionOutline-addButton {
         @include inline-button($icon:$fa-var-plus);
+    }
+
+    .Button {
+        margin-right: 0.3em;
+    }
+
+    textarea {
+        display: block;
+        width: 100%;
+        height: 6em;
+        margin: 0 0 0.5em;
     }
 }

--- a/src/components/panes/EditSurveyQuestionPane.jsx
+++ b/src/components/panes/EditSurveyQuestionPane.jsx
@@ -15,6 +15,7 @@ import {
     deleteSurveyElement,
     updateSurveyOption,
     createSurveyOption,
+    createSurveyOptions,
     deleteSurveyOption,
     reorderSurveyOptions,
 } from '../../actions/survey';
@@ -63,6 +64,7 @@ export default class EditSurveyQuestionPane extends PaneBase {
                         <SurveyQuestionOutline
                             options={ question.options }
                             onOptionCreate={ this.onOptionCreate.bind(this) }
+                            onOptionsCreate={ this.onOptionsCreate.bind(this) }
                             onOptionTextChange={ this.onOptionTextChange.bind(this) }
                             onOptionDelete={ this.onOptionDelete.bind(this) }
                             onReorder={ this.onOptionReorder.bind(this) }
@@ -116,6 +118,15 @@ export default class EditSurveyQuestionPane extends PaneBase {
 
         this.props.dispatch(createSurveyOption(
             surveyId, elementId, data));
+    }
+
+    onOptionsCreate(lines) {
+        const surveyId = this.getParam(0);
+        const elementId = this.getParam(1);
+        const options = lines.map(text => ({ text }));
+
+        this.props.dispatch(createSurveyOptions(
+            surveyId, elementId, options));
     }
 
     onOptionReorder(order) {


### PR DESCRIPTION
This PR adds an interface to create multiple response options for a survey question at once. A new button to "add multiple" is added next to the existing "add response option" one. Clicking it presents a `textarea` where the user can type several options, one per line, before clicking a button to have them all created in one go.

Fixes #922

![image](https://user-images.githubusercontent.com/550212/53695703-288eb600-3dbf-11e9-9248-99a119255a3d.png)
