### PR TITLE
Fix bug where survey filters sometimes crash.

### DIFF
--- a/src/components/filters/SurveyOptionFilter.jsx
+++ b/src/components/filters/SurveyOptionFilter.jsx
@@ -40,7 +40,7 @@ export default class SurveyOptionFilter extends FilterBase {
 
         let surveyList = this.props.surveyList;
 
-        if ((surveyList.items.length == 0 || !surveyList.items.recursive) && !surveyList.isPending) {
+        if (surveyList.items && (surveyList.items.length == 0 || !surveyList.items.recursive) && !surveyList.isPending) {
             this.props.dispatch(retrieveSurveysRecursive());
         }
 

--- a/src/components/filters/SurveyResponseFilter.jsx
+++ b/src/components/filters/SurveyResponseFilter.jsx
@@ -38,7 +38,7 @@ export default class SurveyResponseFilter extends FilterBase {
 
         let surveyList = this.props.surveyList;
 
-        if ((surveyList.items.length == 0 || !surveyList.recursive) && !surveyList.isPending) {
+        if (surveyList.items && (surveyList.items.length == 0 || !surveyList.recursive) && !surveyList.isPending) {
             this.props.dispatch(retrieveSurveysRecursive());
         }
     }

--- a/src/components/filters/SurveySubmissionFilter.jsx
+++ b/src/components/filters/SurveySubmissionFilter.jsx
@@ -37,7 +37,7 @@ export default class SurveySubmissionFilter extends FilterBase {
 
         let surveyList = this.props.surveyList;
 
-        if ((surveyList.items.length == 0 || !surveyList.recursive) && !surveyList.isPending) {
+        if (surveyList.items && (surveyList.items.length == 0 || !surveyList.recursive) && !surveyList.isPending) {
             this.props.dispatch(retrieveSurveysRecursive());
         }
     }

--- a/src/components/sections/people/PeopleListPane.jsx
+++ b/src/components/sections/people/PeopleListPane.jsx
@@ -142,7 +142,7 @@ export default class PeopleListPane extends RootPaneBase {
         //       e.g. a proper type attribute on the query
         let queries = queryList.items.map(i => { 
             // Mark shared surveys as non-editable
-            i.data.noEdit = i.data.organization.id != this.props.activeOrg;
+            i.data.noEdit = i.data.organization && i.data.organization.id != this.props.activeOrg;
             return i.data 
         }).filter(q => q.title);
 

--- a/src/utils/filterByOrg.js
+++ b/src/utils/filterByOrg.js
@@ -14,5 +14,5 @@ export default (orgList, collection, config) => {
     }
     filterOrgs = filterOrgs.map(o => o.id);
 
-    return collection.filter(item => filterOrgs.includes(item.data.organization.id));
+    return collection.filter(item => item.data.organization && filterOrgs.includes(item.data.organization.id));
 }


### PR DESCRIPTION
This fixes a bug that occasionally appears, especially with complex queries, where the survey related filters would crash due to the lack (presumably because it has not been properly loaded yet) of survey.organization.