### PR TITLE
Pin gulp-sass to the newest-working version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-newer": "^1.1.0",
     "gulp-react": "^2.0.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "^3.0.0",
     "gulp-shell": "^0.4.0",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.1.0",


### PR DESCRIPTION
This PR is a repair PR for the installation of this app. Paired with @oelrich to build this!

We picked a new version specifier for `gulp-sass` to fix the issue.

## Details

Any newer version currently fails to build. The newer versions that 3.0.0 all also fail. We attempted them all and found ^3.0.0 to pick a working version.

The underlying issue was that the ^2.2.0 version specifier tried to download a node-sass which had been removed from that project's GitHub Releases download section. This failed installs in the Docker build.

Error message before this change:

```
> node-sass@3.13.1 install /var/app/node_modules/node-sass
> node scripts/install.js
Downloading binary from https://github.com/sass/node-sass/releases/download/v3.13.1/linux-x64-64_binding.node
Cannot download "https://github.com/sass/node-sass/releases/download/v3.13.1/linux-x64-64_binding.node":
HTTP error 404 Not Found
Hint: If github.com is not accessible in your location
      try setting a proxy via HTTP_PROXY, e.g.
      export HTTP_PROXY=http://example.com:1234
or configure npm proxy via
      npm config set proxy http://example.com:8080
```

