### PR TITLE
Fix many surveys query bug

### DIFF
--- a/src/actions/survey.js
+++ b/src/actions/survey.js
@@ -51,21 +51,19 @@ export function retrieveSurvey(id) {
         let orgId;
         let survey;
         const surveys = getState().surveys;
-        if(surveys.surveyList && surveys.surveyList.items) {
+        if(surveys.surveyList && surveys.surveyList.items && !surveys.isPending) {
             survey = getState().surveys.surveyList.items.find(i => i.data.id == id);
-        }
-        if(survey) {
-            orgId = survey.data.organization.id;
-        } else {
-            orgId = getState().org.activeId;
-        }
-        dispatch({
-            type: types.RETRIEVE_SURVEY,
-            meta: { id },
-            payload: {
-                promise: z.resource('orgs', orgId, 'surveys', id).get(),
+            if(survey && !survey.isPending) {
+                orgId = survey.data.organization.id;
+                dispatch({
+                    type: types.RETRIEVE_SURVEY,
+                    meta: { id },
+                    payload: {
+                        promise: z.resource('orgs', orgId, 'surveys', id).get(),
+                    }
+                });
             }
-        });
+        }
     };
 }
 


### PR DESCRIPTION
Fix bug that appears when many conditions are in a query which causes organize to crash and make it impossible to edit the query.

To reproduce:
1. Make a new query
2. Add a bunch of survey response queries (like 10 or more)
3. Save
4. Go to / and reload organize.
5. Go to people and edit the query

Expected results:
You should be able to edit the query.

Actual results:
Many of the survey fields are blank and Organize crashed due to an action trying to access survey.organize which does not exist because the full survey is still pending.

(An example of this is on the live dev server, the query is called test)