### PR TITLE
Shared queries

### DIFF
--- a/locale/panes/query/en.yaml
+++ b/locale/panes/query/en.yaml
@@ -1,4 +1,5 @@
 editLink: Edit this Smart Search query
+shared: 'Query is shared from {org}'
 summary:
     diff: Compare with another query
     size: '{size, plural, =0 {No search results} =1 {One search result} other {# search results}}'

--- a/locale/panes/query/sv.yaml
+++ b/locale/panes/query/sv.yaml
@@ -1,4 +1,5 @@
 editLink: Redigera den här Smarta sökningen
+shared: 'Sökningen är delad från {org}'
 summary:
     diff: Jämför med en annan sökning
     size: '{size, plural, =0 {Inga sökträffar} =1 {En sökträff} other {# sökträffar}}'

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -8,6 +8,7 @@ export function retrieveQueries() {
 
         dispatch({
             type: types.RETRIEVE_QUERIES,
+            meta: { orgId },
             payload: {
                 promise: z.resource('orgs', orgId, 'people', 'queries').get(),
             }
@@ -20,7 +21,7 @@ export function retrieveQuery(id) {
         let orgId = getState().org.activeId;
         dispatch({
             type: types.RETRIEVE_QUERY,
-            meta: { id },
+            meta: { id, orgId },
             payload: {
                 promise: z.resource('orgs', orgId, 'people', 'queries',
                     id).get()

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -133,9 +133,11 @@ export default class RelSelectInput extends InputBase {
                         'focused': (idx === this.state.focusedIndex)
                     });
 
-                    var editLink = null;
-                    if (showEditLink) {
-                        editLink = <a className="RelSelectInput-editLink"
+                    var itemIcon = null;
+                    if (obj.isShared) {
+                        itemIcon = <span className="RelSelectInput-shared" />
+                    } else if(showEditLink) {
+                        itemIcon = <a className="RelSelectInput-editLink"
                             onClick={ this.onClickEdit.bind(this, obj) }/>;
                     }
 
@@ -151,7 +153,7 @@ export default class RelSelectInput extends InputBase {
                                 onMouseDown={ this.onClickOption.bind(this, obj) }>
                                 { this.getLabel(obj) }
                             </label>
-                            { editLink }
+                            { itemIcon }
                         </li>
                     );
                 }, this)}

--- a/src/components/forms/inputs/RelSelectInput.scss
+++ b/src/components/forms/inputs/RelSelectInput.scss
@@ -24,7 +24,6 @@
 
         li {
             position: relative;
-            cursor: pointer;
             font-size: 1.1em;
 
             .RelSelectInput-itemLabel {
@@ -72,7 +71,7 @@
                     }
                 }
 
-                .RelSelectInput-editLink {
+                .RelSelectInput-editLink, .RelSelectInput-shared {
                     display: block;
                 }
             }
@@ -86,7 +85,7 @@
                 }
             }
 
-            .RelSelectInput-editLink {
+            .RelSelectInput-editLink, .RelSelectInput-shared {
                 position: absolute;
                 right: 0;
                 top: 0;
@@ -100,7 +99,9 @@
                 @include small-screen {
                     display: block;
                 }
+            }
 
+            .RelSelectInput-editLink {
                 &:before {
                     @include icon($fa-var-pencil);
                     line-height: 2.4em;
@@ -112,6 +113,17 @@
 
                 &:hover {
                     color: darken(#888, 30)
+                }
+            }
+
+            .RelSelectInput-shared {
+                &:before {
+                    @include icon($fa-var-share-alt);
+                    line-height: 2.4em;
+
+                    @include small-screen {
+                        line-height: 3em;
+                    }
                 }
             }
         }

--- a/src/components/lists/items/PersonQueryListItem.jsx
+++ b/src/components/lists/items/PersonQueryListItem.jsx
@@ -23,6 +23,13 @@ export default class PersonQueryListItem extends React.Component {
                     <span className="PersonQueryListItem-description">
                         { query.info_text }</span>
                 </div>
+                <div className="PersonQueryListItem-orgcol">
+                    { query.isShared ?
+                        <span className="PersonQueryListItem-shared">
+                            { query.organization.title }
+                        </span> : null
+                    }
+                </div>
             </div>
         );
     }

--- a/src/components/lists/items/PersonQueryListItem.scss
+++ b/src/components/lists/items/PersonQueryListItem.scss
@@ -1,4 +1,9 @@
 .PersonQueryListItem {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap-reverse;
+
     .PersonQueryListItem-title {
         display: block;
         font-size: 1.1em;
@@ -21,5 +26,14 @@
         @include small-screen {
             font-size: 0.8em;
         }
+    }
+
+    .PersonQueryListItem-shared {
+        font-size: 0.8em;
+        color: lighten($c-text, 60);
+        &:before {
+            @include icon($fa-var-share-alt);
+        }
+        text-align: left;
     }
 }

--- a/src/components/panes/QueryPane.jsx
+++ b/src/components/panes/QueryPane.jsx
@@ -49,11 +49,21 @@ export default class QueryPane extends PaneBase {
     }
 
     getPaneSubTitle(data) {
-        return (
-            <a key="editLink" onClick={ this.onEditClick.bind(this) }>
-                <Msg id="panes.query.editLink"/>
-            </a>
-        );
+        if(data.queryItem && data.queryItem.data) {
+            if(data.queryItem.data.isShared === true) {
+                return <Msg id="panes.query.shared" values={{
+                            org: data.queryItem.data.organization.title
+                        }}/>
+            } else {
+                return (
+                    <a key="editLink" onClick={ this.onEditClick.bind(this) }>
+                        <Msg id="panes.query.editLink"/>
+                    </a>
+                );
+            }
+        } else {
+            return null;
+        }
     }
 
     renderPaneContent(data) {

--- a/src/components/panes/QueryPane.scss
+++ b/src/components/panes/QueryPane.scss
@@ -1,12 +1,21 @@
 .PaneBase.QueryPane {
     min-width: 480px;
 
-    small a {
+    small {
         display: block;
         margin-bottom: 2em;
-        cursor:pointer;
-        &::before {
-            @include icon($fa-var-pencil);
+        
+        >a {
+            cursor:pointer;
+            &::before {
+                @include icon($fa-var-pencil);
+            }
+        }
+        
+        >span {
+            &::before {
+                @include icon($fa-var-share-alt);
+            }
         }
     }
 
@@ -38,4 +47,8 @@
             @include icon($fa-var-refresh);
         }
     }
+}
+
+.QueryPane-sharedQuery {
+    font-size: 0.5em;
 }

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -20,7 +20,10 @@ export default function queries(state = null, action) {
         case types.RETRIEVE_QUERIES + '_FULFILLED':
             return Object.assign({}, state, {
                 queryList: updateOrAddListItems(state.queryList,
-                    action.payload.data.data,
+                    action.payload.data.data.map(query => {
+                        query.isShared = query.organization.id != action.meta.orgId;
+                        return query;
+                    }),
                     { isPending: false, error: null })
             });
 
@@ -33,6 +36,7 @@ export default function queries(state = null, action) {
 
         case types.RETRIEVE_QUERY + '_FULFILLED':
             query = action.payload.data.data;
+            query.isShared = action.meta.orgId != query.organization.id;
 
             return Object.assign({}, state, {
                 queryList: updateOrAddListItem(state.queryList,


### PR DESCRIPTION
Changes in UI to reflect read-only queries shared from another organization.

The query reducer computes isShared for each query, determining if the query is shared from another organization.

The RelSelectInput shows a share icon instead of edit link when an item isShared.
![relselect-shared](https://user-images.githubusercontent.com/14962107/121445011-e76bb000-c990-11eb-91d4-842f50073fae.png)

The PersonQueryListItem shows share icon and organization name if query isShared.
![Skärmbild från 2021-06-10 02-10-35](https://user-images.githubusercontent.com/14962107/121445176-344f8680-c991-11eb-9d48-37cfb631803e.png)

The PersonQueryPane shows a label without edit link if query isShared.
![Skärmbild från 2021-06-10 02-12-40](https://user-images.githubusercontent.com/14962107/121445244-5cd78080-c991-11eb-8ede-ed953c206fef.png)
