### PR TITLE
Implement view column sorting

### DIFF
--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -26,6 +26,8 @@ export default class PersonViewTable extends React.Component {
         this.state = {
             page: 0,
             searchStr: '',
+            sortIndex: null,
+            sortInverted: false,
         };
     }
 
@@ -62,6 +64,9 @@ export default class PersonViewTable extends React.Component {
                     viewId={ viewId }
                     columnList={ colList }
                     openPane={ this.props.openPane }
+                    sortIndex={ this.state.sortIndex }
+                    sortInverted={ this.state.sortInverted }
+                    onSort={ this.onSort.bind(this) }
                     />
             );
 
@@ -113,6 +118,22 @@ export default class PersonViewTable extends React.Component {
 
                     // Store final count of visible rows for label
                     numVisible = visibleRows.length;
+
+                    // Sort, if a column is selected for sorting
+                    if (this.state.sortIndex !== null) {
+                        visibleRows = visibleRows.concat().sort((row0, row1) => {
+                            const val0 = row0.data.content[this.state.sortIndex] || '';
+                            const val1 = row1.data.content[this.state.sortIndex] || '';
+
+                            let x = val0.toString().localeCompare(val1.toString());
+
+                            if (this.state.sortInverted) {
+                                x *= -1;
+                            }
+
+                            return x;
+                        });
+                    }
 
                     tableBody = (
                         <tbody>
@@ -199,6 +220,32 @@ export default class PersonViewTable extends React.Component {
                 { addSection }
             </div>
         );
+    }
+
+    onSort(idx) {
+        // Already sorting?
+        if (this.state.sortIndex == idx) {
+            if (this.state.sortInverted) {
+                // Already inverted. Reset sort!
+                this.setState({
+                    sortIndex: null,
+                    sortInverted: false,
+                });
+            }
+            else {
+                // Not inverted. Invert!
+                this.setState({
+                    sortInverted: true,
+                });
+            }
+        }
+        else {
+            // Not already sorting. Sort default (not inverted).
+            this.setState({
+                sortIndex: idx,
+                sortInverted: false,
+            });
+        }
     }
 
     onClickDownload() {

--- a/src/components/misc/personViews/PersonViewTableHead.jsx
+++ b/src/components/misc/personViews/PersonViewTableHead.jsx
@@ -5,12 +5,27 @@ import { FormattedMessage as Msg } from 'react-intl';
 
 export default function PersonViewTableHead(props) {
     const cols = props.columnList.items.map((colItem, index) => {
-        const classes = cx('PersonViewTableHead-column', colItem.data.type);
+        const classes = cx('PersonViewTableHead-column', colItem.data.type, {
+            sorted: props.sortIndex == index,
+            inverted: props.sortInverted,
+        });
+
+        const onClickSort = ev => {
+            ev.preventDefault();
+            ev.stopPropagation();
+
+            if (props.onSort) {
+                props.onSort(index);
+            }
+        };
 
         return (
             <th key={ colItem.data.id } className={ classes }
                 onClick={ () => props.openPane('editviewcolumn', props.viewId, colItem.data.id) }>
                 { colItem.data.title }
+                <a className="PersonViewTableHead-columnSort"
+                    onClick={ onClickSort }
+                    />
             </th>
         );
     });

--- a/src/components/misc/personViews/PersonViewTableHead.scss
+++ b/src/components/misc/personViews/PersonViewTableHead.scss
@@ -11,10 +11,11 @@
         text-overflow: ellipsis;
 
         cursor: pointer;
-
     }
 
     .PersonViewTableHead-column {
+        position: relative;
+
         &:before {
             content: "";
             display: inline-block;
@@ -28,6 +29,52 @@
             &:before {
                 @include icon($fa-var-pencil);
                 opacity: 1;
+            }
+
+            .PersonViewTableHead-columnSort {
+                opacity: 1.0;
+            }
+        }
+
+        .PersonViewTableHead-columnSort {
+            opacity: 0;
+            display: block;
+            position: absolute;
+            right: 0.2rem;
+            top: 0.2rem;
+            bottom: 0.2rem;
+            padding-top: 0.2rem;
+            padding-left: 0.1rem;
+            background-color: rgba(white, 0.9);
+
+            transition: opacity 0.4s;
+
+            &:before {
+                opacity: 0.5;
+                @include icon($fa-var-sort);
+            }
+
+            &:hover {
+                &:before {
+                    opacity: 1.0;
+                }
+            }
+        }
+
+        &.sorted {
+            .PersonViewTableHead-columnSort {
+                opacity: 1.0;
+
+                &:before {
+                    opacity: 1.0;
+                    @include icon($fa-var-sort-asc);
+                }
+            }
+
+            &.inverted {
+                .PersonViewTableHead-columnSort:before {
+                    @include icon($fa-var-sort-desc);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1114 

Hover a column to show sorting button. Click to sort. Click again to invert sort. Click again to reset to default order.

![image](https://user-images.githubusercontent.com/550212/101085742-2b2fc800-35b0-11eb-9c71-92b42bffc39f.png)
