### PR TITLE
Workaround for server-client inconsistency with actions

### DIFF
--- a/src/server/datarouter.js
+++ b/src/server/datarouter.js
@@ -2,7 +2,7 @@ import express from 'express';
 
 import { createLocalizeHandler } from './locale';
 import { configureStore } from '../store';
-import { retrieveActions, retrieveAction, retrieveActionsOnDay } from '../actions/action';
+import { retrieveAction, retrieveActionsOnDay } from '../actions/action';
 import { retrieveActionParticipants } from '../actions/participant';
 import { retrieveActionResponses } from '../actions/actionResponse';
 import { retrieveActivities } from '../actions/activity';
@@ -102,7 +102,6 @@ export default messages => {
     ]));
 
     router.get(/campaign\/locations$/, waitForActions(req => [
-        retrieveActions(),
         retrieveCampaigns(),
     ]));
 
@@ -115,20 +114,17 @@ export default messages => {
     ]));
 
     router.get(/campaign\/playback$/, waitForActions(req => [
-        retrieveActions(),
         retrieveActivities(),
         retrieveCampaigns(),
         retrieveLocations()
     ]));
 
     router.get(/campaign\/distribution$/, waitForActions(req => [
-        retrieveActions(),
         retrieveActivities(),
         retrieveCampaigns()
     ]));
 
     router.get(/campaign\/actions$/, waitForActions(req => [
-        retrieveActions(),
         retrieveActivities(),
         retrieveCampaigns(),
     ]));


### PR DESCRIPTION
Resolves #1286

This is a workaround for the server-client inconsistency for actions. It proved difficult to fix, so this PR simply removes preloading of actions on server render. The consequences of this may be a slight delay for displaying actions on reload or direct url entry of e.g. /campaign/actions on slower connections.