### PR TITLE
Custom field overrides during merge

### DIFF
--- a/src/components/panes/MergePeoplePane.jsx
+++ b/src/components/panes/MergePeoplePane.jsx
@@ -39,7 +39,7 @@ const NATIVE_FIELDS = [
     'phone',
     'co_address',
     'street_address',
-    'zip',
+    'zip_code',
     'city',
     'country',
 ];


### PR DESCRIPTION
This PR adds capabilities to select which custom field values to keep after a person merge. To test it, create some duplicates with conflicting custom field values, and try merging. While merging, try selecting different values. Also try merging when there are no custom fields on a person, or when only one of the duplicates has values assigned.

Closes #1162 