### PR TITLE
Enhancement/reminder content

### DIFF
--- a/locale/panes/actionReminder/en.yaml
+++ b/locale/panes/actionReminder/en.yaml
@@ -4,3 +4,9 @@ saveButton: Send
 title: Action reminders
 toBeReminded:
     h: Participants to be reminded
+content:
+    h: 'Content that will be included:'
+    infoAction: Action info and contact information
+    li: 'Information about: "{ content }", '
+    clickToEdit: Click to edit
+    infoZetkin: Generic information about Zetkin

--- a/src/components/panes/ActionReminderPane.jsx
+++ b/src/components/panes/ActionReminderPane.jsx
@@ -62,7 +62,9 @@ export default class ActionReminderPane extends PaneBase {
                         id="panes.actionReminder.content.infoAction"/>
                     { editableListItems.map(item => {
                         return (
-                            <li key={ item } onClick={ this.onEditReminderContent.bind(this, item, data.actionItem.data[item].id)}>
+                            <li key={ item }
+                                onClick={ this.onEditReminderContent.bind(this, item, data.actionItem.data[item].id)}
+                                className="ActionReminderPane-editableItem">
                                 { this.props.intl.formatMessage({ id: 'panes.actionReminder.content.li' }, {
                                     content: data.actionItem.data[item].title,
                                 }) }

--- a/src/components/panes/ActionReminderPane.jsx
+++ b/src/components/panes/ActionReminderPane.jsx
@@ -26,11 +26,6 @@ export default class ActionReminderPane extends PaneBase {
             { id: 'panes.actionReminder.title' });
     }
 
-    getPaneSubTitle(data) {
-        return (data.actionItem && !data.actionItem.isPending)?
-            <Action action={ data.actionItem.data }/> : null;
-    }
-
     componentDidMount() {
         let actionId = this.getParam(0);
         this.props.dispatch(retrieveActionParticipants(actionId));
@@ -50,6 +45,38 @@ export default class ActionReminderPane extends PaneBase {
     }
 
     renderPaneContent(data) {
+        let reminderContent = null;
+
+        const editableListItems = [
+            'activity',
+            'campaign',
+            'location'
+        ];
+
+        if(data.actionItem && !data.actionItem.isPending) {
+            reminderContent = [
+                <Msg key="h" tagName="p"
+                    id="panes.actionReminder.content.h"/>,
+                <ul key="reminderContent" className="ActionReminderPane-reminderContent">
+                    <Msg key="infoAction" tagName="li"
+                        id="panes.actionReminder.content.infoAction"/>
+                    { editableListItems.map(item => {
+                        return (
+                            <li key={ item } onClick={ this.onEditReminderContent.bind(this, item, data.actionItem.data[item].id)}>
+                                { this.props.intl.formatMessage({ id: 'panes.actionReminder.content.li' }, {
+                                    content: data.actionItem.data[item].title,
+                                }) }
+                                <Msg key="clickToEdit" tagName="span"
+                                    id="panes.actionReminder.content.clickToEdit"/>
+                            </li>
+                        )
+                    })}
+                    <Msg key="infoZetkin" tagName="li"
+                        id="panes.actionReminder.content.infoZetkin"/>
+                </ul>,
+            ];
+        }
+
         var reminderForm = null;
         if (data.newParticipants.length) {
             reminderForm = [
@@ -115,6 +142,7 @@ export default class ActionReminderPane extends PaneBase {
         }
 
         return [
+            reminderContent,
             reminderForm,
             remindedList
         ];
@@ -142,5 +170,9 @@ export default class ActionReminderPane extends PaneBase {
 
     onPersonClick(person) {
         this.openPane('person', person.id);
+    }
+
+    onEditReminderContent(field, id) {
+        this.openPane('edit' + field, id);
     }
 }

--- a/src/components/panes/ActionReminderPane.scss
+++ b/src/components/panes/ActionReminderPane.scss
@@ -5,6 +5,30 @@
         }
     }
 
+    .ActionReminderPane-reminderContent {
+        border-bottom: 1px solid darken($c-ui-bg, 10);
+        color: lighten($c-text, 40);
+        list-style: disc;
+        padding-left: 1em;
+        padding-bottom: 2em;
+
+        li {
+            margin-left: .5em;
+            font-size: 1.4em;
+
+            @include small-screen {
+                font-size: 1.2em;
+            }
+
+            span {
+                font-style: italic;
+            }
+        }
+        .ActionReminderPane-editableItem {
+            cursor: pointer;
+        }
+    }
+
     .ActionReminderPane-newParticipants {
         li {
             float: left;


### PR DESCRIPTION
This PR adds a list to ActionReminderPane showing the content of the reminder. An organizer can edit reminder content related to the action (i.e. activity, location and campaign) by clicking the corresponding list item.

Closes #831