### PR TITLE
Mobile layout tweaks

### DIFF
--- a/src/components/misc/ViewSwitch.scss
+++ b/src/components/misc/ViewSwitch.scss
@@ -7,6 +7,7 @@
         white-space: nowrap;
         padding-bottom: 0.5em;
         margin-left: -3%;
+        background-color: lighten($c-ui-bg, 1);
     }
 
     button {

--- a/src/components/sections/RootPaneBase.scss
+++ b/src/components/sections/RootPaneBase.scss
@@ -179,6 +179,7 @@
             @include small-screen {
                 max-height: auto;
                 overflow: scroll;
+                margin-top: 0.5em;
             }
         }
 

--- a/src/components/sections/RootPaneBase.scss
+++ b/src/components/sections/RootPaneBase.scss
@@ -80,7 +80,7 @@
         padding: 80px 20px 0;
 
         @include small-screen {
-            padding: 60px 20px 0;
+            padding: 60px 20px 5em;
         }
 
         h2 {

--- a/src/components/sections/people/ManagePeoplePane.jsx
+++ b/src/components/sections/people/ManagePeoplePane.jsx
@@ -126,9 +126,6 @@ export default class ManagePeoplePane extends RootPaneBase {
                 });
 
                 content = [
-                    <div key="list" className="ManagePeoplePane-duplicateList">
-                        { items }
-                    </div>,
                     <div key="instructions"
                         className="ManagePeoplePane-instructions">
                         <Msg tagName="p" id="panes.managePeople.duplicates.instructions.p"
@@ -137,7 +134,10 @@ export default class ManagePeoplePane extends RootPaneBase {
                             labelMsg="panes.managePeople.duplicates.instructions.resetButton"
                             onClick={ () => this.props.dispatch(clearDuplicates()) }
                             />
-                    </div>
+                    </div>,
+                    <div key="list" className="ManagePeoplePane-duplicateList">
+                        { items }
+                    </div>,
                 ];
             }
             else {

--- a/src/components/sections/people/ManagePeoplePane.scss
+++ b/src/components/sections/people/ManagePeoplePane.scss
@@ -28,18 +28,14 @@
 
     .ManagePeoplePane-duplicateList {
         width: 65%;
-        max-width: 60em;
-        min-width: 40em;
         float: left;
     }
 
     .ManagePeoplePane-instructions {
         font-size: 0.9em;
-        float: left;
+        float: right;
         margin: 0 2%;
-        width: 30%;
-        max-width: 30em;
-        min-width: 18em;
+        width: 31%;
     }
 
     .ManagePeoplePane-duplicateItem {
@@ -93,5 +89,29 @@
         @include button-color($c-brand-comp-light);
         float: right;
         margin: 1em 1.5em 0;
+    }
+
+    @include small-screen {
+        .ManagePeoplePane-duplicateList {
+            float: none;
+            width: auto;
+        }
+
+        .ManagePeoplePane-instructions {
+            float: none;
+            width: auto;
+            margin-bottom: 2em;
+
+            p {
+                margin-top: 0;
+            }
+        }
+
+        .ManagePeoplePane-objectList {
+            li {
+                display: block;
+                width: auto;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a few minor layout issues that were found since the mobile layout implementation:

* `ViewSwitch` which is fixed at the bottom should not be transparent. Fixes #971 
* Adapt duplicate search results for mobile screen widths. Fixes #972 
* Fix overlap in filter drawer. Fixes #973 