### PR TITLE
Confirm CSV export

### DIFF
--- a/locale/panes/confirmExport/en.yaml
+++ b/locale/panes/confirmExport/en.yaml
@@ -1,0 +1,4 @@
+confirmButton: Download CSV
+p0: Avoid exporting data from Zetkin when you can, to make sure all data is kept in order.
+p1: Most organizing tasks can be taken care of in Zetkin. Exporting makes sense when you want to copy data to another system.
+title: Create CSV file?

--- a/locale/panes/confirmExport/sv.yaml
+++ b/locale/panes/confirmExport/sv.yaml
@@ -1,0 +1,4 @@
+confirmButton: Ladda hem CSV
+p0: Undvik att exportera data från Zetkin om du inte måste, för att försäkra dig om att ingen data kommer på villovägar.
+p1: Du kan göra det mesta du behöver i Zetkin. Export är en god idé när du vill kopiera data till ett annat system.
+title: Skapa CSV-fil?

--- a/src/actions/personView.js
+++ b/src/actions/personView.js
@@ -67,11 +67,15 @@ export function createPersonViewColumn(viewId, data) {
     };
 }
 
-export function exportPersonView(viewId) {
+export function exportPersonView(viewId, queryId) {
     return ({ getState }) => {
         const personViews = getState().personViews;
         const columnList = personViews.columnsByView[viewId];
-        const rowList = personViews.rowsByView[viewId];
+        let rowList = personViews.rowsByView[viewId];
+
+        if (queryId) {
+            rowList = personViews.matchesByViewAndQuery[viewId][queryId];
+        }
 
         const rows = [];
 

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -1,4 +1,3 @@
-import { csvFormatRows } from 'd3-dsv';
 import React from 'react';
 import { FormattedMessage as Msg, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -203,36 +202,8 @@ export default class PersonViewTable extends React.Component {
     }
 
     onClickDownload() {
-        const { columnList, rowList, viewId } = this.props;
-
-        const rows = [];
-
-        if (columnList && columnList.items && rowList && rowList.items) {
-            // Start with the header
-            rows.push(['Zetkin ID'].concat(columnList.items.map(colItem => colItem.data.title)));
-
-            // Find dirty rows and retrieve their data anew
-            rowList.items.forEach(rowItem => {
-                const data = rowItem.data;
-                rows.push([data.id].concat(data.content));
-            });
+        if (this.props.onDownload) {
+            this.props.onDownload();
         }
-
-        // Download CSV
-        const csvStr = csvFormatRows(rows);
-        const blob = new Blob([ csvStr ], { type: 'text/csv' });
-        const now = new Date();
-        const dateStr = now.format('%Y%m%d');
-        const timeStr = now.format('%H%m%S');
-        const a = document.createElement('a');
-        a.setAttribute('href', URL.createObjectURL(blob));
-        a.setAttribute('download', `${dateStr}_${timeStr}.csv`);
-        a.style.display = 'none';
-
-        document.body.appendChild(a);
-
-        a.click();
-
-        document.body.removeChild(a);
     }
 }

--- a/src/components/panes/ConfirmExportPane.jsx
+++ b/src/components/panes/ConfirmExportPane.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { FormattedMessage as Msg, injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+
+import Button from '../misc/Button';
+import PaneBase from './PaneBase';
+import { exportPersonView } from '../../actions/personView';
+
+
+@connect()
+@injectIntl
+export default class ConfirmExportPane extends PaneBase {
+    getPaneTitle(data) {
+        return this.props.intl.formatMessage({ id: 'panes.confirmExport.title' });
+    }
+
+    renderPaneContent(data) {
+        return [
+            <Msg key="p0" tagName="p" id="panes.confirmExport.p0"/>,
+            <Msg key="p1" tagName="p" id="panes.confirmExport.p1"/>,
+        ];
+    }
+
+    renderPaneFooter(data) {
+        return (
+            <Button className="ConfirmExportPane-confirmButton"
+                labelMsg="panes.confirmExport.confirmButton"
+                onClick={ this.onConfirm.bind(this) }/>
+        );
+    }
+
+    onConfirm(ev) {
+        const viewId = this.getParam(0);
+        const queryId = this.getParam(1);
+        this.props.dispatch(exportPersonView(viewId, queryId));
+        this.closePane();
+    }
+}

--- a/src/components/panes/ConfirmExportPane.scss
+++ b/src/components/panes/ConfirmExportPane.scss
@@ -1,0 +1,13 @@
+.ConfirmExportPane {
+    h2 {
+        &:before {
+            @include icon($fa-var-warning);
+        }
+    }
+
+    .Button {
+        &:before {
+            @include icon($fa-var-cloud-download);
+        }
+    }
+}

--- a/src/components/panes/index.js
+++ b/src/components/panes/index.js
@@ -28,6 +28,7 @@ import CallAssignmentTargetsPane from './CallAssignmentTargetsPane';
 import CampaignPane from './CampaignPane';
 import CanvassAssignmentPane from './CanvassAssignmentPane';
 import ConfirmImportPane from './ConfirmImportPane';
+import ConfirmExportPane from './ConfirmExportPane';
 import LinkSubmissionPane from './LinkSubmissionPane';
 import EditActionPane from './EditActionPane';
 import EditActivityPane from './EditActivityPane';
@@ -134,6 +135,7 @@ var _panes = {
     'joinform': JoinFormPane,
     'joinsubmission': JoinSubmissionPane,
     'confirmimport': ConfirmImportPane,
+    'confirmexport': ConfirmExportPane,
     'location': LocationPane,
     'mergepeople': MergePeoplePane,
     'moveparticipants': MoveParticipantsPane,

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -12,6 +12,7 @@ import { retrieveQueries } from '../../../actions/query';
 import {
     addPersonViewRow,
     createPersonView,
+    exportPersonView,
     retrievePersonView,
     retrievePersonViewColumns,
     retrievePersonViewQuery,
@@ -195,6 +196,7 @@ export default class PersonViewsPane extends RootPaneBase {
                             rowList={ rowList }
                             placeholder={ placeholder }
                             showAddSection={ this.state.viewMode == 'saved' }
+                            onDownload={ this.onClickDownload.bind(this) }
                             onPersonAdd={ person => this.props.dispatch(addPersonViewRow(viewId, person.id)) }
                             />
                     </div>
@@ -232,6 +234,11 @@ export default class PersonViewsPane extends RootPaneBase {
         else if (this.props.views.viewList.isPending) {
             return <LoadingIndicator/>;
         }
+    }
+
+    onClickDownload() {
+        const viewId = this.getParam(0);
+        this.props.dispatch(exportPersonView(viewId));
     }
 
     onClickNew() {

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -12,7 +12,6 @@ import { retrieveQueries } from '../../../actions/query';
 import {
     addPersonViewRow,
     createPersonView,
-    exportPersonView,
     retrievePersonView,
     retrievePersonViewColumns,
     retrievePersonViewQuery,
@@ -238,7 +237,7 @@ export default class PersonViewsPane extends RootPaneBase {
 
     onClickDownload() {
         const viewId = this.getParam(0);
-        this.props.dispatch(exportPersonView(viewId, this.state.query));
+        this.openPane('confirmexport', viewId, this.state.query);
     }
 
     onClickNew() {

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -238,7 +238,7 @@ export default class PersonViewsPane extends RootPaneBase {
 
     onClickDownload() {
         const viewId = this.getParam(0);
-        this.props.dispatch(exportPersonView(viewId));
+        this.props.dispatch(exportPersonView(viewId, this.state.query));
     }
 
     onClickNew() {


### PR DESCRIPTION
This PR adds a new pane which is opened when the user clicks to download a view as CSV. The pane contains a message and a button to execute the download.

In the future, we can add options here to configure whether the download should contain all objects or just the visible ones (after filtering).

![image](https://user-images.githubusercontent.com/550212/98139360-66ad7880-1ec4-11eb-81a9-af9141849b80.png)

Closes #1147 