### PR TITLE
Retrieve field types in PersonPane

### DIFF
--- a/src/components/panes/PersonPane.jsx
+++ b/src/components/panes/PersonPane.jsx
@@ -10,7 +10,10 @@ import TagCloud from '../misc/tagcloud/TagCloud';
 import { getListItemById } from '../../utils/store';
 import { retrievePerson } from '../../actions/person';
 import { createSelection } from '../../actions/selection';
-import { retrieveFieldsForPerson } from '../../actions/personField';
+import {
+    retrieveFieldsForPerson,
+    retrieveFieldTypesForOrganization
+} from '../../actions/personField';
 import {
     addTagsToPerson,
     removeTagFromPerson,
@@ -39,6 +42,7 @@ export default class PersonPane extends PaneBase {
         this.props.dispatch(retrievePerson(personId));
         this.props.dispatch(retrieveTagsForPerson(personId));
         this.props.dispatch(retrieveFieldsForPerson(personId));
+        this.props.dispatch(retrieveFieldTypesForOrganization());
     }
 
     getRenderData() {


### PR DESCRIPTION
Fixes undocumented bug which prevented custom fields from being displayed.

This bug was introduced in #1078, which only retrieves the custom field types in the `PeopleListPane`, but that pane doesn't always precede the `PersonPane`. The bug could be reproduced as such:

1. Refresh Organize on the home page with dummy org 1 (to reset state)
2. Navigate to Campaign section
3. Search for a person
4. Pick any of the search results – `PersonPane` opens over campaign section

Expected results: `PersonPane` should contain info about custom fields
Actual results: `PersonPane` does not contain the custom fields section because it does not find any field types