### PR TITLE
Revert to old Avatar dimension logic

### DIFF
--- a/src/components/misc/Avatar.scss
+++ b/src/components/misc/Avatar.scss
@@ -1,19 +1,12 @@
 .Avatar {
-    position: relative;
     display: inline-block;
     width: 100%;
-    padding-top: 100%;
 
     img {
         width: 100%;
         height: auto;
         opacity: 1;
         transition: opacity 0.5s;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
     }
 
     &.pending {

--- a/src/components/misc/personViews/PersonViewTableRow.scss
+++ b/src/components/misc/personViews/PersonViewTableRow.scss
@@ -5,6 +5,7 @@
 
     .Avatar {
         width: 2.2rem;
+        height: 2.2rem;
         cursor: pointer;
     }
 }


### PR DESCRIPTION
This PR reverts Avatar dimension styling introduced by 3a4111a5d6ba506f6cb68c1b00c5c7e96f45213f in #1131. Instead of trying to make it square using the `padding-top: 100%` trick, which was causing issues in multiple places, `Avatar` now relies on it's context to set both width and height.