### PR TITLE
Fix survey submission filter bug

### DIFF
--- a/locale/filters/surveySubmission/en.yaml
+++ b/locale/filters/surveySubmission/en.yaml
@@ -1,4 +1,10 @@
-dateOptions:
-    after: After a certain date
-    any: At any point in time
 survey: Survey
+timeframe:
+    label: Timeframe
+    options:
+        after: After a certain date
+        any: At any point in time
+        before: Before a certain date
+        between: Between certain dates
+        future: In the future
+        past: Before today

--- a/src/components/filters/FilterTimeFrameSelect.jsx
+++ b/src/components/filters/FilterTimeFrameSelect.jsx
@@ -7,6 +7,10 @@ import DateInput from '../forms/inputs/DateInput';
 
 @injectIntl
 export default class FilterTimeFrameSelect extends React.Component {
+    static defaultProps = {
+        future: true,
+    }
+
     constructor(props) {
         super(props);
 
@@ -26,6 +30,10 @@ export default class FilterTimeFrameSelect extends React.Component {
             'before': msg('options.before'),
             'between': msg('options.between'),
         };
+
+        if (!this.props.future) {
+            delete DATE_OPTIONS['future'];
+        }
 
         let afterInput = null;
         if (timeframe == 'after' || timeframe == 'between') {

--- a/src/components/filters/SurveySubmissionFilter.jsx
+++ b/src/components/filters/SurveySubmissionFilter.jsx
@@ -48,6 +48,7 @@ export default class SurveySubmissionFilter extends FilterBase {
 
             <FilterTimeFrameSelect key="timeframe"
                 config={ this.state }
+                future={ false }
                 labelMsgStem="filters.surveySubmission.timeframe"
                 onChange={ this.onSelectTimeframe.bind(this) }
                 />

--- a/src/components/filters/SurveySubmissionFilter.jsx
+++ b/src/components/filters/SurveySubmissionFilter.jsx
@@ -3,9 +3,8 @@ import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
 import FilterBase from './FilterBase';
+import FilterTimeFrameSelect from './FilterTimeFrameSelect';
 import Form from '../forms/Form';
-import DateInput from '../forms/inputs/DateInput';
-import SelectInput from '../forms/inputs/SelectInput';
 import RelSelectInput from '../forms/inputs/RelSelectInput';
 import { retrieveSurveys } from '../../actions/survey';
 
@@ -39,24 +38,6 @@ export default class SurveySubmissionFilter extends FilterBase {
 
     renderFilterForm(config) {
         let surveys = this.props.surveyList.items.map(i => i.data);
-        let timeframe = this.state.timeframe;
-
-        const msg = id => this.props.intl.formatMessage({ id });
-
-        const DATE_OPTIONS = {
-            'any': msg('filters.surveySubmission.dateOptions.any'),
-            'after': msg('filters.surveySubmission.dateOptions.after'),
-        };
-
-        let afterInput = null;
-        if (timeframe == 'after') {
-            afterInput = (
-                <DateInput key="after" name="after"
-                    className="SurveySubmissionFilter-after"
-                    value={ this.state.after }
-                    onValueChange={ this.onChangeSimpleField.bind(this) }/>
-            );
-        }
 
         return [
             <RelSelectInput name="survey" key="surveySelect"
@@ -65,12 +46,11 @@ export default class SurveySubmissionFilter extends FilterBase {
                 onValueChange={ this.onChangeSimpleField.bind(this) }
                 />,
 
-            <SelectInput key="timeframe" name="timeframe"
-                options={ DATE_OPTIONS } value={ this.state.timeframe }
-                onValueChange={ this.onSelectTimeframe.bind(this) }
-                />,
-
-            afterInput,
+            <FilterTimeFrameSelect key="timeframe"
+                config={ this.state }
+                labelMsgStem="filters.surveySubmission.timeframe"
+                onChange={ this.onSelectTimeframe.bind(this) }
+                />
         ];
     }
 
@@ -79,6 +59,7 @@ export default class SurveySubmissionFilter extends FilterBase {
             operator: 'submitted',
             survey: this.state.survey,
             after: this.state.after,
+            before: this.state.before,
         };
     }
 
@@ -90,18 +71,8 @@ export default class SurveySubmissionFilter extends FilterBase {
         }
     }
 
-    onSelectTimeframe(name, value) {
-        let after = undefined;
-
-        if (value == 'after') {
-            let today = Date.create();
-            let todayStr = today.format('{yyyy}-{MM}-{dd}');
-
-            after = todayStr;
-        }
-
-        this.setState({ timeframe: value, after }, () =>
-            this.onConfigChange());
+    onSelectTimeframe({ after, before }) {
+        this.setState({ after, before }, () => this.onConfigChange());
     }
 }
 
@@ -109,14 +80,9 @@ function stateFromConfig(config) {
     let state = {
         operator: 'submitted',
         survey: config.survey,
-        timeframe: null,
-        after: null,
+        after: config.after,
+        before: config.before,
     };
-
-    if (config.after) {
-        state.timeframe = 'after';
-        state.after = config.after;
-    }
 
     return state;
 }


### PR DESCRIPTION
This PR fixes the survey submission filter bug documented as #998, by using the recently introduced `FilterTimeFrameSelect` component instead of a bespoke solution. It also enhances `FilterTimeFrameSelect` to make the `future` option optional, and disables it in the context of survey submissions (which cannot have been submitted in the future).

Fixes #998 