### PR TITLE
Enhancement/editable text limit

### DIFF
--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -44,6 +44,21 @@ export default class EditableText extends React.Component {
                     editing: false,
                 });
             },
+            onInput: ev => {
+                if (this.props.maxLength && ev.target.innerText.length <= this.props.maxLength) {
+                    this.setState({
+                        input: ev.target.innerText
+                    });
+                }
+                else if (this.props.maxLength && ev.target.innerText.length > this.props.maxLength) {
+                    ev.target.innerText = this.state.input
+                }
+                else {
+                    this.setState({
+                        input: ''
+                    });
+                };
+            },
             dangerouslySetInnerHTML: {
                 __html: this.state.editing? this.props.content : (this.props.content || this.props.placeholder),
             },

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -59,20 +59,17 @@ export default class EditableText extends React.Component {
                     });
                 };
             },
-            onKeyDown: () => {
-                if (this.props.onKeyDown) {
-                    document.addEventListener('keydown', ev => {
-                        if (ev.key === 'Enter') {
-                            ev.preventDefault()
-                        }
-                    });
+            onKeyDown: (ev) => {
+                if (this.props.preventEnter) {
+                    if (ev.key === 'Enter') {
+                        ev.preventDefault()
+                    }
                 }
             },
             dangerouslySetInnerHTML: {
                 __html: this.state.editing? this.props.content : (this.props.content || this.props.placeholder),
             },
         };
-
         return React.createElement(tagName, props);
     }
 }

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -33,8 +33,8 @@ export default class EditableText extends React.Component {
                 if (text != this.props.content) {
                     if (this.props.onChange) {
                         this.props.onChange(text);
-                    };
-                };
+                    }
+                }
 
                 this.setState({
                     editing: false,
@@ -45,13 +45,13 @@ export default class EditableText extends React.Component {
                     const regex = /^[\w\W]$/;
                     if (ev.key.match(regex)) {
                         ev.preventDefault()
-                    };
-                };
+                    }
+                }
                 if (this.props.preventEnter) {
                     if (ev.key === 'Enter') {
                         ev.preventDefault()
-                    };
-                };
+                    }
+                }
             },
             dangerouslySetInnerHTML: {
                 __html: this.state.editing? this.props.content : (this.props.content || this.props.placeholder),

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -44,22 +44,13 @@ export default class EditableText extends React.Component {
                     editing: false,
                 });
             },
-            onInput: ev => {
-                if (this.props.maxLength && ev.target.innerText.length <= this.props.maxLength) {
-                    this.setState({
-                        input: ev.target.innerText.replace('\n', '')
-                    });
-                }
-                else if (this.props.maxLength && ev.target.innerText.length > this.props.maxLength) {
-                    ev.target.innerText = this.state.input
-                }
-                else {
-                    this.setState({
-                        input: ''
-                    });
-                };
-            },
             onKeyDown: (ev) => {
+                if (ev.target.innerText.length > this.props.maxLength) {
+                    const regex = /^[\w\W]$/;
+                    if (ev.key.match(regex)) {
+                        ev.preventDefault()
+                    }
+                }
                 if (this.props.preventEnter) {
                     if (ev.key === 'Enter') {
                         ev.preventDefault()

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -47,7 +47,7 @@ export default class EditableText extends React.Component {
             onInput: ev => {
                 if (this.props.maxLength && ev.target.innerText.length <= this.props.maxLength) {
                     this.setState({
-                        input: ev.target.innerText
+                        input: ev.target.innerText.replace('\n', '')
                     });
                 }
                 else if (this.props.maxLength && ev.target.innerText.length > this.props.maxLength) {

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -59,6 +59,15 @@ export default class EditableText extends React.Component {
                     });
                 };
             },
+            onKeyDown: () => {
+                if (this.props.onKeyDown) {
+                    document.addEventListener('keydown', ev => {
+                        if (ev.key === 'Enter') {
+                            ev.preventDefault()
+                        }
+                    });
+                }
+            },
             dangerouslySetInnerHTML: {
                 __html: this.state.editing? this.props.content : (this.props.content || this.props.placeholder),
             },

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -26,10 +26,6 @@ export default class EditableText extends React.Component {
                     editing: true,
                 };
 
-                if (text != this.props.content && text == this.props.placeholder) {
-                    state.text = '';
-                }
-
                 this.setState(state);
             },
             onBlur: ev => {

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -33,8 +33,8 @@ export default class EditableText extends React.Component {
                 if (text != this.props.content) {
                     if (this.props.onChange) {
                         this.props.onChange(text);
-                    }
-                }
+                    };
+                };
 
                 this.setState({
                     editing: false,
@@ -45,13 +45,13 @@ export default class EditableText extends React.Component {
                     const regex = /^[\w\W]$/;
                     if (ev.key.match(regex)) {
                         ev.preventDefault()
-                    }
-                }
+                    };
+                };
                 if (this.props.preventEnter) {
                     if (ev.key === 'Enter') {
                         ev.preventDefault()
-                    }
-                }
+                    };
+                };
             },
             dangerouslySetInnerHTML: {
                 __html: this.state.editing? this.props.content : (this.props.content || this.props.placeholder),

--- a/src/components/misc/EditableText.jsx
+++ b/src/components/misc/EditableText.jsx
@@ -33,7 +33,7 @@ export default class EditableText extends React.Component {
                 this.setState(state);
             },
             onBlur: ev => {
-                const text = ev.target.innerText;
+                const text = ev.target.innerText.replace('\n', '');
                 if (text != this.props.content) {
                     if (this.props.onChange) {
                         this.props.onChange(text);

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -174,7 +174,7 @@ export default class PersonViewsPane extends RootPaneBase {
                             content={ viewItem.data.title }
                             onChange={ this.onChange.bind(this, 'title') }
                             placeholder={ this.props.intl.formatMessage({ id: 'panes.personViews.placeholders.title' }) }
-                            onKeyDown={ true }
+                            preventEnter={ true }
                             maxLength={ 80 }
                             />
                         <EditableText tagName="p" key="description"

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -174,6 +174,7 @@ export default class PersonViewsPane extends RootPaneBase {
                             content={ viewItem.data.title }
                             onChange={ this.onChange.bind(this, 'title') }
                             placeholder={ this.props.intl.formatMessage({ id: 'panes.personViews.placeholders.title' }) }
+                            maxLength={ 80 }
                             />
                         <EditableText tagName="p" key="description"
                             content={ viewItem.data.description }

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -174,6 +174,7 @@ export default class PersonViewsPane extends RootPaneBase {
                             content={ viewItem.data.title }
                             onChange={ this.onChange.bind(this, 'title') }
                             placeholder={ this.props.intl.formatMessage({ id: 'panes.personViews.placeholders.title' }) }
+                            onKeyDown={ true }
                             maxLength={ 80 }
                             />
                         <EditableText tagName="p" key="description"


### PR DESCRIPTION
Resolves #1158. Adds limitation to EditableText via maxLength prop as well as limits possibility to make newlines via onKeyDown prop.

There is an issue with contenteditable adding a newline at the end of an entered text. This makes it possible to make one newline upon making changes to the previously added text. This is related to the fact that contenteditable accepts formatting onpaste (which is cleared onBlur).