### PR TITLE
Preload data from correct org

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -19,7 +19,6 @@ import ActivistPage from '../components/fullpages/ActivistPage';
 import IntlReduxProvider from '../components/IntlReduxProvider';
 import ServerErrorPage from "../components/ServerErrorPage";
 import { setPanesFromUrlPath } from '../actions/view';
-import { setActiveOrg } from '../actions/user';
 
 const packageJson = require('../../../package.json');
 
@@ -109,38 +108,6 @@ export default function initApp(messages) {
         }
         else {
             renderReactPage(ActivistPage, req, res);
-        }
-    });
-
-    // Route for switching organizations
-    app.get('*', (req, res, next) => {
-        let state = req.store.getState();
-        let orgId = null;
-
-        let orgIsValid = orgId =>
-            !!state.user.memberships.find(m => m.organization.id == orgId);
-
-        if (req.query.org && orgIsValid(req.query.org)) {
-            // Will store organization from querystring in cookie and redirect.
-            // The next request will fall into the next condition.
-            res.cookie('activeOrgId', req.query.org);
-            res.redirect('/');
-            return;
-        }
-        else if (req.cookies.activeOrgId) {
-            // Will use organization from cookie, if (still) valid
-            if (orgIsValid(req.cookies.activeOrgId)) {
-                req.store.dispatch(setActiveOrg(req.cookies.activeOrgId));
-            }
-            else {
-                res.clearCookie('activeOrgId');
-            }
-
-            next();
-        }
-        else {
-            // Will use default, which is first organization
-            next();
         }
     });
 


### PR DESCRIPTION
This PR fixes #798 by changing the order in which various middleware handle a request on the server-side. Before it went like this:

1. Set up store
2. Preload data
3. Set correct org from cookie

With this change, the order is now:

1. Set up store
2. Set correct org from cookie
3. Preload data