### PR TITLE
Remove unused websocket code

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "envify": "^3.4.0",
     "eventemitter3": "^0.1.6",
     "express": "^4.12.3",
-    "express-ws": "^0.2.6",
     "express-zetkin-auth": "~1.2.1",
     "fast-memoize": "^2.5.1",
     "flat": "^2.0.1",
@@ -75,7 +74,6 @@
     "validator": "^12.2.0",
     "webpack": "^2.2.1",
     "worker-loader": "^0.8.1",
-    "ws": "^0.7.2",
     "xlsx": "^0.8.0",
     "zetkin": "~1.2.0"
   },

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,7 +4,6 @@ import Raven from 'raven';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import express from 'express';
-import expressWs from 'express-ws';
 import helmet from 'helmet';
 import http from 'http';
 import url from 'url';
@@ -101,8 +100,6 @@ export default function initApp(messages) {
     app.use('/widgets', widgets);
 
     app.use('/prints', prints);
-
-    expressWs(app);
 
     app.get('/activist', function(req, res, next) {
         if (req.store.getState().user.memberships.length) {


### PR DESCRIPTION
This PR removes unused websocket code. It was introduced for websocket-based search, which has been replaced with simple HTTP requests to the Zetkin Platform search API.

Closes #1057 