### PR TITLE
Fix AddViewColumn bug

### DIFF
--- a/src/components/panes/AddViewColumnPane.jsx
+++ b/src/components/panes/AddViewColumnPane.jsx
@@ -238,16 +238,18 @@ class PersonFieldColumnTemplate extends React.Component {
 class PersonNotesColumnTemplate extends React.Component {
 
     componentDidMount() {
-        const column = {
-            title: this.props.intl.formatMessage({
-                id: 'panes.addViewColumn.templates.person_notes.title'
-            }),
-            config: {
-                limit: 1,
-            }
-        };
+        if(this.props.selected) {
+            const column = {
+                title: this.props.intl.formatMessage({
+                    id: 'panes.addViewColumn.templates.person_notes.title'
+                }),
+                config: {
+                    limit: 1,
+                }
+            };
 
-        this.props.onChange(column);
+            this.props.onChange(column);
+        }
     }
 
     render() {

--- a/src/components/panes/AddViewColumnPane.jsx
+++ b/src/components/panes/AddViewColumnPane.jsx
@@ -237,10 +237,10 @@ class PersonFieldColumnTemplate extends React.Component {
 @injectIntl
 class PersonNotesColumnTemplate extends React.Component {
 
-    componentWillReceiveProps(nextProps) {
-        if(nextProps.selected && nextProps.config.limit == undefined) {
+    componentDidUpdate(prevProps) {
+        if(this.props.selected && !prevProps.selected) {
             const column = {
-                title: nextProps.intl.formatMessage({
+                title: this.props.intl.formatMessage({
                     id: 'panes.addViewColumn.templates.person_notes.title'
                 }),
                 config: {
@@ -248,7 +248,7 @@ class PersonNotesColumnTemplate extends React.Component {
                 }
             };
 
-            nextProps.onChange(column);
+            this.props.onChange(column);
         }
     }
 
@@ -390,9 +390,11 @@ class PersonTagColumnTemplate extends React.Component {
 }))
 class SurveyResponseColumnTemplate extends React.Component {
     componentDidUpdate(prevProps) {
-        const surveyId = this.props.config.survey_id;
-        if (surveyId != prevProps.config.survey_id) {
-            this.props.dispatch(retrieveSurvey(surveyId));
+        if(this.props.selected) {
+            const surveyId = this.props.config.survey_id;
+            if (surveyId != prevProps.config.survey_id && surveyId != null) {
+                this.props.dispatch(retrieveSurvey(surveyId));
+            }
         }
     }
 
@@ -480,9 +482,11 @@ class SurveyResponseColumnTemplate extends React.Component {
 }))
 class SurveySubmittedColumnTemplate extends React.Component {
     componentDidUpdate(prevProps) {
-        const surveyId = this.props.config.survey_id;
-        if (surveyId != prevProps.config.survey_id) {
-            this.props.dispatch(retrieveSurvey(surveyId));
+        if(this.props.selected) {
+            const surveyId = this.props.config.survey_id;
+            if (surveyId != prevProps.config.survey_id && surveyId != null) {
+                this.props.dispatch(retrieveSurvey(surveyId));
+            }
         }
     }
 

--- a/src/components/panes/AddViewColumnPane.jsx
+++ b/src/components/panes/AddViewColumnPane.jsx
@@ -237,10 +237,10 @@ class PersonFieldColumnTemplate extends React.Component {
 @injectIntl
 class PersonNotesColumnTemplate extends React.Component {
 
-    componentDidMount() {
-        if(this.props.selected) {
+    componentWillReceiveProps(nextProps) {
+        if(nextProps.selected && nextProps.config.limit == undefined) {
             const column = {
-                title: this.props.intl.formatMessage({
+                title: nextProps.intl.formatMessage({
                     id: 'panes.addViewColumn.templates.person_notes.title'
                 }),
                 config: {
@@ -248,7 +248,7 @@ class PersonNotesColumnTemplate extends React.Component {
                 }
             };
 
-            this.props.onChange(column);
+            nextProps.onChange(column);
         }
     }
 


### PR DESCRIPTION
Fix undocumented bug where adding a view column without selecting anything would add a person_field filter with the configuration of a person_note.

To reproduce:
1. Create a view
2. Add a few people to the view
3. Click Add column
4. Click the Add column button in the AddViewColumnPane

Expected results: Adds the selected view column type
Actual results: Adds a column named Person notes, clears people from the view due to the backend not knowing what to do with the odd column configuration.