### PR TITLE
Implement 2-step interaction in DeleteButton

### DIFF
--- a/locale/misc/en.yaml
+++ b/locale/misc/en.yaml
@@ -21,6 +21,9 @@ campaignSelect:
     nullLabel: All campaigns
 deleteButton:
     label: Delete
+    confirm: Confirm
+    cancel: Cancel
+    confirmPrompt: Are you sure?
 infoList:
     andMore: ' and { number } more'
 inviteBox:

--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -25,6 +25,9 @@ campaignSelect:
     nullLabel: Alla kampanjer
 deleteButton:
     label: Radera
+    confirm: Bekräfta
+    cancel: Avbryt
+    confirmPrompt: Är du säker?
 infoList:
     andMore: ' och { number } fler'
 inviteBox:

--- a/src/components/misc/DeleteButton.jsx
+++ b/src/components/misc/DeleteButton.jsx
@@ -2,14 +2,44 @@ import React from 'react';
 
 import Button from './Button';
 
+import { FormattedMessage as Msg } from 'react-intl';
 
 export default class DeleteButton extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            clicked: false,
+        };
+    }
+
     render() {
-        return (
-            <Button className="DeleteButton"
-                labelMsg="misc.deleteButton.label"
-                onClick={ this.props.onClick }
-                />
-        );
+        if (!this.state.clicked) {
+            return (
+                <div className="DeleteButton">
+                    <a
+                        className="DeleteButton-delete"
+                        onClick={() => this.setState({clicked: true})}
+                    >
+                        <Msg id="misc.deleteButton.label"/>
+                    </a>
+                </div>
+            );
+        } else {
+            return (
+                <div className="DeleteButton">
+                    <Msg id="misc.deleteButton.confirmPrompt"/>
+                    <Button className="DeleteButton-confirm"
+                        labelMsg="misc.deleteButton.confirm"
+                        onClick={this.props.onClick}
+                    />
+                    <a
+                        className="DeleteButton-cancel"
+                        onClick={() => this.setState({clicked: false})}
+                    >
+                        <Msg id="misc.deleteButton.cancel"/>
+                    </a>
+                </div>
+            );
+        }
     }
 }

--- a/src/components/misc/DeleteButton.scss
+++ b/src/components/misc/DeleteButton.scss
@@ -1,3 +1,18 @@
 .DeleteButton {
+    font-size: 1.25em;
+}
+
+.DeleteButton-confirm {
     @include button($color: $c-brand-delete, $icon: $fa-var-trash);
+    font-size: 1em;
+    padding: 0.05em 1em 0.05em 0.5em;
+    margin-left: 0.8em;
+    margin-right: 0.8em;
+}
+
+.DeleteButton-delete {
+    text-decoration: underline;
+}
+.DeleteButton-cancel {
+    text-decoration: underline;
 }


### PR DESCRIPTION
Implement 2-step interaction when deleting, for example an action, to avoid deleting by error. See screenshot below.

Before clicking
![image](https://user-images.githubusercontent.com/70433427/94343679-0c461000-001a-11eb-82d4-3ea0667b0c11.png)

After clicking (confirm and cancel clickable)
![image](https://user-images.githubusercontent.com/70433427/94343691-21bb3a00-001a-11eb-9aae-e48b13fba726.png)

Fixes #302 
