### PR TITLE
Expose target details by default

### DIFF
--- a/src/components/panes/AddCallAssignmentPane.jsx
+++ b/src/components/panes/AddCallAssignmentPane.jsx
@@ -324,7 +324,10 @@ export default class AddCallAssignmentPane extends PaneBase {
         else if (this.state.step == 'form') {
             ev.preventDefault();
 
-            let values = this.refs.form.getValues();
+            let values = {
+                expose_target_details: true,
+                ...this.refs.form.getValues(),
+            };
 
             if (this.state.targetType == 'allTarget') {
                 values.target_filters = [{


### PR DESCRIPTION
Set `expose_target_details=true` by default when creating a new call assignment.

Fixes #1316 