### PR TITLE
Tweak collapse/back links in person view

### DIFF
--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 import React from 'react';
@@ -113,24 +114,26 @@ export default class PersonViewsPane extends RootPaneBase {
 
     renderPaneTop() {
         const viewId = this.getParam(0);
+        const collapseClasses = cx('PersonViewsPane-collapseHeaderLink', {
+            collapsed: this.state.collapseHeader,
+        });
 
         if (viewId) {
             return (
                 <div key="topLinks" className="PersonViewsPane-topLinks">
-                    <div key="backLink" className="PersonViewsPane-backLink">
-                        <a onClick={ () => this.gotoPane('views') }>
-                            <Msg id="panes.personViews.view.backLink"/>
-                        </a>
+                    <div key="backLink" className="PersonViewsPane-backLink"
+                        onClick={ () => this.gotoPane('views') }
+                        >
+                        <Msg id="panes.personViews.view.backLink"/>
                     </div>,
-                    <div key="collapseLink" className={ "PersonViewsPane-collapseHeaderLink" + (
-                    this.state.collapseHeader ? "-collapsed" : "" )} >
-                        <a onClick={ this.onClickCollapseHeader.bind(this) }>
-                            { this.state.collapseHeader ? 
-                                <Msg id="panes.personViews.view.showHeader" />
-                                :
-                                <Msg id="panes.personViews.view.hideHeader" />
-                            }
-                        </a>
+                    <div key="collapseLink" className={ collapseClasses }
+                        onClick={ this.onClickCollapseHeader.bind(this) }
+                        >
+                        { this.state.collapseHeader ?
+                            <Msg id="panes.personViews.view.showHeader" />
+                            :
+                            <Msg id="panes.personViews.view.hideHeader" />
+                        }
                     </div>
                 </div>
             );

--- a/src/components/sections/people/PersonViewsPane.scss
+++ b/src/components/sections/people/PersonViewsPane.scss
@@ -101,6 +101,7 @@
     font-size: 1rem;
     color: $c-ui-darker;
     margin-right: 1rem;
+    cursor: pointer;
 
     &:before {
         @include icon($fa-var-chevron-left);
@@ -119,31 +120,19 @@
 }
 
 .PersonViewsPane-collapseHeaderLink {
-    @extend .PersonViewsPane-backLink;
     font-size: 1rem;
     color: $c-ui-darker;
+    cursor: pointer;
 
-    &:before {
+    &:after {
         @include icon($fa-var-chevron-up);
-        transition: top 0.2s;
+
+        transition: transform 0.2s;
     }
 
-    &:hover {
-        &:before {
-            top: -0.1em;
-        }
-    }
-}
-
-.PersonViewsPane-collapseHeaderLink-collapsed {
-    @extend .PersonViewsPane-collapseHeaderLink;
-    &:before {
-        @include icon($fa-var-chevron-down);
-    }
-
-    &:hover {
-        &:before {
-            top: 0.1em;
+    &.collapsed {
+        &:after {
+            transform: rotate(180deg);
         }
     }
 }


### PR DESCRIPTION
This PR tweaks the "back" and "collapse" links for person views:

* Makes the entire link clickable, including the chevron icon
* Moves the chevron of the "collapse" link to the right-hand side
* Animates chevron by rotating it (see animation below)

![view-collapse-rotate](https://user-images.githubusercontent.com/550212/106187311-c191fb80-61a5-11eb-8db5-4f100d0a2b41.gif)
