### PR TITLE
Bugfix/External id not set when merging

### DIFF
--- a/locale/panes/mergePeople/en.yaml
+++ b/locale/panes/mergePeople/en.yaml
@@ -18,5 +18,5 @@ override:
     h: Object after merge
     instructions: |
         This field varies across duplicates. Select one of the values to be
-        kept for the reamining person after merging.
+        kept for the remaining person after merging.
 title: 'Merge from set of {count} objects'

--- a/src/components/panes/MergePeoplePane.jsx
+++ b/src/components/panes/MergePeoplePane.jsx
@@ -222,6 +222,7 @@ export default class MergePeoplePane extends PaneBase {
     onOverrideChange(field, ev) {
         this.setState({
             override: {
+                ...this.state.override,
                 [field]: ev.target.value,
             }
         });


### PR DESCRIPTION
This PR fixes override bug where not all fields are set when merging two people. 
Also fixes misspelling on `MergePeoplePane`

Closes #1033
Closes #1035