### PR TITLE
Fix bug where old all filters were missing a config object. 

### DIFF
--- a/src/components/sections/dialog/AllCallAssignmentsPane.jsx
+++ b/src/components/sections/dialog/AllCallAssignmentsPane.jsx
@@ -12,7 +12,6 @@ const mapStateToProps = (state, props) => {
     // FIXME: This is a temporary fix until a proper UI filter has been implemented
     const list = state.callAssignments.assignmentList;
     const orgId = state.user.activeMembership.organization.id;
-    list.items = list.items.filter(i => i.data.organization.id == orgId);
 
     return {
         assignmentList: list, 

--- a/src/store/queries.js
+++ b/src/store/queries.js
@@ -9,6 +9,10 @@ import {
 
 function mapOrganizationParams(data) {
     data.filter_spec = data.filter_spec.map(spec => {
+        if(!spec.config) {
+            spec.config = {};
+        }
+
         if(spec.config.organizations) {
             if(spec.config.organizations instanceof Array) {
                 spec.config.organizationOption = 'specific';


### PR DESCRIPTION
Also fix a bug in the AllCallAssignmentsPane related to recursive fetching, don't filter on the organization for now and assume that all call assignments are fetched as normal.