### PR TITLE
CSV import

### DIFF
--- a/locale/panes/import/en.yaml
+++ b/locale/panes/import/en.yaml
@@ -33,7 +33,7 @@ error:
 parseError:
     h: Invalid file
     p: >-
-        The file you selected could not be loaded. Please convert your file to XLSX format and try again.
+        The file you selected could not be loaded. Please convert your file to CSV or XLSX format and try again.
 importButton: Import
 importDropZoneMessage: 'Drag and drop a file here, or click to select a file to import.'
 importMoreButton: Import more

--- a/locale/panes/import/sv.yaml
+++ b/locale/panes/import/sv.yaml
@@ -33,7 +33,7 @@ error:
 parseError:
     h: Ogiltig fil
     p: >-
-        Filen du valde kan inte laddas. Konvertera din fil till XLSX-format och försök igen.
+        Filen du valde kan inte laddas. Konvertera din fil till CSV- eller XLSX-format och försök igen.
 importButton: Importera
 importDropZoneMessage: 'Dra och släpp en fil här, eller klicka och välj en för att importera.'
 importMoreButton: Importera mer

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "negotiator": "^0.6.1",
     "node-yaml": "^3.0.3",
     "object-subset": "0.0.4",
+    "papaparse": "^5.2.0",
     "raven": "^1.2.1",
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^15.0.1",

--- a/src/actions/importer.js
+++ b/src/actions/importer.js
@@ -1,24 +1,37 @@
 import * as types from '.';
 
-import { parseWorkbook } from '../utils/import';
+import { parseCSV, parseWorkbook } from '../utils/import';
 import { getListItemById } from '../utils/store';
+
+const XLS_SUFFIXES = ['xlsx', 'xls'];
+const CSV_SUFFIXES = ['csv'];
+
+const hasSuffix = (name, suffixes) => {
+    return !!suffixes.find(suffix => name.endsWith(suffix));
+}
 
 
 export function parseImportFile(file) {
     let promise = new Promise((resolve, reject) => {
-        let reader = new FileReader();
+        if (hasSuffix(file.name, XLS_SUFFIXES)) {
+            let reader = new FileReader();
 
-        reader.onload = e => {
-            // TODO: Check type and support CSV as well
-            try {
-                let tableSet = parseWorkbook(e.target.result);
-                resolve({ tableSet });
-            } catch(error) {
-                reject({ error });
-            }
-        };
+            reader.onload = e => {
+                try {
+                    resolve(parseWorkbook(e.target.result));
+                } catch(error) {
+                    reject({ error });
+                }
+            };
 
-        reader.readAsBinaryString(file);
+            reader.readAsBinaryString(file);
+        }
+        else if (hasSuffix(file.name, CSV_SUFFIXES)) {
+            resolve(parseCSV(file));
+        }
+        else {
+            reject({ error: 'Unknown file type' });
+        }
     });
 
     return {


### PR DESCRIPTION
This PR adds support for parsing and importing CSV files.

You can try with any CSV file, including most variations for delimiters, quotes et c. If the format is not recognized by the parser, a proper error is shown.

The CSV parser isn't quite as fancy as the Excel parser, but some of that is because the format itself is not as fancy. For example, the CSV parser will not look for a header (because there is no formatting) and hence will also not guess the contents of each column.

It will also not remove empty columns, which could theoretically be done but is not a prioritized feature and should probably be refactored into some general-purpose solution eventually.

Closes #1054