### PR TITLE
BUGFIX: Truncate view column title to a max of 80 characters

### DIFF
--- a/src/actions/personView.js
+++ b/src/actions/personView.js
@@ -57,6 +57,10 @@ export function createPersonViewColumn(viewId, data) {
     return ({ dispatch, getState, z }) => {
         const orgId = getState().org.activeId;
 
+        if(data.title.length > 80) {
+          data.title = data.title.substring(0,77) + '...';
+        }
+
         dispatch({
             type: types.CREATE_PERSON_VIEW_COLUMN,
             meta: { viewId },

--- a/src/actions/personView.js
+++ b/src/actions/personView.js
@@ -58,7 +58,7 @@ export function createPersonViewColumn(viewId, data) {
         const orgId = getState().org.activeId;
 
         if(data.title.length > 80) {
-          data.title = data.title.substring(0,77) + '...';
+            data.title = data.title.substring(0,77) + '...';
         }
 
         dispatch({


### PR DESCRIPTION
Creating a person view column from a survey question results in the column title having the same title as the survey question. But the max length of a survey question is over 200 characters whereas the max length of a column title is 80 characters.

This fix truncates column titles in the createPersonViewColumn action before it is sent to the server.