### PR TITLE
Fix: PersonViewsPane: Download users in active view

### DIFF
--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -245,7 +245,9 @@ export default class PersonViewsPane extends RootPaneBase {
 
     onClickDownload() {
         const viewId = this.getParam(0);
-        this.openPane('confirmexport', viewId, this.state.query);
+        const queryId = (this.state.viewMode === 'saved') ? undefined : this.state.query;
+
+        this.openPane('confirmexport', viewId, queryId);
     }
 
     onClickDelete() {


### PR DESCRIPTION
The queryId passed to the confirmexport component needs to be
blank to be able to export the "Saved" tab.

We made it so that any selected queryId in the Smart Search is retained when clicking that button. (Like, when you leave the Saved for the Smart Search button.)

Fixes #1217.

Pair-programmed with @oelrich