### PR TITLE
Fix duplicate person_field bug

### DIFF
--- a/src/components/panes/ConfirmImportPane.jsx
+++ b/src/components/panes/ConfirmImportPane.jsx
@@ -33,7 +33,7 @@ export default class ConfirmImportPane extends PaneBase {
         } else if (item.data.type == "person_field") {
             const field = this.props.fieldTypes.items.find((f) => 
                 f.data.id == item.data.config.field_id);
-            return field.data.type;
+            return field.data.type + '.' + item.data.config.field_id;
         } else {
             return "unknown_type";
         }
@@ -174,19 +174,19 @@ export default class ConfirmImportPane extends PaneBase {
                                 this.addError(column, rowidx+1, 'TooLong');
                             }
                             break;
-                        case 'date':
+                        case /^date\./.test(column):
                             if(isNaN(Date.parse(row.values[colidx]))) {
                                 this.addError(column, rowidx+1, 'Invalid')
                             }
                             break;
-                        case 'url':
+                        case /^url\./.test(column):
                             try {
                                 new URL(row.values[colidx])
                             } catch(err) {
                                 this.addError(column, rowidx+1, 'Invalid')
                             }
                             break;
-                        case 'text':
+                        case /^text\./.test(column):
                             // Anything goes
                             break;
                     }


### PR DESCRIPTION
There is a bug where two columns of the same person_field data-type, but with different IDs, triggered a duplicate column error in the client-side validation. This pull request fixes that. The solution, with a regex-match in a switch-statemnt, is not very pretty, but rewriting the whole thing with a dozen if-statements is not very pretty either.