### PR TITLE
Fix incorrect field name for zip code in PersonDataFilter

### DIFF
--- a/src/components/filters/PersonDataFilter.jsx
+++ b/src/components/filters/PersonDataFilter.jsx
@@ -28,7 +28,7 @@ export default class PersonDataFilter extends FilterBase {
             'phone': 'filters.personData.fields.phone',
             'co_address': 'filters.personData.fields.co_address',
             'street_address': 'filters.personData.fields.street_address',
-            'zip': 'filters.personData.fields.zip',
+            'zip_code': 'filters.personData.fields.zip',
             'city': 'filters.personData.fields.city',
             'country': 'filters.personData.fields.country',
         };


### PR DESCRIPTION
This PR fixes an undocumented issue with the name of the zip code field in `PersonDataFilter`. It was named `zip` but is expected by the Zetkin platform API to be named `zip_code`.

Steps to reproduce (before applying this fix):

1. Create a new Smart Search Query, name it whatever
2. Add a new Person Data filter
3. Set the field to search for to Zip
4. Type in any Zip
5. Save the query

Expected result: API should accept input
Actual result: API rejects input