### PR TITLE
Upgrade xlsx package to fix date import bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "verifiera": "^1.2.0",
     "webpack": "^2.2.1",
     "worker-loader": "^0.8.1",
-    "xlsx": "^0.8.0",
+    "xlsx": "^0.16.9",
     "zetkin": "~1.2.0"
   },
   "devDependencies": {

--- a/src/utils/import.js
+++ b/src/utils/import.js
@@ -67,7 +67,7 @@ export function parseCSV(file) {
 }
 
 export function parseWorkbook(data) {
-    let wb = xlsx.read(data, { type: 'binary', cellStyles: true });
+    let wb = xlsx.read(data, { type: 'binary', cellStyles: true, dateNF: 'yyyy"-"mm"-"dd'});
 
     let tableSet = {
         tableList: createList(),
@@ -103,7 +103,7 @@ export function parseWorkbook(data) {
                 let rowValues = table.columnList.items.map((col, idx) => {
                     let addr = xlsx.utils.encode_cell({ r, c: idx });
                     let cell = sheet[addr];
-                    return cell? (cell.w || cell.v) : undefined;
+                    return cell? (cell.d || cell.w || cell.v) : undefined;
                 });
 
                 // Only include if there are non-null values in the row


### PR DESCRIPTION
This fixes a problem where dates are not properly formatted on import from Excel documents.

To reproduce bug:
1. Export from dynamics 365 with a date column
2. Import in Zetkin
3. Map date column to a custom date field
Expected: Properly formatted date
Actual: Raw value representing date in Excel of the format "42785.12547"

This seems to be caused by the xlsx package not properly parsing the "z" parameter of cells. This appears to be fixed in a later version of the package. This also specifies the date format to international standard to make sure it's interpreted properly.