### PR TITLE
Render organizer message in CallListItem

### DIFF
--- a/locale/lists/callList/en.yaml
+++ b/locale/lists/callList/en.yaml
@@ -9,3 +9,5 @@ item:
         allocated: On-going...
         notReached: Not reached
         reached: Reached
+    organizerMsg:
+        noMessage: Caller did not leave a message

--- a/locale/lists/callList/sv.yaml
+++ b/locale/lists/callList/sv.yaml
@@ -9,3 +9,5 @@ item:
         allocated: Pågår...
         notReached: Nåddes inte
         reached: Nåddes
+    organizerMsg:
+        noMessage: Ringaren lämnade inget meddelande

--- a/src/actions/call.js
+++ b/src/actions/call.js
@@ -31,13 +31,13 @@ export function retrieveCalls(page = 0, filters = {}) {
     };
 }
 
-export function retrieveCall(id) {
+export function retrieveCall(id, retrieveMessage = false) {
     return ({ dispatch, getState, z }) => {
         let orgId = getState().org.activeId;
 
         dispatch({
             type: types.RETRIEVE_CALL,
-            meta: { id },
+            meta: { id, retrieveMessage },
             payload: {
                 promise: z.resource('orgs', orgId, 'calls', id).get()
             }

--- a/src/components/lists/items/CallListItem.jsx
+++ b/src/components/lists/items/CallListItem.jsx
@@ -1,15 +1,30 @@
+import { connect } from 'react-redux';
 import React from 'react';
 import cx from 'classnames';
 import { FormattedMessage as Msg } from 'react-intl';
+import { retrieveCall } from '../../../actions/call';
 
 import Avatar from '../../misc/Avatar';
 
-
+@connect()
 export default class CallListItem extends React.Component {
     static propTypes = {
         onItemClick: React.PropTypes.func.isRequired,
         data: React.PropTypes.object,
     };
+
+    componentDidUpdate(prevProps) {
+        const call = this.props.data;
+
+        if (this.props.inView && !prevProps.inView) {
+            if (!call || call.message_to_organizer !== undefined) {
+                return;
+            }
+            else if (call.organizer_action_needed) {
+                this.props.dispatch(retrieveCall(call.id))
+            }
+        }
+    }
 
     render() {
         let call = this.props.data;
@@ -66,6 +81,10 @@ export default class CallListItem extends React.Component {
                         </span>
                         <span className="CallListItem-caller">
                             { call.caller.name }</span>
+                        { call.organizer_action_needed && (
+                            <span className="CallListItem-organizerMsg">
+                                { call.message_to_organizer }</span>
+                        )}
                     </div>
                     <div className="CallListItem-callStatuses"/>
                     <div className="CallListItem-organizerStatuses"/>

--- a/src/components/lists/items/CallListItem.jsx
+++ b/src/components/lists/items/CallListItem.jsx
@@ -56,7 +56,13 @@ export default class CallListItem extends React.Component {
             actionStatus = "needed";
         }
 
-         let actionClassNames  = cx('CallListItem-action', actionStatus );
+        let actionClassNames  = cx('CallListItem-action', actionStatus );
+
+        const messageIsPending = call.organizer_action_needed && call.message_to_organizer === undefined;
+
+        const organizerMsgClassNames = cx('CallListItem-organizerMsg', {
+            loading: messageIsPending,
+        })
 
         return (
             <div className="CallListItem"
@@ -82,7 +88,7 @@ export default class CallListItem extends React.Component {
                         <span className="CallListItem-caller">
                             { call.caller.name }</span>
                         { call.organizer_action_needed && (
-                            <span className="CallListItem-organizerMsg">
+                            <span className={ organizerMsgClassNames }>
                                 { call.message_to_organizer }</span>
                         )}
                     </div>

--- a/src/components/lists/items/CallListItem.jsx
+++ b/src/components/lists/items/CallListItem.jsx
@@ -21,7 +21,7 @@ export default class CallListItem extends React.Component {
                 return;
             }
             else if (call.organizer_action_needed) {
-                this.props.dispatch(retrieveCall(call.id))
+                this.props.dispatch(retrieveCall(call.id, true))
             }
         }
     }

--- a/src/components/lists/items/CallListItem.jsx
+++ b/src/components/lists/items/CallListItem.jsx
@@ -65,6 +65,15 @@ export default class CallListItem extends React.Component {
             empty: call.message_to_organizer === null,
         })
 
+        const truncateMessage = msg => {
+            if (msg && msg.length > 180) {
+                return msg.substr(0, 180) + '...';
+            }
+            else {
+                return msg;
+            }
+        };
+
         return (
             <div className="CallListItem"
                 onClick={ this.props.onItemClick.bind(this, call) }>
@@ -93,7 +102,7 @@ export default class CallListItem extends React.Component {
                                 { call.message_to_organizer === null ?
                                     <Msg tagName="span"
                                         id="lists.callList.item.organizerMsg.noMessage"/> :
-                                    call.message_to_organizer
+                                    truncateMessage(call.message_to_organizer)
                                  }</span>
                         )}
                     </div>

--- a/src/components/lists/items/CallListItem.jsx
+++ b/src/components/lists/items/CallListItem.jsx
@@ -62,6 +62,7 @@ export default class CallListItem extends React.Component {
 
         const organizerMsgClassNames = cx('CallListItem-organizerMsg', {
             loading: messageIsPending,
+            empty: call.message_to_organizer === null,
         })
 
         return (
@@ -89,7 +90,11 @@ export default class CallListItem extends React.Component {
                             { call.caller.name }</span>
                         { call.organizer_action_needed && (
                             <span className={ organizerMsgClassNames }>
-                                { call.message_to_organizer }</span>
+                                { call.message_to_organizer === null ?
+                                    <Msg tagName="span"
+                                        id="lists.callList.item.organizerMsg.noMessage"/> :
+                                    call.message_to_organizer
+                                 }</span>
                         )}
                     </div>
                     <div className="CallListItem-callStatuses"/>

--- a/src/components/lists/items/CallListItem.jsx
+++ b/src/components/lists/items/CallListItem.jsx
@@ -34,6 +34,7 @@ export default class CallListItem extends React.Component {
         let stateClass = "CallListItem-state";
         let stateLabel = null;
         let actionStatus = null;
+        let organizerMessage = null;
 
         switch (call.state) {
             case 0:
@@ -56,23 +57,34 @@ export default class CallListItem extends React.Component {
             actionStatus = "needed";
         }
 
-        let actionClassNames  = cx('CallListItem-action', actionStatus );
+        if (actionStatus) {
+            const messageClassNames = cx('CallListItem-organizerMsg', {
+                loading: call.message_to_organizer === undefined,
+                empty: call.message_to_organizer === null,
+            });
 
-        const messageIsPending = call.organizer_action_needed && call.message_to_organizer === undefined;
+            let messageContent = null;
 
-        const organizerMsgClassNames = cx('CallListItem-organizerMsg', {
-            loading: messageIsPending,
-            empty: call.message_to_organizer === null,
-        })
-
-        const truncateMessage = msg => {
-            if (msg && msg.length > 180) {
-                return msg.substr(0, 180) + '...';
+            if (call.message_to_organizer === null) {
+                messageContent = (
+                    <Msg tagName="span"
+                        id="lists.callList.item.organizerMsg.noMessage"/>
+                );
+            }
+            else if (call.message_to_organizer && call.message_to_organizer.length > 180) {
+                messageContent = call.message_to_organizer.substr(0, 180) + '...';
             }
             else {
-                return msg;
+                messageContent = call.message_to_organizer;
             }
-        };
+
+            organizerMessage = (
+                <span className={ messageClassNames }>
+                    { messageContent }</span>
+            );
+        }
+
+        let actionClassNames  = cx('CallListItem-action', actionStatus );
 
         return (
             <div className="CallListItem"
@@ -97,14 +109,7 @@ export default class CallListItem extends React.Component {
                         </span>
                         <span className="CallListItem-caller">
                             { call.caller.name }</span>
-                        { call.organizer_action_needed && (
-                            <span className={ organizerMsgClassNames }>
-                                { call.message_to_organizer === null ?
-                                    <Msg tagName="span"
-                                        id="lists.callList.item.organizerMsg.noMessage"/> :
-                                    truncateMessage(call.message_to_organizer)
-                                 }</span>
-                        )}
+                        { organizerMessage }
                     </div>
                     <div className="CallListItem-callStatuses"/>
                     <div className="CallListItem-organizerStatuses"/>

--- a/src/components/lists/items/CallListItem.scss
+++ b/src/components/lists/items/CallListItem.scss
@@ -126,6 +126,14 @@
                     content: '.';
                 }
             }
+
+            &.empty {
+                span {
+                    font-size: inherit;
+                    font-style: italic;
+                    color: #666666;
+                }
+            }
         }
     }
 

--- a/src/components/lists/items/CallListItem.scss
+++ b/src/components/lists/items/CallListItem.scss
@@ -17,10 +17,6 @@
     .CallListItem-content {
         @include col(11,12);
         padding: 1em;
-
-        @include medium-screen {
-            @include col(12,12);
-        }
     }
 
     .CallListItem-target {
@@ -105,6 +101,22 @@
 
             &:before {
                 @include icon($fa-var-phone);
+            }
+        }
+
+        .CallListItem-organizerMsg {
+            @include col(12,12, $align:middle, $first:true);
+            display: flex;
+            align-items: baseline;
+
+            @include small-screen {
+                margin-top: 0.5em;
+                padding: 0;
+            }
+
+            &:before {
+                @include icon($fa-var-sticky-note-o);
+                min-width: 1.6em;
             }
         }
     }

--- a/src/components/lists/items/CallListItem.scss
+++ b/src/components/lists/items/CallListItem.scss
@@ -118,6 +118,14 @@
                 @include icon($fa-var-sticky-note-o);
                 min-width: 1.6em;
             }
+
+            &.loading {
+                &::after {
+                    display: inline-block;
+                    animation: CallListItem-organizerMsg-loadingAnimation steps(1, end) 1s infinite;
+                    content: '.';
+                }
+            }
         }
     }
 
@@ -196,4 +204,11 @@
             }
         }
     }
+}
+
+@keyframes CallListItem-organizerMsg-loadingAnimation {
+    0%   { content: '.'; }
+    33%  { content: '..'; }
+    66%  { content: '...'; }
+    99%  { content: '.'; }
 }

--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -39,9 +39,11 @@ export default function calls(state = null, action) {
             });
 
         case types.RETRIEVE_CALL + '_PENDING':
+            const messageIsPending = action.meta.retrieveMessage;
+
             return Object.assign({
                 callList: updateOrAddListItem(state.callList,
-                    action.meta.id, null, { isPending: true }),
+                    action.meta.id, null, { isPending: !messageIsPending }),
             });
 
         case types.RETRIEVE_CALL + '_FULFILLED':


### PR DESCRIPTION
This PR adds functionality for displaying the message to organizer in `CallListItem`.
Since `message_to_organizer` only is included in the data when retrieving a single call, `CallListItem` dispatches an action for retrieving additional data once the item is in view, displaying a loading (dots) animation while the request is pending.
In cases where there is no `message_to_organizer` data, a fallback message is rendered.

Closes #933 