### PR TITLE
Lazy-loading Avatar

### DIFF
--- a/src/components/misc/Avatar.jsx
+++ b/src/components/misc/Avatar.jsx
@@ -50,6 +50,14 @@ export default class Avatar extends React.Component {
         if (this.refs.image.complete) {
             this.onLoad();
         }
+        else {
+            // Ideally we'd like to set loading="lazy" in the JSX inside
+            // render(), but it does not work with our version of react-dom.
+            // Instead we have to do it "at runtime" in the browser using
+            // the regular DOM API.
+            // TODO: After upgrading react-dom to 16+, move to JSX
+            this.refs.image.setAttribute('loading', 'lazy');
+        }
     }
 
     onLoad() {

--- a/src/components/misc/Avatar.scss
+++ b/src/components/misc/Avatar.scss
@@ -1,13 +1,19 @@
 .Avatar {
+    position: relative;
     display: inline-block;
     width: 100%;
-    height: auto;
+    padding-top: 100%;
 
     img {
         width: 100%;
         height: auto;
         opacity: 1;
         transition: opacity 0.5s;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
     }
 
     &.pending {


### PR DESCRIPTION
This PR sets the "new" `loading="lazy"` attribute on the `<img>` element in `Avatar`, as discussed in #1129. Because it can't be done through the declarative React JSX (because our version of `react-dom` is too old) I've done it using the regular DOM API post mount. It seems to work just fine without performance issues.

The PR also sets avatars to always be square, regardless of width, using the `padding-top` CSS trick. This was always a bit of an issue causing avatars to flicker as they loaded, but it became even more obvious when lazy-loaded.

Fixes #1129