### PR TITLE
Suborg acces in Organize gui

### DIFF
--- a/locale/forms/query/en.yaml
+++ b/locale/forms/query/en.yaml
@@ -1,2 +1,6 @@
 description: Description
 title: Title
+orgAccess: Access
+orgAccessOptions:
+    sameorg: This organization
+    suborgs: Sub-organizations

--- a/locale/forms/query/sv.yaml
+++ b/locale/forms/query/sv.yaml
@@ -1,2 +1,6 @@
 description: Beskrivning
 title: Titel
+orgAccess: Tillgänglighet
+orgAccessOptions:
+    sameorg: Den här organisationen
+    suborgs: Underorganisationer

--- a/locale/panes/query/en.yaml
+++ b/locale/panes/query/en.yaml
@@ -3,3 +3,7 @@ summary:
     diff: Compare with another query
     size: '{size, plural, =0 {No search results} =1 {One search result} other {# search results}}'
     refresh: Refresh results
+    orgAccess:
+        sameorg: Accessible to this organization only
+        suborgs: Accessible to sub-organizations
+    ownership: Belongs to { organization }

--- a/locale/panes/query/sv.yaml
+++ b/locale/panes/query/sv.yaml
@@ -2,3 +2,7 @@ editLink: Redigera den här Smarta sökningen
 summary:
     diff: Jämför med en annan sökning
     size: '{size, plural, =0 {Inga sökträffar} =1 {En sökträff} other {# sökträffar}}'
+    orgAccess:
+        sameorg: Tillgänglig för den här organisationen
+        suborgs: Tillgänglig för underorganisationer
+    ownership: Tillhör { organization }

--- a/src/components/forms/QueryForm.jsx
+++ b/src/components/forms/QueryForm.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Form from './Form';
 import TextInput from './inputs/TextInput';
 import TextArea from './inputs/TextArea';
+import SelectInput from './inputs/SelectInput';
 
 
 export default class QueryForm extends React.Component {
@@ -16,6 +17,11 @@ export default class QueryForm extends React.Component {
     render() {
         let query = this.props.query || {};
 
+        const accessOptions = {
+            'sameorg': 'forms.query.orgAccessOptions.sameorg',
+            'suborgs': 'forms.query.orgAccessOptions.suborgs',
+        }
+
         return (
             <Form ref="form" { ...this.props }>
                 <TextInput labelMsg="forms.query.title" name="title"
@@ -23,6 +29,11 @@ export default class QueryForm extends React.Component {
 
                 <TextArea labelMsg="forms.query.description" name="info_text"
                     initialValue={ query.info_text }/>
+
+                <SelectInput labelMsg="forms.query.orgAccess" name="org_access"
+                    initialValue={ query.org_access }
+                    options={ accessOptions } optionLabelsAreMessages={ true }/>
+
             </Form>
         );
     }

--- a/src/components/forms/inputs/RelSelectInput.jsx
+++ b/src/components/forms/inputs/RelSelectInput.jsx
@@ -134,7 +134,7 @@ export default class RelSelectInput extends InputBase {
                     });
 
                     var editLink = null;
-                    if (showEditLink) {
+                    if (showEditLink && !obj.noEdit) {
                         editLink = <a className="RelSelectInput-editLink"
                             onClick={ this.onClickEdit.bind(this, obj) }/>;
                     }

--- a/src/components/panes/QueryPane.jsx
+++ b/src/components/panes/QueryPane.jsx
@@ -12,6 +12,7 @@ import LoadingIndicator from '../misc/LoadingIndicator';
 const mapStateToProps = (state, props) => ({
     queryItem: getListItemById(state.queries.queryList,
         props.paneData.params[0]),
+    activeOrg: state.org.activeId,
 });
 
 @connect(mapStateToProps)
@@ -41,6 +42,7 @@ export default class QueryPane extends PaneBase {
     getRenderData() {
         return {
             queryItem: this.props.queryItem,
+            activeOrg: this.props.activeOrg,
         };
     }
 
@@ -49,22 +51,43 @@ export default class QueryPane extends PaneBase {
     }
 
     getPaneSubTitle(data) {
-        return (
-            <a key="editLink" onClick={ this.onEditClick.bind(this) }>
+        if (data.queryItem && 
+            data.queryItem.data && 
+            data.queryItem.data.organization && 
+            data.queryItem.data.organization.id == data.activeOrg) {
+
+            return (<a key="editLink" onClick={ this.onEditClick.bind(this) }>
                 <Msg id="panes.query.editLink"/>
-            </a>
-        );
+            </a>);
+        } else {
+            return null;
+        }
     }
 
     renderPaneContent(data) {
         let item = data.queryItem;
         if (item && item.data && item.data.matchList) {
             let matchList = item.data.matchList;
-            let content = [];
+            let content = []; 
 
             let summary = [
                 { name: 'desc', value: data.queryItem.data.info_text },
             ];
+ 
+            if (item.data.organization && item.data.organization.id != data.activeOrg) {
+                summary.push({
+                    name: 'ownership',
+                    msgId: `panes.query.summary.ownership`,
+                    msgValues: {
+                        organization: item.data.organization.title,
+                    }
+                })
+            } else {
+                summary.push({
+                    name: 'org_access',
+                    msgId: `panes.query.summary.orgAccess.${item.data.org_access}`,
+                })
+            }
 
             if (!matchList.isPending) {
                 summary.push({ name: 'size',

--- a/src/components/panes/QueryPane.scss
+++ b/src/components/panes/QueryPane.scss
@@ -21,6 +21,18 @@
         }
     }
 
+    .InfoListItem-org_access {
+        &::before {
+            @include icon($fa-var-eye);
+        }
+    }
+
+    .InfoListItem-ownership {
+        &::before {
+            @include icon($fa-var-sitemap);
+        }
+    }
+
     .InfoListItem-size {
         &::before {
             @include icon($fa-var-users);

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -23,17 +23,11 @@ import {
 
 
 const mapStateToProps = state => {
-    const orgId = state.user.activeMembership.organization.id;
-
-    const queries = state.queries;
-    if(queries.queryList && !queries.queryList.isPending) {
-        queries.queryList.items = queries.queryList.items.filter(i => i.data.organization.id == orgId);
-    }
-
     return {
         people: state.people,
-        queries: queries,
+        queries: state.queries,
         selections: state.selections,
+        activeOrg: state.org.activeId,
     }
 };
 
@@ -146,7 +140,11 @@ export default class PeopleListPane extends RootPaneBase {
         // Only include queries that have a title
         // TODO: Find some better way to filter out call assignment queries,
         //       e.g. a proper type attribute on the query
-        let queries = queryList.items.map(i => i.data).filter(q => q.title);
+        let queries = queryList.items.map(i => { 
+            // Mark shared surveys as non-editable
+            i.data.noEdit = i.data.organization.id != this.props.activeOrg;
+            return i.data 
+        }).filter(q => q.title);
 
         let querySelectNullLabel = formatMessage(
             { id: 'panes.peopleList.querySelect.nullLabel' });

--- a/src/components/sections/people/PersonViewsPane.jsx
+++ b/src/components/sections/people/PersonViewsPane.jsx
@@ -25,17 +25,10 @@ import { getListItemById } from '../../../utils/store';
 
 
 const mapStateToProps = state => {
-    const orgId = state.user.activeMembership.organization.id;
-
-    let queryList = state.queries.queryList; 
-    if(queryList && !queryList.isPending) {
-        queryList.items = queryList.items.filter(i => 
-            i.data.organization.id == orgId);
-    }
-
     return {
-        queryList: queryList,
+        queryList: state.queries.queryList,
         views: state.personViews,
+        activeOrg: state.org.activeId,
     }
 };
 
@@ -171,7 +164,11 @@ export default class PersonViewsPane extends RootPaneBase {
                 let querySelect = null;
                 if (this.state.viewMode == 'query') {
                     const queryList = this.props.queryList;
-                    const queries = queryList.items.map(i => i.data).filter(q => !!q.title).sort((a, b) => a.title.localeCompare(b.title));
+                    const queries = queryList.items.map(i => { 
+                        // Mark shared surveys as non-editable
+                        i.data.noEdit = i.data.organization.id != this.props.activeOrg;
+                        return i.data 
+                    }).filter(q => !!q.title).sort((a, b) => a.title.localeCompare(b.title));
 
                     querySelect = (
                         <RelSelectInput name="query"


### PR DESCRIPTION
Add selectbox for choosing access level of queries.
![Screenshot from 2022-02-10 22-03-12](https://user-images.githubusercontent.com/14962107/153495998-5445adf6-9834-4870-95a5-3d5511b8f10b.png)

Show the owner of a parent org query and show the status of organization sharing for the organizations own queries. Remove link to edit pane for parent query.
![Screenshot from 2022-02-10 21-59-48](https://user-images.githubusercontent.com/14962107/153495778-423b1d98-f741-4816-a50f-3520a3a513e3.png)

Remove edit link from query select box for parent queries.
![Screenshot from 2022-02-10 22-01-32](https://user-images.githubusercontent.com/14962107/153495799-249d9ba2-d1a3-4a19-b83c-b7bdd6900135.png)

