### PR TITLE
Fix error when bulk deleting people

### DIFF
--- a/src/server/api/bulk.js
+++ b/src/server/api/bulk.js
@@ -161,7 +161,7 @@ let operations = {
             .get()
             .then(result => {
                 const userPersonId = result.data.data
-                    .find(m => m.organization.id === orgId)
+                    .find(m => m.organization.id == orgId)
                     .profile.id;
 
                 const promises = req.body.objects


### PR DESCRIPTION
Fixes #937 
Fixes #1007

This seems to have been introduced by #984, which prevents users from deleting themselves by checking their memberships and filtering their profile out of the people that are about to be deleted.

The issue is that organization ID is sometimes(?) sent as a string and sometimes as an integer, but was compared using strict equality (`===`). This meant that sometimes no matching membership would be found, causing an exception.

Just switching to `==` means that a membership will always be found. If for some reason it's not, this should fail anyway.