### PR TITLE
Fix cannot read property title of action.campaign bug

### DIFF
--- a/src/components/panes/ActionPane.jsx
+++ b/src/components/panes/ActionPane.jsx
@@ -215,7 +215,7 @@ export default class ActionPane extends PaneBase {
                         msgId: 'panes.action.summary.noDesc'
                     }, {
                         name: 'campaign',
-                        value: action.campaign.title
+                        value: action.campaign? action.campaign.title : ''
                     }, {
                         name: 'date',
                         value: dateLabel


### PR DESCRIPTION
This PR adds a conditional statement for `action.campaign` in ActionPane InfoList. Like activity and location, if action campaign is undefined the corresponding list item value is set to an empty string.

Fixes #987 