### PR TITLE
Change max length of external to 96 char in validation

### DIFF
--- a/locale/panes/confirmImport/en.yaml
+++ b/locale/panes/confirmImport/en.yaml
@@ -9,7 +9,7 @@ dateInvalid: Date invalid on rows { rows }.
 duplicatesInfo: You have selected duplicate columns.
 emailInvalid: Invalid E-mail address on rows { rows }.
 errorTitle: Invalid data
-externalTooLong: External ID longer thant 12 characters on rows { rows }.
+externalTooLong: External ID longer than 96 characters on rows { rows }.
 first_nameTooLong: First name longer than 50 character on rows { rows }.
 genderInvalid: Invalid gender format on rows { rows }. Gender may only contain f for female, m for male, o for other, _ or blank for unknown.
 inconsistentRow: The number of rows in a column is inconsistent with the number of columns configured.

--- a/locale/panes/confirmImport/sv.yaml
+++ b/locale/panes/confirmImport/sv.yaml
@@ -7,7 +7,7 @@ continueImportButton: Fortsätt import
 countryTooLong: Land längre än 60 tecken på rad { rows }.
 duplicatesInfo: Du har valt dublettkolumner
 emailInvalid: Ogiltig e-postadress på rad { rows }.
-externalTooLong: Externt ID längre än 12 tecken på rad { rows }.
+externalTooLong: Externt ID längre än 96 tecken på rad { rows }.
 first_nameTooLong: Förnamn längre än 50 tecken på rad { rows }.
 genderInvalid: Ogilitigt kön på rad { rows }. Gitliga värden är m för män, f för kvinnor, o för annat, och blank eller _ för okänd.
 inconsistentRow: Antalet rader i en kolumn stämmer inte överrens med antalet konfigurerade kolumner.

--- a/src/components/panes/ConfirmImportPane.jsx
+++ b/src/components/panes/ConfirmImportPane.jsx
@@ -162,7 +162,7 @@ export default class ConfirmImportPane extends PaneBase {
                             }
                             break;
                         case 'external':
-                            if(row.values[colidx].trim().length > 12) {
+                            if(row.values[colidx].trim().length > 96) {
                                 this.addError(column.type, rowidx+1, 'TooLong');
                             }
                             if(row.values[colidx].trim().length > 0) {


### PR DESCRIPTION
* Changes max length of external ID from 12 to 96 in import validater
* Changes Swedish and English warning messages from 12 to 96

Resolves #1326 on front end, @richardolsson  to double check that back end is okay for longer external IDs