### PR TITLE
Include slug in export file name

### DIFF
--- a/src/actions/personView.js
+++ b/src/actions/personView.js
@@ -139,11 +139,13 @@ export function exportPersonView(viewId, queryId) {
         const csvStr = csvFormatRows(rows);
         const blob = new Blob([ csvStr ], { type: 'text/csv' });
         const now = new Date();
+        let orgName = getState().user.activeMembership.organization.title;
+        orgName = orgName.toLowerCase().replace(/\s/g,'-').replace(/[^a-z\-]/g, '')
         const dateStr = now.format('%Y%m%d');
         const timeStr = now.format('%H%m%S');
         const a = document.createElement('a');
         a.setAttribute('href', URL.createObjectURL(blob));
-        a.setAttribute('download', `${dateStr}_${timeStr}.csv`);
+        a.setAttribute('download', `${orgName}_${dateStr}_${timeStr}.csv`);
         a.style.display = 'none';
 
         document.body.appendChild(a);


### PR DESCRIPTION
Resolves #1260 

Does not include slug exactly because it's not available without making changes to the way the platform returns organizations, instead merely returns a lowercased organization title stripped of any non-a-z-characters.