### PR TITLE
Windows dev environment fixes

### DIFF
--- a/bin/run_dev.cmd
+++ b/bin/run_dev.cmd
@@ -1,16 +1,15 @@
-start docker-volume-watcher -v organize_zetk_in
-
 docker run ^
-    -v %cd%/static:/var/app/static ^
-    -v %cd%/bin:/var/app/bin ^
-    -v %cd%/locale:/var/app/locale ^
-    -v %cd%/src:/var/app/src ^
+    -v "%cd%/static:/var/app/static" ^
+    -v "%cd%/bin:/var/app/bin" ^
+    -v "%cd%/locale:/var/app/locale" ^
+    -v "%cd%/src:/var/app/src" ^
     --name organize_zetk_in ^
     --env TOKEN_SECRET=012345678901234567891234 ^
     --env ZETKIN_LOGIN_URL=http://login.dev.zetkin.org ^
-    --env ZETKIN_APP_ID=c690938258d842cba406a492b9bcfa24 ^
-    --env ZETKIN_APP_KEY=MmEyYjRhOGQtMWFjMS00Y2VhLTgwY2EtNDE1NDA1YmNhMTJj ^
+    --env ZETKIN_APP_ID=2dab3ce079234744aeb4b6cc38abdd00 ^
+    --env ZETKIN_APP_KEY=OGJlNTQyOTktMzBjNy00MzllLWIwNDgtM2RjYTA3MjZlZTIz ^
     --env ZETKIN_DOMAIN=dev.zetkin.org ^
+    --env ZETKIN_USE_TLS=0 ^
     -p 80:80 ^
     -p 81:81 ^
     -t ^

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,23 +105,23 @@ gulp.task('default', [ 'clean' ], function(cb) {
 gulp.task('watch', function() {
     var watch = require('gulp-watch');
 
-    watch('src/**/*.@(js|jsx)', function() {
+    watch('src/**/*.@(js|jsx)', { usePolling: true }, function() {
         return runSequence('js');
     });
 
-    watch('src/**/*.scss', function() {
+    watch('src/**/*.scss', { usePolling: true }, function() {
         return runSequence('buildSass');
     });
 
-    watch('static/images/**/*', function() {
+    watch('static/images/**/*', { usePolling: true }, function() {
         return runSequence('minifyImages');
     });
 
-    watch('static/fonts/**/*', function() {
+    watch('static/fonts/**/*', { usePolling: true }, function() {
         return runSequence('copyFonts');
     });
 
-    watch('locale/**/*', function() {
+    watch('locale/**/*', { usePolling: true }, function() {
         return runSequence('copyMessages');
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,11 @@ const WEBPACK_HOST = process.env.WEBPACK_HOST || 'organize.dev.zetkin.org';
 const WEBPACK_PORT = parseInt(process.env.WEBPACK_PORT) || 81;
 
 const config = {
+    watch: true,
+    watchOptions: {
+        aggregateTimeout: 200,
+        poll: 500,
+    },
     entry: [
         path.join(__dirname, 'src/client/main'),
     ],


### PR DESCRIPTION
This PR contains changes to the development environment to accommodate Windows developers.

* The `run_dev.cmd` script is amended to allow spaces in volume directory names
* Environment variables are given correct values for development
* Polling in `gulp-watch` and `webpack` replace the old `docker-volume-watcher` solution
