### PR TITLE
Custom field view columns

### DIFF
--- a/src/components/panes/AddViewColumnPane.jsx
+++ b/src/components/panes/AddViewColumnPane.jsx
@@ -328,17 +328,6 @@ class PersonTagColumnTemplate extends React.Component {
 }))
 class SurveyResponseColumnTemplate extends React.Component {
     componentDidUpdate(prevProps) {
-        // When selected, pick the first tag and propagate config
-        /*
-        if (this.props.selected && !prevProps.selected) {
-            const { tagList } = this.props;
-
-            if (tagList && tagList.items && tagList.items.length) {
-                this.onConfigChange('tag_id', tagList.items[0].data.id);
-            }
-        }
-        */
-
         const surveyId = this.props.config.survey_id;
         if (surveyId != prevProps.config.survey_id) {
             this.props.dispatch(retrieveSurvey(surveyId));

--- a/src/components/panes/AddViewColumnPane.jsx
+++ b/src/components/panes/AddViewColumnPane.jsx
@@ -176,6 +176,7 @@ class PersonFieldColumnTemplate extends React.Component {
                     labelMsg="panes.addViewColumn.config.personField.field"
                     options={ fieldOptions }
                     value={ props.config.field }
+                    orderAlphabetically={ true }
                     onValueChange={ this.onConfigChange.bind(this) }
                     />
             </AssignmentTemplate>


### PR DESCRIPTION
Support custom fields in view columns of type `person_field`.

To test:

1. Navigate to Views
2. Create a view
3. Click "Add Column"
4. From the "Person field" settings, select a custom field

If there are no custom fields, make sure one exists. Either add through the API or reset development data if possible.

![image](https://user-images.githubusercontent.com/550212/97838451-82f0c000-1ce0-11eb-9037-28a0b1342acf.png)
