### PR TITLE
Handle error when adding row to view

### DIFF
--- a/src/store/personViews.js
+++ b/src/store/personViews.js
@@ -239,6 +239,16 @@ export default function personViews(state = null, action) {
             })
         });
     }
+    else if (action.type == types.ADD_PERSON_VIEW_ROW + '_REJECTED') {
+        const viewId = action.meta.viewId;
+        return Object.assign({}, state, {
+            rowsByView: Object.assign({}, state.rowsByView, {
+                [viewId]: Object.assign({}, state.rowsByView[viewId], {
+                    addIsPending: false,
+                }),
+            })
+        });
+    }
     else if (action.type == types.REMOVE_PERSON_VIEW_ROW + '_FULFILLED') {
         const viewId = action.meta.viewId;
         const personId = action.meta.personId;


### PR DESCRIPTION
This PR fixes an undocumented error caused when trying to add the same row twice to a view (or indeed any other operation which causes an error). Previously the `addIsPending` would not be updated, so the spinner in the person select box would not be removed. This PR fixes that.