### PR TITLE
View scrolling improvements

### DIFF
--- a/src/components/misc/personViews/PersonViewAddRow.jsx
+++ b/src/components/misc/personViews/PersonViewAddRow.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import RelSelectInput from '../../forms/inputs/RelSelectInput';
+import PersonSelectWidget from '../PersonSelectWidget';
+
+
+export default connect()(function PersonViewTableRow(props) {
+    return (
+        <tr className="PersonViewAddRow">
+            <td/>
+            <td/>
+            <td colSpan={ 2 }>
+                <PersonSelectWidget
+                    isPending={ props.rowList && props.rowList.addIsPending }
+                    onSelect={ props.onSelect }
+                    />
+            </td>
+            <td colSpan={ props.columnList.items.length - 2 }/>
+            <td className="PersonViewTableRow-placeholder"/>
+        </tr>
+    );
+});

--- a/src/components/misc/personViews/PersonViewAddRow.scss
+++ b/src/components/misc/personViews/PersonViewAddRow.scss
@@ -1,0 +1,14 @@
+.PersonViewAddRow {
+    .PersonSelectWidget {
+        margin-left: -10px;
+
+        input {
+        }
+
+        ul {
+            top: auto;
+            bottom: 50px;
+            font-size: 1em;
+        }
+    }
+}

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -1,4 +1,3 @@
-import cx from 'classnames';
 import React from 'react';
 import { FormattedMessage as Msg, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -7,6 +6,7 @@ import Button from '../Button';
 import LoadingIndicator from '../LoadingIndicator';
 import PageSelect from '../PageSelect';
 import PersonSelectWidget from '../PersonSelectWidget';
+import PersonViewAddRow from './PersonViewAddRow';
 import PersonViewTableHead from './PersonViewTableHead';
 import PersonViewTableRow from './PersonViewTableRow';
 import {
@@ -135,6 +135,10 @@ export default class PersonViewTable extends React.Component {
                                 onRemove={ row => this.props.dispatch(removePersonViewRow(viewId, row.id)) }
                                 />
                         ))}
+                            <PersonViewAddRow
+                                columnList={ colList }
+                                rowList={ this.props.rowList }
+                                onSelect={ this.props.onPersonAdd }/>
                         </tbody>
                     );
                 }
@@ -155,14 +159,6 @@ export default class PersonViewTable extends React.Component {
             );
         }
 
-        const addSection = this.props.showAddSection? (
-            <div className="PersonViewTable-addPerson">
-                <PersonSelectWidget
-                    isPending={ this.props.rowList && this.props.rowList.addIsPending }
-                    onSelect={ this.props.onPersonAdd }/>
-            </div>
-        ) : null;
-
         let countMsgId = 'misc.personViewTable.tools.count.default';
         if (this.state.searchStr && pageSelect) {
             countMsgId = 'misc.personViewTable.tools.count.filteredPaginated';
@@ -174,12 +170,8 @@ export default class PersonViewTable extends React.Component {
             countMsgId = 'misc.personViewTable.tools.count.paginated';
         }
 
-        const classes = cx('PersonViewTable', {
-            withAdd: !!addSection,
-        });
-
         return (
-            <div className={ classes }>
+            <div className="PersonViewTable">
                 <div className="PersonViewTable-tools">
                     <div className="PersonViewTable-downloadButton">
                         <Button
@@ -212,7 +204,6 @@ export default class PersonViewTable extends React.Component {
                     </table>
                 </div>
                 { placeholder }
-                { addSection }
             </div>
         );
     }

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import React from 'react';
 import { FormattedMessage as Msg, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -26,6 +27,14 @@ export default class PersonViewTable extends React.Component {
         this.state = {
             page: 0,
             searchStr: '',
+            scrollLeft: 0,
+        };
+
+        // Creating this here to avoid having to bind
+        this.onScroll = ev => {
+            this.setState({
+                scrollLeft: ev.target.scrollLeft,
+            });
         };
     }
 
@@ -62,6 +71,7 @@ export default class PersonViewTable extends React.Component {
                     viewId={ viewId }
                     columnList={ colList }
                     openPane={ this.props.openPane }
+                    scrollLeft={ this.state.scrollLeft }
                     />
             );
 
@@ -115,7 +125,7 @@ export default class PersonViewTable extends React.Component {
                     numVisible = visibleRows.length;
 
                     tableBody = (
-                        <tbody>
+                        <tbody onScroll={ this.onScroll }>
                         {visibleRows.map(rowItem => (
                             <PersonViewTableRow key={ rowItem.data.id }
                                 columnList={ colList }
@@ -164,8 +174,12 @@ export default class PersonViewTable extends React.Component {
             countMsgId = 'misc.personViewTable.tools.count.paginated';
         }
 
+        const classes = cx('PersonViewTable', {
+            withAdd: !!addSection,
+        });
+
         return (
-            <div className="PersonViewTable">
+            <div className={ classes }>
                 <div className="PersonViewTable-tools">
                     <div className="PersonViewTable-downloadButton">
                         <Button
@@ -191,10 +205,12 @@ export default class PersonViewTable extends React.Component {
                             }}/> : null }
                     </div>
                 </div>
-                <table>
-                    { tableHead }
-                    { tableBody }
-                </table>
+                <div className="PersonViewTable-table">
+                    <table>
+                        { tableHead }
+                        { tableBody }
+                    </table>
+                </div>
                 { placeholder }
                 { addSection }
             </div>

--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -38,6 +38,14 @@ export default class PersonViewTable extends React.Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (!nextProps.rowList || !nextProps.rowList.items.length) {
+            this.setState({
+                scrollLeft: 0,
+            });
+        }
+    }
+
     componentDidUpdate() {
         const { columnList, rowList, viewId } = this.props;
 

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -1,13 +1,8 @@
 .PersonViewTable {
-    table {
-        display: block;
-        overflow-x: scroll;
-    }
-
     .person_query,
     .person_tag {
-        max-width: 6em;
-        min-width: 6em;
+        max-width: 6rem;
+        min-width: 6rem;
         text-align: center;
     }
 
@@ -80,12 +75,49 @@
     }
 }
 
+.PersonViewTable-table {
+    @include large-screen {
+        position: absolute;
+        top: 2.5rem;
+        right: 0;
+        left: 0;
+        bottom: 0;
+
+        tbody {
+            position: absolute;
+            top: 2.5em;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            overflow: scroll;
+        }
+    }
+}
+
+.PersonViewTable.withAdd {
+    @include large-screen {
+        .PersonViewTable-table {
+            bottom: 100px;
+        }
+    }
+}
+
+.PersonViewTable-addPerson {
+    @include large-screen {
+        position: absolute;
+        bottom: 0;
+        left: 1em;
+        right: 1em;
+    }
+}
+
 .PersonViewTable-placeholder {
     background-color: darken($c-ui-bg, 4);
     padding: 2rem;
     text-align: center;
 
     @include large-screen {
+        margin-top: 3rem;
         padding: 4rem 25%;
     }
 

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -85,7 +85,7 @@
 
         tbody {
             position: absolute;
-            top: 2.5em;
+            top: 2rem;
             bottom: 0;
             left: 0;
             right: 0;

--- a/src/components/misc/personViews/PersonViewTable.scss
+++ b/src/components/misc/personViews/PersonViewTable.scss
@@ -92,13 +92,9 @@
             overflow: scroll;
         }
     }
-}
 
-.PersonViewTable.withAdd {
-    @include large-screen {
-        .PersonViewTable-table {
-            bottom: 100px;
-        }
+    table {
+        font-size: inherit;
     }
 }
 

--- a/src/components/misc/personViews/PersonViewTableHead.jsx
+++ b/src/components/misc/personViews/PersonViewTableHead.jsx
@@ -16,7 +16,7 @@ export default function PersonViewTableHead(props) {
     });
 
     return (
-        <thead className="PersonViewTableHead">
+        <thead className="PersonViewTableHead" style={{ left: -1 * props.scrollLeft }}>
             <tr>
                 <th className="PersonViewTableHead-avatarColumn"></th>
                 <th className="PersonViewTableHead-savedColumn"></th>

--- a/src/components/misc/personViews/PersonViewTableHead.scss
+++ b/src/components/misc/personViews/PersonViewTableHead.scss
@@ -1,4 +1,9 @@
 .PersonViewTableHead {
+    @include large-screen {
+        position: absolute;
+        left: 0;
+    }
+
     th {
         padding: 0.5em;
 
@@ -33,11 +38,11 @@
     }
 
     .PersonViewTableHead-newColumn {
-        min-width: 14em;
-        max-width: 14em;
+        min-width: 12rem;
+        max-width: 12rem;
         text-align: center;
-        padding-left: 1em;
-        padding-right: 1em;
+        padding-left: 1rem;
+        padding-right: 1rem;
         border: 2px dashed rgba(0,0,0, 0.2);
         color: $c-ui-dark;
 

--- a/src/components/misc/personViews/PersonViewTableHead.scss
+++ b/src/components/misc/personViews/PersonViewTableHead.scss
@@ -7,7 +7,6 @@
     th {
         padding: 0.5em;
 
-        font-size: 0.8em;
         font-weight: normal;
         text-align: left;
 
@@ -69,14 +68,15 @@
     }
 }
 
-.PersonViewTableHead-avatarColumn,
-.PersonViewTableHead-savedColumn {
+th.PersonViewTableHead-avatarColumn,
+th.PersonViewTableHead-savedColumn {
     $w: 2.2rem;
 
     width: $w;
     min-width: $w;
     max-width: $w;
     background-color: white;
+    text-align: center;
 }
 
 .PersonViewTableHead-savedColumn {

--- a/src/components/misc/personViews/PersonViewTableRow.jsx
+++ b/src/components/misc/personViews/PersonViewTableRow.jsx
@@ -76,6 +76,7 @@ export default connect()(function PersonViewTableRow(props) {
                 onClick={ () => rowData.saved? props.onRemove(rowData) : props.onAdd(rowData) }
                 />
             { cells }
+            <td className="PersonViewTableRow-placeholder"/>
         </tr>
     );
 });

--- a/src/components/misc/personViews/PersonViewTableRow.scss
+++ b/src/components/misc/personViews/PersonViewTableRow.scss
@@ -35,7 +35,17 @@
 
 .PersonViewTableRow {
     td {
+        $border-color: darken($c-ui-bg, 5);
         font-size: 1.2em;
+        padding: 0.2em 0.4em;
+        border-bottom: 1px solid $border-color;
+        border-right: 1px solid $border-color;
+    }
+
+    .PersonViewTableRow-avatar,
+    .PersonViewTableRow-saved {
+        padding: 0;
+        border-right: 1px solid transparent;
     }
 
     &.saved {

--- a/src/components/misc/personViews/PersonViewTableRow.scss
+++ b/src/components/misc/personViews/PersonViewTableRow.scss
@@ -25,6 +25,14 @@
     }
 }
 
+.PersonViewTableRow-placeholder {
+    min-width: 12rem;
+    max-width: 12rem;
+    text-align: center;
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
 .PersonViewTableRow {
     &.saved {
         .PersonViewTableRow-saved {

--- a/src/components/misc/personViews/PersonViewTableRow.scss
+++ b/src/components/misc/personViews/PersonViewTableRow.scss
@@ -34,8 +34,16 @@
 }
 
 .PersonViewTableRow {
+    td {
+        font-size: 1.2em;
+    }
+
     &.saved {
         .PersonViewTableRow-saved {
+            width: 2.2rem;
+            min-width: 2.2rem;
+            max-width: 2.2rem;
+
             &:before {
                 @include icon($fa-var-star);
                 color: $c-brand-comp-dark;

--- a/src/components/misc/personViews/cells/SurveyResponseCell.scss
+++ b/src/components/misc/personViews/cells/SurveyResponseCell.scss
@@ -1,7 +1,6 @@
 .SurveyResponseCell-response {
     cursor: pointer;
     margin: 0 0 0.5em;
-    font-size: 0.9em;
     font-style: italic;
 
     &:hover {

--- a/src/components/sections/people/PersonViewsPane.scss
+++ b/src/components/sections/people/PersonViewsPane.scss
@@ -1,3 +1,10 @@
+.PersonViewsPane {
+    .RootPaneBase-content {
+        overflow: auto;
+        padding-top: 4rem;
+    }
+}
+
 .PersonViewsPane-viewList {
     display: flex;
     flex-wrap: wrap;
@@ -141,5 +148,13 @@
 }
 
 .PersonViewsPane-singleViewTable {
-    clear: both;
+    @include large-screen {
+        .PersonViewTable {
+            position: fixed;
+            top: 280px;
+            left: 110px;
+            right: 0;
+            bottom: 0;
+        }
+    }
 }


### PR DESCRIPTION
This PR makes a number of improvements to the experience when working with large views that require scrolling.

* Fixate view table to browser viewport, so that horizontal and vertical scrollbars are visible. Fixes #1174 
* Keep table header sticky at top. Fixes half of #1118 (sticky avatars proved very complex and must be postponed)
* Add cell outlines Fixes #1155 

See screenshots below for examples of what this looks like in default state, when scrolled a little bit in both directions, and the new location of the "Add" widget at the bottom.

![image](https://user-images.githubusercontent.com/550212/101057346-3bce4700-358c-11eb-9155-71b1c56e3605.png)
![image](https://user-images.githubusercontent.com/550212/101057404-4983cc80-358c-11eb-8478-f658d8fc1692.png)
![image](https://user-images.githubusercontent.com/550212/101057465-59031580-358c-11eb-8bbc-011dffaf454d.png)
