### PR TITLE
Handle survey_response cells when searching in view

### DIFF
--- a/src/components/misc/personViews/PersonViewTable.jsx
+++ b/src/components/misc/personViews/PersonViewTable.jsx
@@ -79,9 +79,20 @@ export default class PersonViewTable extends React.Component {
                         const searchStr = this.state.searchStr.toLowerCase();
 
                         visibleRows = visibleRows.filter(item => {
-                            return item.data.content.some(cell => {
-                                if (cell && cell.toLowerCase) {
-                                    return cell.toLowerCase().indexOf(searchStr) >= 0;
+                            return item.data.content.some((cell, idx) => {
+                                const col = colList.items[idx].data;
+
+                                let text = null;
+
+                                if (cell && col.type == 'survey_response') {
+                                    text = cell.map(r => r.text).join('\n');
+                                }
+                                else if (typeof cell == 'string') {
+                                    text = cell;
+                                }
+
+                                if (text) {
+                                    return text.toLowerCase().indexOf(searchStr) >= 0;
                                 }
                                 else {
                                     return false;


### PR DESCRIPTION
This PR handles cells in `survey_response` columns properly when searching in a view. These cells include an array of objects, each object representing a response to the given survey question. The logic merges the array into a single string and searches it the same way that regular search in text-based cells work.

Fixes #1142 