### PR TITLE
Most active filter

### DIFF
--- a/locale/filters/en.yaml
+++ b/locale/filters/en.yaml
@@ -5,6 +5,7 @@ types:
     callHistory: Call history
     campaignParticipation: Campaign participation
     joinDate: Join date
+    mostActive: Most active campaigners
     personData: Personal data
     personTags: Tags
     random: Random selection

--- a/locale/filters/mostActive/en.yaml
+++ b/locale/filters/mostActive/en.yaml
@@ -1,1 +1,10 @@
 size: Number of most active people
+timeframe:
+    label: Timeframe
+    options:
+        after: After a certain date
+        any: At any point in time
+        before: Before a certain date
+        between: Between certain dates
+        future: In the future
+        past: Before today

--- a/locale/filters/mostActive/en.yaml
+++ b/locale/filters/mostActive/en.yaml
@@ -1,0 +1,1 @@
+size: Number of most active people

--- a/src/components/filters/FilterList.jsx
+++ b/src/components/filters/FilterList.jsx
@@ -60,6 +60,7 @@ export default class FilterList extends React.Component {
             'all': msg('filters.types.all'),
             'call_history': msg('filters.types.callHistory'),
             'campaign_participation': msg('filters.types.campaignParticipation'),
+            'most_active': msg('filters.types.mostActive'),
             'person_data': msg('filters.types.personData'),
             'person_tags': msg('filters.types.personTags'),
             'random': msg('filters.types.random'),

--- a/src/components/filters/FilterTimeFrameSelect.jsx
+++ b/src/components/filters/FilterTimeFrameSelect.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+
+import SelectInput from '../forms/inputs/SelectInput';
+import DateInput from '../forms/inputs/DateInput';
+
+
+@injectIntl
+export default class FilterTimeFrameSelect extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = stateFromConfig(props.config);
+    }
+
+    render() {
+        let timeframe = this.state.timeframe;
+
+        const msg = id => this.props.intl.formatMessage({ id: this.props.labelMsgStem + '.' + id });
+
+        const DATE_OPTIONS = {
+            'any': msg('options.any'),
+            'future': msg('options.future'),
+            'past': msg('options.past'),
+            'after': msg('options.after'),
+            'before': msg('options.before'),
+            'between': msg('options.between'),
+        };
+
+        let afterInput = null;
+        if (timeframe == 'after' || timeframe == 'between') {
+            afterInput = (
+                <DateInput key="after" name="after"
+                    className="CampaignFilter-after"
+                    value={ this.state.after }
+                    onValueChange={ this.onChangeSimpleField.bind(this) }/>
+            );
+        }
+
+        let beforeInput = null;
+        if (timeframe == 'before' || timeframe == 'between') {
+            beforeInput = (
+                <DateInput key="before" name="before"
+                    className="CampaignFilter-before"
+                    value={ this.state.before }
+                    onValueChange={ this.onChangeSimpleField.bind(this) }/>
+            );
+        }
+
+        return (
+            <div className="FilterTimeFrameSelect">
+                <SelectInput key="timeframe" name="timeframe"
+                    labelMsg={ this.props.labelMsgStem + '.label' }
+                    options={ DATE_OPTIONS } value={ this.state.timeframe }
+                    onValueChange={ this.onSelectTimeframe.bind(this) }/>
+
+                { afterInput }
+                { beforeInput }
+            </div>
+        );
+    }
+
+    onSelectTimeframe(name, value) {
+        let before = undefined;
+        let after = undefined;
+        let today = Date.create();
+        let todayStr = today.format('{yyyy}-{MM}-{dd}');
+
+        switch (value) {
+            case 'future':
+                after = 'now';
+                break;
+            case 'past':
+                before = 'now';
+                break;
+            case 'after':
+                after = todayStr;
+                break;
+            case 'before':
+                before = todayStr;
+                break;
+            case 'between':
+                after = todayStr;
+                before = today.addDays(30).format('{yyyy}-{MM}-{dd}');
+                break;
+        }
+
+        this.setState({ timeframe: value, before, after }, () =>
+            this.dispatchChange());
+    }
+
+    onChangeSimpleField(name, value) {
+        this.setState({ [name]: value }, () =>
+            this.dispatchChange());
+    }
+
+    dispatchChange() {
+        if (this.props.onChange) {
+            this.props.onChange({
+                after: this.state.after,
+                before: this.state.before,
+            });
+        }
+    }
+}
+
+function stateFromConfig(config) {
+    const state = {
+        after: config.after,
+        before: config.before,
+        timeframe: 'any',
+    };
+
+    if (config.before && config.after) {
+        state.timeframe = 'between';
+    }
+    else if (config.before == 'now') {
+        state.timeframe = 'past';
+    }
+    else if (config.before) {
+        state.timeframe = 'before';
+    }
+    else if (config.after == 'now') {
+        state.timeframe = 'future';
+    }
+    else if (config.after) {
+        state.timeframe = 'after';
+    }
+
+    return state;
+}

--- a/src/components/filters/MostActiveFilter.jsx
+++ b/src/components/filters/MostActiveFilter.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import FilterBase from './FilterBase';
+import IntInput from '../forms/inputs/IntInput';
+import SelectInput from '../forms/inputs/SelectInput';
+import Button from '../misc/Button';
+import { injectIntl } from 'react-intl';
+
+@injectIntl
+export default class MostActiveFilter extends FilterBase {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            size: props.config.size || 20,
+        };
+    }
+
+    componentWillReceiveProps({ config }) {
+        if (config.size != this.state.size) {
+            this.setState(config);
+        }
+    }
+
+    renderFilterForm(config) {
+        return [
+            <IntInput key="size" name="size"
+                className="MostActiveFilter-size"
+                labelMsg="filters.mostActive.size"
+                value={ this.state.size }
+                onValueChange={ this.onSizeChange.bind(this) }
+            />
+        ];
+    }
+
+    onSizeChange(name, size) {
+        this.setState({ size }, () => this.onConfigChange());
+    }
+
+    getConfig = () => ({
+        size: parseInt(this.state.size),
+    })
+}

--- a/src/components/filters/MostActiveFilter.jsx
+++ b/src/components/filters/MostActiveFilter.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import FilterBase from './FilterBase';
 import IntInput from '../forms/inputs/IntInput';
-import SelectInput from '../forms/inputs/SelectInput';
+import FilterTimeFrameSelect from './FilterTimeFrameSelect';
 import Button from '../misc/Button';
 import { injectIntl } from 'react-intl';
 
@@ -13,13 +13,13 @@ export default class MostActiveFilter extends FilterBase {
 
         this.state = {
             size: props.config.size || 20,
+            after: props.config.after,
+            before: props.config.before,
         };
     }
 
     componentWillReceiveProps({ config }) {
-        if (config.size != this.state.size) {
-            this.setState(config);
-        }
+        this.setState(config);
     }
 
     renderFilterForm(config) {
@@ -29,8 +29,18 @@ export default class MostActiveFilter extends FilterBase {
                 labelMsg="filters.mostActive.size"
                 value={ this.state.size }
                 onValueChange={ this.onSizeChange.bind(this) }
-            />
+            />,
+
+            <FilterTimeFrameSelect key="timeframe"
+                config={ this.state }
+                labelMsgStem="filters.mostActive.timeframe"
+                onChange={ this.onChangeTimeFrame.bind(this) }
+                />,
         ];
+    }
+
+    onChangeTimeFrame({ before, after }) {
+        this.setState({ before, after }, () => this.onConfigChange());
     }
 
     onSizeChange(name, size) {
@@ -39,5 +49,7 @@ export default class MostActiveFilter extends FilterBase {
 
     getConfig = () => ({
         size: parseInt(this.state.size),
+        after: this.state.after,
+        before: this.state.before,
     })
 }

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -1,6 +1,7 @@
 import AllFilter from './AllFilter';
 import CallHistoryFilter from './CallHistoryFilter';
 import CampaignFilter from './CampaignFilter';
+import MostActiveFilter from './MostActiveFilter';
 import PersonDataFilter from './PersonDataFilter';
 import PersonTagsFilter from './PersonTagsFilter';
 import RandomFilter from './RandomFilter';
@@ -14,6 +15,7 @@ const filterComponents = {
     'all': AllFilter,
     'call_history': CallHistoryFilter,
     'campaign_participation': CampaignFilter,
+    'most_active': MostActiveFilter,
     'person_data': PersonDataFilter,
     'person_tags': PersonTagsFilter,
     'random': RandomFilter,


### PR DESCRIPTION
This PR introduces the new _Most active campaigners_ filter which was recently introduced to the Zetkin Platform, which lets you select in your Smart Search queries the people who have been most active in campaigns during a specific timeframe.

Closes #999 