### PR TITLE
View tools (export, search, pagination)

### DIFF
--- a/locale/misc/pageSelect/en.yaml
+++ b/locale/misc/pageSelect/en.yaml
@@ -1,0 +1,1 @@
+label: Page {page} of {count}

--- a/locale/misc/personViewTable/en.yaml
+++ b/locale/misc/personViewTable/en.yaml
@@ -1,4 +1,9 @@
 tools:
+    count:
+        default: Showing {visible} rows
+        filtered: Showing {visible} rows ({total} total)
+        filteredPaginated: Showing {visible} of {matches} rows ({total} total)
+        paginated: Showing {visible} of {total} rows
     downloadButton: Download .csv
     search:
         placeholder: Type to filter rows

--- a/locale/misc/personViewTable/en.yaml
+++ b/locale/misc/personViewTable/en.yaml
@@ -4,6 +4,6 @@ tools:
         filtered: Showing {visible} rows ({total} total)
         filteredPaginated: Showing {visible} of {matches} rows ({total} total)
         paginated: Showing {visible} of {total} rows
-    downloadButton: Download .csv
+    downloadButton: Download All
     search:
         placeholder: Type to filter rows

--- a/locale/misc/personViewTable/en.yaml
+++ b/locale/misc/personViewTable/en.yaml
@@ -1,2 +1,4 @@
 tools:
     downloadButton: Download .csv
+    search:
+        placeholder: Type to filter rows

--- a/locale/misc/personViewTable/en.yaml
+++ b/locale/misc/personViewTable/en.yaml
@@ -1,0 +1,2 @@
+tools:
+    downloadButton: Download .csv

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "classnames": "^2.1.3",
     "cookie-cutter": "^0.1.1",
     "cookie-parser": "^1.3.5",
+    "d3-dsv": "^2.0.0",
     "del": "^1.1.1",
     "envify": "^3.4.0",
     "eventemitter3": "^0.1.6",

--- a/src/components/misc/PageSelect.jsx
+++ b/src/components/misc/PageSelect.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+
+
+export default injectIntl(function PageSelect(props) {
+    const items = Array.from(Array(props.pageCount).keys()).map(i => {
+        return (
+            <option key={i} value={i}>
+                { props.intl.formatMessage(
+                    { id: 'misc.pageSelect.label' },
+                    { page: i + 1, count: props.pageCount }) }
+            </option>
+        );
+    });
+
+    return (
+        <select className="PageSelect"
+            onChange={ ev => props.onChange? props.onChange(parseInt(ev.target.value)) : true }
+            value={ props.page }
+            >
+            { items }
+        </select>
+    );
+});

--- a/src/components/misc/PageSelect.scss
+++ b/src/components/misc/PageSelect.scss
@@ -1,0 +1,4 @@
+.PageSelect {
+    @include input-base;
+    margin-bottom: 0;
+}

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import Button from '../Button';
 import LoadingIndicator from '../LoadingIndicator';
+import PageSelect from '../PageSelect';
 import PersonSelectWidget from '../PersonSelectWidget';
 import PersonViewTableHead from './PersonViewTableHead';
 import PersonViewTableRow from './PersonViewTableRow';
@@ -15,6 +16,8 @@ import {
 } from '../../../actions/personView';
 
 
+const MAX_PAGE_SIZE = 500;
+
 @connect()
 @injectIntl
 export default class PersonViewTable extends React.Component {
@@ -22,6 +25,7 @@ export default class PersonViewTable extends React.Component {
         super(props);
 
         this.state = {
+            page: 0,
             searchStr: '',
         };
     }
@@ -48,6 +52,7 @@ export default class PersonViewTable extends React.Component {
         let tableHead;
         let tableBody;
         let loadingIndicator;
+        let pageSelect = null;
 
         if (colList && colList.items) {
             tableHead = (
@@ -78,6 +83,24 @@ export default class PersonViewTable extends React.Component {
                                 }
                             });
                         });
+                    }
+
+                    if (visibleRows.length > MAX_PAGE_SIZE) {
+                        const pageCount = Math.ceil(visibleRows.length / MAX_PAGE_SIZE);
+
+                        pageSelect = (
+                            <div className="PersonViewTable-pages">
+                                <PageSelect
+                                    page={ this.state.page }
+                                    pageCount={ pageCount }
+                                    onChange={ page => this.setState({ page }) }
+                                    />
+                            </div>
+                        );
+
+                        const startIndex = this.state.page * MAX_PAGE_SIZE;
+                        const endIndex = (this.state.page + 1) * MAX_PAGE_SIZE;
+                        visibleRows = visibleRows.slice(startIndex, endIndex);
                     }
 
                     tableBody = (
@@ -132,9 +155,10 @@ export default class PersonViewTable extends React.Component {
                         <input type="text"
                             placeholder={ this.props.intl.formatMessage({ id: 'misc.personViewTable.tools.search.placeholder' }) }
                             value={ this.state.searchStr }
-                            onChange={ ev => this.setState({ searchStr: ev.target.value }) }
+                            onChange={ ev => this.setState({ searchStr: ev.target.value, page: 0 }) }
                             />
                     </div>
+                    { pageSelect }
                 </div>
                 <table>
                     { tableHead }

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -221,9 +221,12 @@ export default class PersonViewTable extends React.Component {
         // Download CSV
         const csvStr = csvFormatRows(rows);
         const blob = new Blob([ csvStr ], { type: 'text/csv' });
+        const now = new Date();
+        const dateStr = now.format('%Y%m%d');
+        const timeStr = now.format('%H%m%S');
         const a = document.createElement('a');
         a.setAttribute('href', URL.createObjectURL(blob));
-        a.setAttribute('download', 'view.csv');
+        a.setAttribute('download', `${dateStr}_${timeStr}.csv`);
         a.style.display = 'none';
 
         document.body.appendChild(a);

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -1,7 +1,9 @@
+import { csvFormatRows } from 'd3-dsv';
 import React from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
 import { connect } from 'react-redux';
 
+import Button from '../Button';
 import LoadingIndicator from '../LoadingIndicator';
 import PersonSelectWidget from '../PersonSelectWidget';
 import PersonViewTableHead from './PersonViewTableHead';
@@ -93,6 +95,13 @@ export default class PersonViewTable extends React.Component {
 
         return (
             <div className="PersonViewTable">
+                <div className="PersonViewTable-tools">
+                    <Button
+                        className="PersonViewTable-downloadButton"
+                        labelMsg="misc.personViewTable.tools.downloadButton"
+                        onClick={ this.onClickDownload.bind(this) }
+                        />
+                </div>
                 <table>
                     { tableHead }
                     { tableBody }
@@ -101,5 +110,36 @@ export default class PersonViewTable extends React.Component {
                 { addSection }
             </div>
         );
+    }
+
+    onClickDownload() {
+        const { columnList, rowList, viewId } = this.props;
+
+        const rows = [];
+
+        if (columnList && columnList.items && rowList && rowList.items) {
+            // Start with the header
+            rows.push(['Zetkin ID'].concat(columnList.items.map(colItem => colItem.data.title)));
+
+            // Find dirty rows and retrieve their data anew
+            rowList.items.forEach(rowItem => {
+                const data = rowItem.data;
+                rows.push([data.id].concat(data.content));
+            });
+        }
+
+        // Download CSV
+        const csvStr = csvFormatRows(rows);
+        const blob = new Blob([ csvStr ], { type: 'text/csv' });
+        const a = document.createElement('a');
+        a.setAttribute('href', URL.createObjectURL(blob));
+        a.setAttribute('download', 'view.csv');
+        a.style.display = 'none';
+
+        document.body.appendChild(a);
+
+        a.click();
+
+        document.body.removeChild(a);
     }
 }

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -53,6 +53,9 @@ export default class PersonViewTable extends React.Component {
         let tableBody;
         let loadingIndicator;
         let pageSelect = null;
+        let numMatches;
+        let numTotal;
+        let numVisible;
 
         if (colList && colList.items) {
             tableHead = (
@@ -70,6 +73,9 @@ export default class PersonViewTable extends React.Component {
                 else if (rowList.items && rowList.items.length) {
                     let visibleRows = rowList.items;
 
+                    // Store total length for label
+                    numTotal = visibleRows.length;
+
                     if (this.state.searchStr && this.state.searchStr.length > 1) {
                         const searchStr = this.state.searchStr.toLowerCase();
 
@@ -84,6 +90,9 @@ export default class PersonViewTable extends React.Component {
                             });
                         });
                     }
+
+                    // Store match count for label
+                    numMatches = visibleRows.length;
 
                     if (visibleRows.length > MAX_PAGE_SIZE) {
                         const pageCount = Math.ceil(visibleRows.length / MAX_PAGE_SIZE);
@@ -102,6 +111,9 @@ export default class PersonViewTable extends React.Component {
                         const endIndex = (this.state.page + 1) * MAX_PAGE_SIZE;
                         visibleRows = visibleRows.slice(startIndex, endIndex);
                     }
+
+                    // Store final count of visible rows for label
+                    numVisible = visibleRows.length;
 
                     tableBody = (
                         <tbody>
@@ -142,6 +154,17 @@ export default class PersonViewTable extends React.Component {
             </div>
         ) : null;
 
+        let countMsgId = 'misc.personViewTable.tools.count.default';
+        if (this.state.searchStr && pageSelect) {
+            countMsgId = 'misc.personViewTable.tools.count.filteredPaginated';
+        }
+        else if (this.state.searchStr) {
+            countMsgId = 'misc.personViewTable.tools.count.filtered';
+        }
+        else if (pageSelect) {
+            countMsgId = 'misc.personViewTable.tools.count.paginated';
+        }
+
         return (
             <div className="PersonViewTable">
                 <div className="PersonViewTable-tools">
@@ -159,6 +182,15 @@ export default class PersonViewTable extends React.Component {
                             />
                     </div>
                     { pageSelect }
+                    <div className="PersonViewTable-count">
+                        { numVisible?
+                        <Msg id={ countMsgId }
+                            values={{
+                                visible: numVisible,
+                                matches: numMatches,
+                                total: numTotal,
+                            }}/> : null }
+                    </div>
                 </div>
                 <table>
                     { tableHead }

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -29,11 +29,36 @@
 }
 
 .PersonViewTable-tools {
+    display: flex;
+    justify-content: flex-start;
+
     margin: 0 0 0.5em;
 
     .PersonViewTable-downloadButton {
+        margin-right: 1em;
+
+        .Button {
+            &:before {
+                @include icon($fa-var-cloud-download);
+            }
+        }
+    }
+
+    .PersonViewTable-searchInput {
+        position: relative;
+        margin-right: 1em;
+
         &:before {
-            @include icon($fa-var-cloud-download);
+            @include icon($fa-var-search);
+            position: absolute;
+            font-size: 1.3em;
+            top: 0.4em;
+            left: 0.4em;
+        }
+
+        input {
+            @include input-base;
+            padding: 0.7em 0.5em 0.7em 2em;
         }
     }
 }

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -28,6 +28,16 @@
     padding-bottom: 10rem;
 }
 
+.PersonViewTable-tools {
+    margin: 0 0 0.5em;
+
+    .PersonViewTable-downloadButton {
+        &:before {
+            @include icon($fa-var-cloud-download);
+        }
+    }
+}
+
 .PersonViewTable-placeholder {
     background-color: darken($c-ui-bg, 4);
     padding: 2rem;

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -36,6 +36,8 @@
 
     .PersonViewTable-downloadButton {
         margin-right: 1em;
+        padding-right: 1em;
+        border-right: 1px solid $c-ui-dark;
 
         .Button {
             &:before {

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -59,7 +59,22 @@
         input {
             @include input-base;
             padding: 0.7em 0.5em 0.7em 2em;
+            margin-bottom: 0;
         }
+    }
+
+    .PersonViewTable-pages {
+        margin-right: 1em;
+    }
+
+    .PersonViewTable-count {
+        span {
+            margin-right: 1em;
+        }
+
+        align-self: center;
+        color: $c-ui-dark;
+        font-style: italic;
     }
 }
 


### PR DESCRIPTION
This PR introduces a new "toolbar" to Views, adding search, pagination and export capabilities.

* As-you-type search for plaintext cells in the view (does not support survey responses at this point)
* Pagination with a 500 row page limit, which is necessary for performance
* Export entire view (all pages) as CSV file

![image](https://user-images.githubusercontent.com/550212/97284281-281f1a80-1841-11eb-8342-a2f31848a648.png)

Closes #1108 
Closes #1116
Closes #1117 