### PR TITLE
Fix SurveySubmissionFilter datepicker bug

### DIFF
--- a/src/components/filters/SurveySubmissionFilter.jsx
+++ b/src/components/filters/SurveySubmissionFilter.jsx
@@ -83,9 +83,11 @@ export default class SurveySubmissionFilter extends FilterBase {
     }
 
     onChangeSimpleField(name, value) {
-        let state = {};
-        state[name] = value;
-        this.setState(state, () => this.onConfigChange());
+        if (value) {
+            let state = {};
+            state[name] = value;
+            this.setState(state, () => this.onConfigChange());
+        }
     }
 
     onSelectTimeframe(name, value) {
@@ -113,7 +115,7 @@ function stateFromConfig(config) {
 
     if (config.after) {
         state.timeframe = 'after';
-        state.after = Date(config.after);
+        state.after = config.after;
     }
 
     return state;


### PR DESCRIPTION
Fixes #934 

Issue was related to Chrome datepicker at times sending an empty string as value. By checking if value exists in `onChangeSimpleField`, setState callback wont trigger an update of component props with `after` set to empty string, thus not resetting `timeframe` to null when mapping state from config.

This PR also sets `state.after` to correctly formatted date string passed in as `config.after` in `stateFromConfig`. Previously, `state.after` was set to Date object resulting in the datepicker not displaying the date value.